### PR TITLE
Results from 21.3-1 tests

### DIFF
--- a/21.3-1/README.md
+++ b/21.3-1/README.md
@@ -1,0 +1,14 @@
+Ubuntu SRU bionic, focal, hirsute for cloud-init 21.3-1
+=====
+This Readme hosts the manual SRU verification logs for bugs related to the cloud-init SRU started on 2021/08/23
+
+Given [cloud-init's exception process](https://wiki.ubuntu.com/CloudinitUpdates), Ubuntu SRUs will from this point forward create an general SRU process bug which will describe related bugs/features fixed in the given cloud-init SRU. A readme like this will exist to capture any manual SRU validation performed for specific bugs or features fixed in the SRU. Generally most of the features and bugs should be covered by cloud-init's conituous integration at https://jenkins.ubuntu.com/server/view/cloud-init/.
+
+
+[launchpad process bug:#1940871](https://pad.lv/1940871)
+
+All tests results run from defined integration tests will be stored in this directory. The links listed below are to bugs fixed in this SRU needing manual verification, and the verification logs of those bugs.
+
+## SRU verification content
+| Bug | Verification Script and Output |
+| -------- |  -------- |

--- a/21.3-1/curtin-cloud-init-sru.txt
+++ b/21.3-1/curtin-cloud-init-sru.txt
@@ -1,0 +1,2257 @@
+Started by user James Falcon
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru
+[WS-CLEANUP] Deleting project workspace...
+[WS-CLEANUP] Deferred wipeout is used...
+[WS-CLEANUP] Done
+[curtin-cloudinit-sru] $ /bin/bash /tmp/jenkins18126860168719359930.sh
+++ find /srv/images/.vmtest-data -maxdepth 0 -mmin -1080
++ test /srv/images/.vmtest-data
++ exit 0
+[curtin-cloudinit-sru] $ /bin/bash /tmp/jenkins16339712625703368177.sh
+test filter args: " --filter=target_distro=ubuntu --filter=test_type=network"
+Trying: git clone --branch=master https://git.launchpad.net/curtin curtin-5
+Cloning into 'curtin-5'...
+Trying: git fetch upstream --tags
+From https://git.launchpad.net/curtin
+ * [new branch]        19.1          -> upstream/19.1
+ * [new branch]        master        -> upstream/master
+ * [new branch]        ubuntu/artful -> upstream/ubuntu/artful
+ * [new branch]        ubuntu/bionic -> upstream/ubuntu/bionic
+ * [new branch]        ubuntu/cosmic -> upstream/ubuntu/cosmic
+ * [new branch]        ubuntu/devel  -> upstream/ubuntu/devel
+ * [new branch]        ubuntu/disco  -> upstream/ubuntu/disco
+ * [new branch]        ubuntu/eoan   -> upstream/ubuntu/eoan
+ * [new branch]        ubuntu/focal  -> upstream/ubuntu/focal
+ * [new branch]        ubuntu/groovy -> upstream/ubuntu/groovy
+ * [new branch]        ubuntu/xenial -> upstream/ubuntu/xenial
+ * [new branch]        ubuntu/zesty  -> upstream/ubuntu/zesty
+2021-09-09 14:09:54,108 - tests.vmtests - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+CURTIN_VMTEST_ADD_REPOS=ppa:cloud-init-dev/proposed
+CURTIN_VMTEST_CURTIN_EXE_VERSION=21.2-28-gfd6b2a0d
+CURTIN_VMTEST_CURTIN_VERSION=21.2-28-gfd6b2a0d
+CURTIN_VMTEST_IMAGE_SYNC=0
+CURTIN_VMTEST_ISCSI_PORTAL=10.247.8.15:1589
+CURTIN_VMTEST_KEEP_DATA_FAIL=logs,collect
+CURTIN_VMTEST_KEEP_DATA_PASS=logs,collect
+CURTIN_VMTEST_LOG=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log
+CURTIN_VMTEST_PARALLEL=4
+CURTIN_VMTEST_REUSE_TOPDIR=0
+CURTIN_VMTEST_SHUFFLE_TESTS=1
+CURTIN_VMTEST_SYSTEM_UPGRADE=false
+CURTIN_VMTEST_TAR_DISKS=0
+CURTIN_VMTEST_TOPDIR=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+CURTIN_VMTEST_UPGRADE_PACKAGES=cloud-init
+TGT_IPC_SOCKET=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/tgt.d/socket
+TGT_LOG_D=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/tgt.d
+TGT_PID=15959
+TGT_PORTAL=10.247.8.15:1589
+http_proxy=
+https_proxy=
+no_proxy=
+Quering synced ephemeral images/kernels in /srv/images
+======================================================================================
+ Release Codename ImageDate    Arch /SubArch         Path
+--------------------------------------------------------------------------------------
+   16.04   xenial 20210804     amd64/ga-16.04       xenial/amd64/20210804/squashfs
+   16.04   xenial 20210804     amd64/hwe-16.04      xenial/amd64/20210804/squashfs
+   16.04   xenial 20210804     amd64/hwe-16.04-edge xenial/amd64/20210804/squashfs
+   16.04   xenial 20210804     i386 /ga-16.04       xenial/i386/20210804/squashfs
+   16.04   xenial 20210804     i386 /hwe-16.04      xenial/i386/20210804/squashfs
+   16.04   xenial 20210804     i386 /hwe-16.04-edge xenial/i386/20210804/squashfs
+   18.04   bionic 20210811     amd64/ga-18.04       bionic/amd64/20210811/squashfs
+   18.04   bionic 20210811     amd64/hwe-18.04      bionic/amd64/20210811/squashfs
+   18.04   bionic 20210811     amd64/hwe-18.04-edge bionic/amd64/20210811/squashfs
+   18.04   bionic 20210811     i386 /ga-18.04       bionic/i386/20210811/squashfs
+   18.04   bionic 20210811     i386 /hwe-18.04      bionic/i386/20210811/squashfs
+   18.04   bionic 20210811     i386 /hwe-18.04-edge bionic/i386/20210811/squashfs
+   19.10     eoan 20190929     i386 /ga-19.10       eoan/i386/20190929/squashfs
+   19.10     eoan 20200611     amd64/ga-19.10       eoan/amd64/20200611/squashfs
+   20.04    focal 20210811     amd64/ga-20.04       focal/amd64/20210811/squashfs
+   20.04    focal 20210811     amd64/hwe-20.04      focal/amd64/20210811/squashfs
+   20.04    focal 20210811     amd64/hwe-20.04-edge focal/amd64/20210811/squashfs
+   20.10   groovy 20210720     amd64/ga-20.10       groovy/amd64/20210720/squashfs
+   21.04  hirsute 20210804     amd64/ga-21.04       hirsute/amd64/20210804/squashfs
+   21.10   impish 20210812     amd64/ga-21.10       impish/amd64/20210812/squashfs
+--------------------------------------------------------------------------------------
+     6.6 centos66 20190701_01  amd64/generic        centos66/amd64/20190701_01/root-tgz
+     7.0 centos70 20210811_01  amd64/generic        centos/centos70/amd64/20210811_01/root-tgz
+======================================================================================
+
+Thu, 09 Sep 2021 14:09:57 +0000: vmtest start: nosetests3 --process-timeout=86400 --processes=4 -vv --nologcapture tests/vmtests/test_network_static_routes.py:ImpishTestNetworkStaticRoutes tests/vmtests/test_network.py:BionicTestNetworkBasic tests/vmtests/test_network_ipv6_static.py:ImpishTestNetworkIPV6Static tests/vmtests/test_network_disabled.py:HirsuteCurtinDisableNetworkRendering tests/vmtests/test_network.py:HirsuteTestNetworkBasic tests/vmtests/test_network_alias.py:FocalTestNetworkAlias tests/vmtests/test_network_bonding.py:XenialTestBonding tests/vmtests/test_network_ipv6_static.py:BionicTestNetworkIPV6Static tests/vmtests/test_network_ovs.py:HirsuteTestNetworkOvs tests/vmtests/test_network_vlan.py:BionicTestNetworkVlan tests/vmtests/test_network_disabled.py:ImpishCurtinDisableNetworkRendering tests/vmtests/test_network_static.py:HirsuteTestNetworkStatic tests/vmtests/test_network_bonding.py:FocalTestBonding tests/vmtests/test_network_mtu.py:TestNetworkMtu tests/vmtests/test_network_alias.py:BionicTestNetworkAlias tests/vmtests/test_network_ipv6_vlan.py:ImpishTestNetworkIPV6Vlan tests/vmtests/test_network_disabled.py:ImpishCurtinDisableCloudInitNetworking tests/vmtests/test_network_bridging.py:BionicTestBridging tests/vmtests/test_network_disabled.py:FocalCurtinDisableNetworkRendering tests/vmtests/test_network_mtu.py:HirsuteTestNetworkMtu tests/vmtests/test_network_enisource.py:XenialTestNetworkENISource tests/vmtests/test_network_ipv6_vlan.py:HirsuteTestNetworkIPV6Vlan tests/vmtests/test_network_static.py:FocalTestNetworkStatic tests/vmtests/test_network_vlan.py:FocalTestNetworkVlan tests/vmtests/test_network_static_routes.py:FocalTestNetworkStaticRoutes tests/vmtests/test_network_ipv6_static.py:FocalTestNetworkIPV6Static tests/vmtests/test_network_alias.py:ImpishTestNetworkAlias tests/vmtests/test_network_vlan.py:XenialTestNetworkVlan tests/vmtests/test_network_ovs.py:BionicTestNetworkOvs tests/vmtests/test_network_ipv6.py:ImpishTestNetworkIPV6 tests/vmtests/test_network_ipv6_vlan.py:XenialTestNetworkIPV6Vlan tests/vmtests/test_network_alias.py:HirsuteTestNetworkAlias tests/vmtests/test_network_bridging.py:XenialTestBridgingV2 tests/vmtests/test_network_ipv6.py:XenialTestNetworkIPV6 tests/vmtests/test_network_static_routes.py:XenialTestNetworkStaticRoutes tests/vmtests/test_network_bridging.py:FocalTestBridging tests/vmtests/test_network_disabled.py:HirsuteCurtinDisableCloudInitNetworkingVersion1 tests/vmtests/test_network_static_routes.py:HirsuteTestNetworkStaticRoutes tests/vmtests/test_network_mtu.py:FocalTestNetworkMtu tests/vmtests/test_network.py:XenialTestNetworkBasic tests/vmtests/test_network_bridging.py:HirsuteTestBridging tests/vmtests/test_network_disabled.py:ImpishCurtinDisableCloudInitNetworkingVersion1 tests/vmtests/test_network_ipv6_enisource.py:XenialTestNetworkIPV6ENISource tests/vmtests/test_network_ipv6_vlan.py:FocalTestNetworkIPV6Vlan tests/vmtests/test_network_ipv6_vlan.py:BionicTestNetworkIPV6Vlan tests/vmtests/test_network_disabled.py:HirsuteCurtinDisableCloudInitNetworking tests/vmtests/test_network.py:FocalTestNetworkBasic tests/vmtests/test_network_mtu.py:ImpishTestNetworkMtu tests/vmtests/test_network_ovs.py:ImpishTestNetworkOvs tests/vmtests/test_network_ipv6_static.py:HirsuteTestNetworkIPV6Static tests/vmtests/test_network_static.py:ImpishTestNetworkStatic tests/vmtests/test_network_vlan.py:HirsuteTestNetworkVlan tests/vmtests/test_network_mtu.py:BionicTestNetworkMtu tests/vmtests/test_network_disabled.py:FocalCurtinDisableCloudInitNetworkingVersion1 tests/vmtests/test_network_ovs.py:FocalTestNetworkOvs tests/vmtests/test_network.py:ImpishTestNetworkBasic tests/vmtests/test_network_ipv6.py:FocalTestNetworkIPV6 tests/vmtests/test_network_disabled.py:FocalCurtinDisableCloudInitNetworking tests/vmtests/test_network_bonding.py:ImpishTestBonding tests/vmtests/test_network_bonding.py:BionicTestBonding tests/vmtests/test_network_alias.py:XenialTestNetworkAlias tests/vmtests/test_network_bridging.py:ImpishTestBridging tests/vmtests/test_network_ipv6_static.py:XenialTestNetworkIPV6Static tests/vmtests/test_network_vlan.py:ImpishTestNetworkVlan tests/vmtests/test_network_static.py:XenialTestNetworkStatic tests/vmtests/test_network_ipv6.py:HirsuteTestNetworkIPV6 tests/vmtests/test_network_static.py:BionicTestNetworkStatic tests/vmtests/test_network_bonding.py:HirsuteTestBonding tests/vmtests/test_network_ipv6.py:BionicTestNetworkIPV6 tests/vmtests/test_network_static_routes.py:BionicTestNetworkStaticRoutes
+nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
+2021-09-09 14:09:57,633 - vmtests - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:09:57,794 - ImpishTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:09:57,797 - ImpishTestNetworkStaticRoutes - INFO - Starting setup for testclass: ImpishTestNetworkStaticRoutes (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:09:57,802 - FocalTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:09:57,805 - FocalTestNetworkStaticRoutes - INFO - Starting setup for testclass: FocalTestNetworkStaticRoutes (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:09:57,814 - XenialTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:09:57,824 - HirsuteTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:09:57,826 - BionicTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:09:57,826 - BionicTestNetworkStaticRoutes - INFO - Starting setup for testclass: BionicTestNetworkStaticRoutes (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:09:57,827 - HirsuteTestNetworkStaticRoutes - INFO - Starting setup for testclass: HirsuteTestNetworkStaticRoutes (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:09:58,007 - FocalTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes
+2021-09-09 14:09:58,007 - HirsuteTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStaticRoutes
+2021-09-09 14:09:58,007 - ImpishTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStaticRoutes
+2021-09-09 14:09:58,007 - BionicTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes
+2021-09-09 14:09:58,008 - FocalTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,008 - ImpishTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,008 - BionicTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,008 - HirsuteTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,016 - HirsuteTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:09:58,016 - ImpishTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:09:58,016 - ImpishTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:09:58,016 - HirsuteTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:09:58,016 - FocalTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:09:58,016 - BionicTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:09:58,016 - FocalTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:09:58,016 - BionicTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:09:58,022 - HirsuteTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,022 - ImpishTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,022 - FocalTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,022 - BionicTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2021-09-09 14:09:58,025 - ImpishTestNetworkStaticRoutes - INFO - disk_serials: []
+2021-09-09 14:09:58,025 - HirsuteTestNetworkStaticRoutes - INFO - disk_serials: []
+2021-09-09 14:09:58,025 - ImpishTestNetworkStaticRoutes - INFO - nvme_serials: []
+2021-09-09 14:09:58,025 - BionicTestNetworkStaticRoutes - INFO - disk_serials: []
+2021-09-09 14:09:58,025 - FocalTestNetworkStaticRoutes - INFO - disk_serials: []
+2021-09-09 14:09:58,025 - HirsuteTestNetworkStaticRoutes - INFO - nvme_serials: []
+2021-09-09 14:09:58,025 - ImpishTestNetworkStaticRoutes - INFO - nvme disks: []
+2021-09-09 14:09:58,025 - FocalTestNetworkStaticRoutes - INFO - nvme_serials: []
+2021-09-09 14:09:58,025 - BionicTestNetworkStaticRoutes - INFO - nvme_serials: []
+2021-09-09 14:09:58,025 - HirsuteTestNetworkStaticRoutes - INFO - nvme disks: []
+2021-09-09 14:09:58,026 - FocalTestNetworkStaticRoutes - INFO - nvme disks: []
+2021-09-09 14:09:58,026 - BionicTestNetworkStaticRoutes - INFO - nvme disks: []
+2021-09-09 14:09:58,064 - HirsuteTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:09:58,064 - ImpishTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:09:58,065 - ImpishTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:09:58,065 - HirsuteTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:09:58,065 - BionicTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:09:58,065 - FocalTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:09:58,066 - BionicTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:09:58,066 - FocalTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:09:58,073 - HirsuteTestNetworkStaticRoutes - INFO - Using root_disk: []
+2021-09-09 14:09:58,073 - HirsuteTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStaticRoutes/logs/install-serial.log
+2021-09-09 14:09:58,074 - BionicTestNetworkStaticRoutes - INFO - Using root_disk: []
+2021-09-09 14:09:58,074 - ImpishTestNetworkStaticRoutes - INFO - Using root_disk: []
+2021-09-09 14:09:58,075 - BionicTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes/logs/install-serial.log
+2021-09-09 14:09:58,075 - ImpishTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStaticRoutes/logs/install-serial.log
+2021-09-09 14:09:58,075 - FocalTestNetworkStaticRoutes - INFO - Using root_disk: []
+2021-09-09 14:09:58,076 - FocalTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes/logs/install-serial.log
+2021-09-09 14:13:14,789 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes[install]: boot took 196.69 seconds. returned True
+2021-09-09 14:13:15,102 - BionicTestNetworkStaticRoutes - INFO - Install OK
+2021-09-09 14:13:15,102 - BionicTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes/logs/boot-serial.log
+2021-09-09 14:13:48,088 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes[install]: boot took 230.01 seconds. returned True
+2021-09-09 14:13:48,243 - FocalTestNetworkStaticRoutes - INFO - Install OK
+2021-09-09 14:13:48,244 - FocalTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes/logs/boot-serial.log
+2021-09-09 14:13:50,668 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes[first_boot]: boot took 35.56 seconds. returned True
+2021-09-09 14:13:51,109 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes: setUpClass finished. took 233.28 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_output_files_exist (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+2021-09-09 14:13:51,371 - BionicTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:13:51,371 - BionicTestNetworkBasic - INFO - Starting setup for testclass: BionicTestNetworkBasic (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:13:52,181 - BionicTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic
+2021-09-09 14:13:52,182 - BionicTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:13:52,192 - BionicTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:13:52,192 - BionicTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:13:52,204 - BionicTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:13:52,209 - BionicTestNetworkBasic - INFO - disk_serials: []
+2021-09-09 14:13:52,209 - BionicTestNetworkBasic - INFO - nvme_serials: []
+2021-09-09 14:13:52,209 - BionicTestNetworkBasic - INFO - nvme disks: []
+2021-09-09 14:13:52,513 - BionicTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:13:52,514 - BionicTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:13:52,583 - BionicTestNetworkBasic - INFO - Using root_disk: []
+2021-09-09 14:13:52,583 - BionicTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic/logs/install-serial.log
+2021-09-09 14:14:00,819 - HirsuteTestNetworkStaticRoutes - INFO - HirsuteTestNetworkStaticRoutes[install]: boot took 242.75 seconds. returned True
+2021-09-09 14:14:01,287 - HirsuteTestNetworkStaticRoutes - INFO - Install OK
+2021-09-09 14:14:01,287 - HirsuteTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStaticRoutes/logs/boot-serial.log
+2021-09-09 14:14:26,775 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes[first_boot]: boot took 38.53 seconds. returned True
+2021-09-09 14:14:26,836 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes: setUpClass finished. took 269.03 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+2021-09-09 14:14:27,093 - HirsuteTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:14:27,093 - HirsuteTestNetworkBasic - INFO - Starting setup for testclass: HirsuteTestNetworkBasic (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:14:27,847 - HirsuteTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkBasic
+2021-09-09 14:14:27,848 - HirsuteTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:14:27,861 - HirsuteTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:14:27,861 - HirsuteTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:14:27,871 - HirsuteTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:14:27,875 - HirsuteTestNetworkBasic - INFO - disk_serials: []
+2021-09-09 14:14:27,875 - HirsuteTestNetworkBasic - INFO - nvme_serials: []
+2021-09-09 14:14:27,875 - HirsuteTestNetworkBasic - INFO - nvme disks: []
+2021-09-09 14:14:27,886 - HirsuteTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:14:27,886 - HirsuteTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:14:27,893 - HirsuteTestNetworkBasic - INFO - Using root_disk: []
+2021-09-09 14:14:27,893 - HirsuteTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkBasic/logs/install-serial.log
+2021-09-09 14:14:37,484 - HirsuteTestNetworkStaticRoutes - INFO - HirsuteTestNetworkStaticRoutes[first_boot]: boot took 36.20 seconds. returned True
+2021-09-09 14:14:37,550 - HirsuteTestNetworkStaticRoutes - INFO - HirsuteTestNetworkStaticRoutes: setUpClass finished. took 279.72 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.HirsuteTestNetworkStaticRoutes) ... ok
+2021-09-09 14:14:37,882 - XenialTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:14:37,885 - FocalTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:14:37,885 - FocalTestNetworkBasic - INFO - Starting setup for testclass: FocalTestNetworkBasic (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:14:38,788 - FocalTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic
+2021-09-09 14:14:38,788 - FocalTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:14:38,797 - FocalTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:14:38,797 - FocalTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:14:38,809 - FocalTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:14:38,814 - FocalTestNetworkBasic - INFO - disk_serials: []
+2021-09-09 14:14:38,814 - FocalTestNetworkBasic - INFO - nvme_serials: []
+2021-09-09 14:14:38,814 - FocalTestNetworkBasic - INFO - nvme disks: []
+2021-09-09 14:14:38,825 - FocalTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:14:38,826 - FocalTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:14:38,833 - FocalTestNetworkBasic - INFO - Using root_disk: []
+2021-09-09 14:14:38,834 - FocalTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic/logs/install-serial.log
+2021-09-09 14:16:02,333 - ImpishTestNetworkStaticRoutes - INFO - ImpishTestNetworkStaticRoutes[install]: boot took 364.26 seconds. returned True
+2021-09-09 14:16:02,639 - ImpishTestNetworkStaticRoutes - INFO - Install OK
+2021-09-09 14:16:02,640 - ImpishTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStaticRoutes/logs/boot-serial.log
+2021-09-09 14:16:55,875 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic[install]: boot took 183.29 seconds. returned True
+2021-09-09 14:16:56,164 - BionicTestNetworkBasic - INFO - Install OK
+2021-09-09 14:16:56,164 - BionicTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic/logs/boot-serial.log
+2021-09-09 14:17:39,655 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic[first_boot]: boot took 43.49 seconds. returned True
+2021-09-09 14:17:39,848 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic: setUpClass finished. took 228.48 seconds. Running testcases.
+get_test_files (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.BionicTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.BionicTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_output_files_exist (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.BionicTestNetworkBasic) ... ok
+2021-09-09 14:17:40,248 - ImpishTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:17:40,248 - ImpishTestNetworkBasic - INFO - Starting setup for testclass: ImpishTestNetworkBasic (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:17:40,988 - ImpishTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkBasic
+2021-09-09 14:17:40,989 - ImpishTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:17:40,998 - ImpishTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:17:40,998 - ImpishTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:17:41,009 - ImpishTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2021-09-09 14:17:41,013 - ImpishTestNetworkBasic - INFO - disk_serials: []
+2021-09-09 14:17:41,013 - ImpishTestNetworkBasic - INFO - nvme_serials: []
+2021-09-09 14:17:41,014 - ImpishTestNetworkBasic - INFO - nvme disks: []
+2021-09-09 14:17:41,092 - ImpishTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:17:41,093 - ImpishTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:17:41,134 - ImpishTestNetworkBasic - INFO - Using root_disk: []
+2021-09-09 14:17:41,135 - ImpishTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkBasic/logs/install-serial.log
+2021-09-09 14:18:14,511 - HirsuteTestNetworkBasic - INFO - HirsuteTestNetworkBasic[install]: boot took 226.62 seconds. returned True
+2021-09-09 14:18:14,706 - HirsuteTestNetworkBasic - INFO - Install OK
+2021-09-09 14:18:14,706 - HirsuteTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkBasic/logs/boot-serial.log
+2021-09-09 14:18:21,522 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic[install]: boot took 222.69 seconds. returned True
+2021-09-09 14:18:21,760 - FocalTestNetworkBasic - INFO - Install OK
+2021-09-09 14:18:21,760 - FocalTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic/logs/boot-serial.log
+2021-09-09 14:18:57,915 - HirsuteTestNetworkBasic - INFO - HirsuteTestNetworkBasic[first_boot]: boot took 43.21 seconds. returned True
+2021-09-09 14:18:57,974 - HirsuteTestNetworkBasic - INFO - HirsuteTestNetworkBasic: setUpClass finished. took 270.88 seconds. Running testcases.
+get_test_files (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.HirsuteTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.HirsuteTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.HirsuteTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.HirsuteTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.HirsuteTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.HirsuteTestNetworkBasic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.HirsuteTestNetworkBasic) ... ok
+2021-09-09 14:18:58,404 - ImpishTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:18:58,405 - ImpishTestNetworkIPV6Static - INFO - Starting setup for testclass: ImpishTestNetworkIPV6Static (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:18:59,237 - ImpishTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Static
+2021-09-09 14:18:59,238 - ImpishTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:18:59,246 - ImpishTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:18:59,246 - ImpishTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:18:59,250 - ImpishTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:18:59,253 - ImpishTestNetworkIPV6Static - INFO - disk_serials: []
+2021-09-09 14:18:59,253 - ImpishTestNetworkIPV6Static - INFO - nvme_serials: []
+2021-09-09 14:18:59,253 - ImpishTestNetworkIPV6Static - INFO - nvme disks: []
+2021-09-09 14:18:59,264 - ImpishTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:18:59,264 - ImpishTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:18:59,271 - ImpishTestNetworkIPV6Static - INFO - Using root_disk: []
+2021-09-09 14:18:59,271 - ImpishTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Static/logs/install-serial.log
+2021-09-09 14:19:07,992 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic[first_boot]: boot took 46.23 seconds. returned True
+2021-09-09 14:19:08,058 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic: setUpClass finished. took 270.17 seconds. Running testcases.
+get_test_files (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.FocalTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.FocalTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.FocalTestNetworkBasic) ... ok
+2021-09-09 14:19:08,535 - BionicTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:19:08,536 - BionicTestNetworkIPV6Static - INFO - Starting setup for testclass: BionicTestNetworkIPV6Static (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:19:09,236 - BionicTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static
+2021-09-09 14:19:09,237 - BionicTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:19:09,244 - BionicTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:19:09,244 - BionicTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:19:09,249 - BionicTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:19:09,252 - BionicTestNetworkIPV6Static - INFO - disk_serials: []
+2021-09-09 14:19:09,252 - BionicTestNetworkIPV6Static - INFO - nvme_serials: []
+2021-09-09 14:19:09,252 - BionicTestNetworkIPV6Static - INFO - nvme disks: []
+2021-09-09 14:19:09,263 - BionicTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:19:09,264 - BionicTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:19:09,272 - BionicTestNetworkIPV6Static - INFO - Using root_disk: []
+2021-09-09 14:19:09,272 - BionicTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static/logs/install-serial.log
+2021-09-09 14:19:44,664 - ImpishTestNetworkStaticRoutes - INFO - ImpishTestNetworkStaticRoutes[first_boot]: boot took 222.02 seconds. returned True
+2021-09-09 14:19:44,727 - ImpishTestNetworkStaticRoutes - INFO - ImpishTestNetworkStaticRoutes: setUpClass finished. took 586.93 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.ImpishTestNetworkStaticRoutes) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:19:44,911 - FocalTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:19:44,911 - FocalTestNetworkIPV6Static - INFO - Starting setup for testclass: FocalTestNetworkIPV6Static (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:19:45,825 - FocalTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static
+2021-09-09 14:19:45,825 - FocalTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:19:45,833 - FocalTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:19:45,833 - FocalTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:19:45,837 - FocalTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:19:45,840 - FocalTestNetworkIPV6Static - INFO - disk_serials: []
+2021-09-09 14:19:45,840 - FocalTestNetworkIPV6Static - INFO - nvme_serials: []
+2021-09-09 14:19:45,841 - FocalTestNetworkIPV6Static - INFO - nvme disks: []
+2021-09-09 14:19:45,852 - FocalTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:19:45,853 - FocalTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:19:45,861 - FocalTestNetworkIPV6Static - INFO - Using root_disk: []
+2021-09-09 14:19:45,861 - FocalTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static/logs/install-serial.log
+2021-09-09 14:22:16,886 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static[install]: boot took 187.61 seconds. returned True
+2021-09-09 14:22:17,079 - BionicTestNetworkIPV6Static - INFO - Install OK
+2021-09-09 14:22:17,079 - BionicTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static/logs/boot-serial.log
+2021-09-09 14:23:07,380 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static[first_boot]: boot took 50.30 seconds. returned True
+2021-09-09 14:23:07,590 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static: setUpClass finished. took 239.05 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+2021-09-09 14:23:07,869 - HirsuteTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:23:07,869 - HirsuteTestNetworkIPV6Static - INFO - Starting setup for testclass: HirsuteTestNetworkIPV6Static (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:23:08,697 - HirsuteTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Static
+2021-09-09 14:23:08,698 - HirsuteTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:23:08,705 - HirsuteTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:23:08,705 - HirsuteTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:23:08,710 - HirsuteTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2021-09-09 14:23:08,713 - HirsuteTestNetworkIPV6Static - INFO - disk_serials: []
+2021-09-09 14:23:08,713 - HirsuteTestNetworkIPV6Static - INFO - nvme_serials: []
+2021-09-09 14:23:08,713 - HirsuteTestNetworkIPV6Static - INFO - nvme disks: []
+2021-09-09 14:23:08,879 - HirsuteTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:23:08,879 - HirsuteTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:23:08,957 - HirsuteTestNetworkIPV6Static - INFO - Using root_disk: []
+2021-09-09 14:23:08,958 - HirsuteTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Static/logs/install-serial.log
+2021-09-09 14:23:33,035 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static[install]: boot took 227.17 seconds. returned True
+2021-09-09 14:23:33,228 - FocalTestNetworkIPV6Static - INFO - Install OK
+2021-09-09 14:23:33,228 - FocalTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static/logs/boot-serial.log
+2021-09-09 14:23:39,710 - ImpishTestNetworkBasic - INFO - ImpishTestNetworkBasic[install]: boot took 358.58 seconds. returned True
+2021-09-09 14:23:39,856 - ImpishTestNetworkBasic - INFO - Install OK
+2021-09-09 14:23:39,856 - ImpishTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkBasic/logs/boot-serial.log
+2021-09-09 14:24:31,580 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static[first_boot]: boot took 58.35 seconds. returned True
+2021-09-09 14:24:31,641 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static: setUpClass finished. took 286.73 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+2021-09-09 14:24:32,046 - XenialTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:24:32,049 - HirsuteCurtinDisableNetworkRendering - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:24:32,049 - HirsuteCurtinDisableNetworkRendering - INFO - Starting setup for testclass: HirsuteCurtinDisableNetworkRendering (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:24:32,730 - HirsuteCurtinDisableNetworkRendering - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableNetworkRendering
+2021-09-09 14:24:32,731 - HirsuteCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:24:32,737 - HirsuteCurtinDisableNetworkRendering - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:24:32,737 - HirsuteCurtinDisableNetworkRendering - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:24:32,738 - HirsuteCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:24:32,739 - HirsuteCurtinDisableNetworkRendering - INFO - disk_serials: []
+2021-09-09 14:24:32,739 - HirsuteCurtinDisableNetworkRendering - INFO - nvme_serials: []
+2021-09-09 14:24:32,739 - HirsuteCurtinDisableNetworkRendering - INFO - nvme disks: []
+2021-09-09 14:24:32,751 - HirsuteCurtinDisableNetworkRendering - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:24:32,751 - HirsuteCurtinDisableNetworkRendering - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:24:32,759 - HirsuteCurtinDisableNetworkRendering - INFO - Using root_disk: []
+2021-09-09 14:24:32,759 - HirsuteCurtinDisableNetworkRendering - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableNetworkRendering/logs/install-serial.log
+2021-09-09 14:24:53,674 - ImpishTestNetworkIPV6Static - INFO - ImpishTestNetworkIPV6Static[install]: boot took 354.40 seconds. returned True
+2021-09-09 14:24:53,858 - ImpishTestNetworkIPV6Static - INFO - Install OK
+2021-09-09 14:24:53,858 - ImpishTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Static/logs/boot-serial.log
+2021-09-09 14:26:44,927 - HirsuteTestNetworkIPV6Static - INFO - HirsuteTestNetworkIPV6Static[install]: boot took 215.97 seconds. returned True
+2021-09-09 14:26:45,026 - HirsuteTestNetworkIPV6Static - INFO - Install OK
+2021-09-09 14:26:45,026 - HirsuteTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Static/logs/boot-serial.log
+2021-09-09 14:27:20,715 - ImpishTestNetworkBasic - INFO - ImpishTestNetworkBasic[first_boot]: boot took 220.86 seconds. returned True
+2021-09-09 14:27:20,823 - ImpishTestNetworkBasic - INFO - ImpishTestNetworkBasic: setUpClass finished. took 580.58 seconds. Running testcases.
+get_test_files (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.ImpishTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.ImpishTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.ImpishTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.ImpishTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.ImpishTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.ImpishTestNetworkBasic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.ImpishTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.ImpishTestNetworkBasic) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:27:20,998 - ImpishCurtinDisableNetworkRendering - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:27:20,998 - ImpishCurtinDisableNetworkRendering - INFO - Starting setup for testclass: ImpishCurtinDisableNetworkRendering (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:27:21,948 - ImpishCurtinDisableNetworkRendering - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableNetworkRendering
+2021-09-09 14:27:21,949 - ImpishCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:27:21,954 - ImpishCurtinDisableNetworkRendering - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:27:21,954 - ImpishCurtinDisableNetworkRendering - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:27:21,955 - ImpishCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:27:21,956 - ImpishCurtinDisableNetworkRendering - INFO - disk_serials: []
+2021-09-09 14:27:21,956 - ImpishCurtinDisableNetworkRendering - INFO - nvme_serials: []
+2021-09-09 14:27:21,956 - ImpishCurtinDisableNetworkRendering - INFO - nvme disks: []
+2021-09-09 14:27:21,977 - ImpishCurtinDisableNetworkRendering - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:27:21,978 - ImpishCurtinDisableNetworkRendering - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:27:22,013 - ImpishCurtinDisableNetworkRendering - INFO - Using root_disk: []
+2021-09-09 14:27:22,014 - ImpishCurtinDisableNetworkRendering - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableNetworkRendering/logs/install-serial.log
+2021-09-09 14:27:40,895 - HirsuteTestNetworkIPV6Static - INFO - HirsuteTestNetworkIPV6Static[first_boot]: boot took 55.87 seconds. returned True
+2021-09-09 14:27:40,971 - HirsuteTestNetworkIPV6Static - INFO - HirsuteTestNetworkIPV6Static: setUpClass finished. took 273.10 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.HirsuteTestNetworkIPV6Static) ... ok
+2021-09-09 14:27:41,423 - ImpishCurtinDisableCloudInitNetworking - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:27:41,423 - ImpishCurtinDisableCloudInitNetworking - INFO - Starting setup for testclass: ImpishCurtinDisableCloudInitNetworking (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:27:42,303 - ImpishCurtinDisableCloudInitNetworking - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworking
+2021-09-09 14:27:42,303 - ImpishCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:27:42,310 - ImpishCurtinDisableCloudInitNetworking - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:27:42,310 - ImpishCurtinDisableCloudInitNetworking - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:27:42,311 - ImpishCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:27:42,311 - ImpishCurtinDisableCloudInitNetworking - INFO - disk_serials: []
+2021-09-09 14:27:42,312 - ImpishCurtinDisableCloudInitNetworking - INFO - nvme_serials: []
+2021-09-09 14:27:42,312 - ImpishCurtinDisableCloudInitNetworking - INFO - nvme disks: []
+2021-09-09 14:27:42,337 - ImpishCurtinDisableCloudInitNetworking - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:27:42,337 - ImpishCurtinDisableCloudInitNetworking - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:27:42,344 - ImpishCurtinDisableCloudInitNetworking - INFO - Using root_disk: []
+2021-09-09 14:27:42,344 - ImpishCurtinDisableCloudInitNetworking - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworking/logs/install-serial.log
+2021-09-09 14:28:07,014 - HirsuteCurtinDisableNetworkRendering - INFO - HirsuteCurtinDisableNetworkRendering[install]: boot took 214.25 seconds. returned True
+2021-09-09 14:28:07,460 - HirsuteCurtinDisableNetworkRendering - INFO - Install OK
+2021-09-09 14:28:07,460 - HirsuteCurtinDisableNetworkRendering - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableNetworkRendering/logs/boot-serial.log
+2021-09-09 14:28:42,600 - HirsuteCurtinDisableNetworkRendering - INFO - HirsuteCurtinDisableNetworkRendering[first_boot]: boot took 35.14 seconds. returned True
+2021-09-09 14:28:42,732 - HirsuteCurtinDisableNetworkRendering - INFO - HirsuteCurtinDisableNetworkRendering: setUpClass finished. took 250.68 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>
+test_cloudinit_network_not_created (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>
+test_dname (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_dname_rules (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>
+test_fstab (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_ip_output (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>
+test_kernel_img_conf (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_reporting_data (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+test_static_routes (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering'>
+test_swaps_used (vmtests.test_network_disabled.HirsuteCurtinDisableNetworkRendering) ... ok
+2021-09-09 14:28:43,159 - FocalCurtinDisableNetworkRendering - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:28:43,159 - FocalCurtinDisableNetworkRendering - INFO - Starting setup for testclass: FocalCurtinDisableNetworkRendering (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:28:44,197 - FocalCurtinDisableNetworkRendering - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering
+2021-09-09 14:28:44,198 - FocalCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:28:44,204 - FocalCurtinDisableNetworkRendering - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:28:44,204 - FocalCurtinDisableNetworkRendering - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:28:44,205 - FocalCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2021-09-09 14:28:44,206 - FocalCurtinDisableNetworkRendering - INFO - disk_serials: []
+2021-09-09 14:28:44,206 - FocalCurtinDisableNetworkRendering - INFO - nvme_serials: []
+2021-09-09 14:28:44,206 - FocalCurtinDisableNetworkRendering - INFO - nvme disks: []
+2021-09-09 14:28:44,263 - FocalCurtinDisableNetworkRendering - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:28:44,263 - FocalCurtinDisableNetworkRendering - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:28:44,287 - FocalCurtinDisableNetworkRendering - INFO - Using root_disk: []
+2021-09-09 14:28:44,287 - FocalCurtinDisableNetworkRendering - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering/logs/install-serial.log
+2021-09-09 14:28:56,223 - ImpishTestNetworkIPV6Static - INFO - ImpishTestNetworkIPV6Static[first_boot]: boot took 242.36 seconds. returned True
+2021-09-09 14:28:56,286 - ImpishTestNetworkIPV6Static - INFO - ImpishTestNetworkIPV6Static: setUpClass finished. took 597.88 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.ImpishTestNetworkIPV6Static) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:28:56,620 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:28:56,620 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Starting setup for testclass: HirsuteCurtinDisableCloudInitNetworkingVersion1 (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:28:57,521 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworkingVersion1
+2021-09-09 14:28:57,521 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:28:57,526 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:28:57,527 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:28:57,528 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:28:57,528 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - disk_serials: []
+2021-09-09 14:28:57,528 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme_serials: []
+2021-09-09 14:28:57,528 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme disks: []
+2021-09-09 14:28:57,540 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:28:57,540 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:28:57,548 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Using root_disk: []
+2021-09-09 14:28:57,548 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworkingVersion1/logs/install-serial.log
+2021-09-09 14:32:34,308 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering[install]: boot took 230.02 seconds. returned True
+2021-09-09 14:32:34,779 - FocalCurtinDisableNetworkRendering - INFO - Install OK
+2021-09-09 14:32:34,779 - FocalCurtinDisableNetworkRendering - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering/logs/boot-serial.log
+2021-09-09 14:32:51,627 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - HirsuteCurtinDisableCloudInitNetworkingVersion1[install]: boot took 234.08 seconds. returned True
+2021-09-09 14:32:51,980 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Install OK
+2021-09-09 14:32:51,981 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworkingVersion1/logs/boot-serial.log
+2021-09-09 14:33:12,860 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering[first_boot]: boot took 38.08 seconds. returned True
+2021-09-09 14:33:13,337 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering: setUpClass finished. took 270.18 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_cloudinit_network_not_created (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+2021-09-09 14:33:13,642 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:33:13,642 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Starting setup for testclass: ImpishCurtinDisableCloudInitNetworkingVersion1 (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:33:14,693 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworkingVersion1
+2021-09-09 14:33:14,693 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:33:14,702 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:33:14,702 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:33:14,704 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:33:14,705 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - disk_serials: []
+2021-09-09 14:33:14,705 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme_serials: []
+2021-09-09 14:33:14,705 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme disks: []
+2021-09-09 14:33:15,029 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:33:15,030 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:33:15,147 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Using root_disk: []
+2021-09-09 14:33:15,148 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworkingVersion1/logs/install-serial.log
+2021-09-09 14:33:17,535 - ImpishCurtinDisableNetworkRendering - INFO - ImpishCurtinDisableNetworkRendering[install]: boot took 355.52 seconds. returned True
+2021-09-09 14:33:17,872 - ImpishCurtinDisableNetworkRendering - INFO - Install OK
+2021-09-09 14:33:17,872 - ImpishCurtinDisableNetworkRendering - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableNetworkRendering/logs/boot-serial.log
+2021-09-09 14:33:26,779 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - HirsuteCurtinDisableCloudInitNetworkingVersion1[first_boot]: boot took 34.80 seconds. returned True
+2021-09-09 14:33:26,843 - HirsuteCurtinDisableCloudInitNetworkingVersion1 - INFO - HirsuteCurtinDisableCloudInitNetworkingVersion1: setUpClass finished. took 270.22 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname_rules (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1'>
+test_fstab (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_ip_output (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1'>
+test_kernel_img_conf (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_reporting_data (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_static_routes (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1'>
+test_swaps_used (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworkingVersion1) ... ok
+2021-09-09 14:33:27,226 - HirsuteCurtinDisableCloudInitNetworking - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:33:27,226 - HirsuteCurtinDisableCloudInitNetworking - INFO - Starting setup for testclass: HirsuteCurtinDisableCloudInitNetworking (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:33:28,099 - HirsuteCurtinDisableCloudInitNetworking - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworking
+2021-09-09 14:33:28,100 - HirsuteCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:33:28,105 - HirsuteCurtinDisableCloudInitNetworking - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:33:28,105 - HirsuteCurtinDisableCloudInitNetworking - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:33:28,106 - HirsuteCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:33:28,106 - HirsuteCurtinDisableCloudInitNetworking - INFO - disk_serials: []
+2021-09-09 14:33:28,106 - HirsuteCurtinDisableCloudInitNetworking - INFO - nvme_serials: []
+2021-09-09 14:33:28,106 - HirsuteCurtinDisableCloudInitNetworking - INFO - nvme disks: []
+2021-09-09 14:33:28,117 - HirsuteCurtinDisableCloudInitNetworking - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:33:28,117 - HirsuteCurtinDisableCloudInitNetworking - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:33:28,125 - HirsuteCurtinDisableCloudInitNetworking - INFO - Using root_disk: []
+2021-09-09 14:33:28,125 - HirsuteCurtinDisableCloudInitNetworking - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworking/logs/install-serial.log
+2021-09-09 14:33:44,167 - ImpishCurtinDisableCloudInitNetworking - INFO - ImpishCurtinDisableCloudInitNetworking[install]: boot took 361.82 seconds. returned True
+2021-09-09 14:33:44,407 - ImpishCurtinDisableCloudInitNetworking - INFO - Install OK
+2021-09-09 14:33:44,407 - ImpishCurtinDisableCloudInitNetworking - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworking/logs/boot-serial.log
+2021-09-09 14:36:54,903 - ImpishCurtinDisableNetworkRendering - INFO - ImpishCurtinDisableNetworkRendering[first_boot]: boot took 217.03 seconds. returned True
+2021-09-09 14:36:54,970 - ImpishCurtinDisableNetworkRendering - INFO - ImpishCurtinDisableNetworkRendering: setUpClass finished. took 573.97 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>
+test_cloudinit_network_not_created (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>
+test_dname (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_dname_rules (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>
+test_fstab (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_ip_output (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>
+test_kernel_img_conf (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_reporting_data (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... ok
+test_static_routes (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering'>
+test_swaps_used (vmtests.test_network_disabled.ImpishCurtinDisableNetworkRendering) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:36:55,152 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:36:55,152 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Starting setup for testclass: FocalCurtinDisableCloudInitNetworkingVersion1 (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:36:56,092 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1
+2021-09-09 14:36:56,093 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:36:56,102 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:36:56,102 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:36:56,104 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2021-09-09 14:36:56,105 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - disk_serials: []
+2021-09-09 14:36:56,105 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme_serials: []
+2021-09-09 14:36:56,105 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme disks: []
+2021-09-09 14:36:56,117 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:36:56,118 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:36:56,128 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Using root_disk: []
+2021-09-09 14:36:56,128 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1/logs/install-serial.log
+2021-09-09 14:37:07,385 - HirsuteCurtinDisableCloudInitNetworking - INFO - HirsuteCurtinDisableCloudInitNetworking[install]: boot took 219.26 seconds. returned True
+2021-09-09 14:37:07,814 - HirsuteCurtinDisableCloudInitNetworking - INFO - Install OK
+2021-09-09 14:37:07,814 - HirsuteCurtinDisableCloudInitNetworking - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteCurtinDisableCloudInitNetworking/logs/boot-serial.log
+2021-09-09 14:37:18,400 - ImpishCurtinDisableCloudInitNetworking - INFO - ImpishCurtinDisableCloudInitNetworking[first_boot]: boot took 213.99 seconds. returned True
+2021-09-09 14:37:18,494 - ImpishCurtinDisableCloudInitNetworking - INFO - ImpishCurtinDisableCloudInitNetworking: setUpClass finished. took 577.07 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_dname (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_dname_rules (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking'>
+test_fstab (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_ip_output (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking'>
+test_kernel_img_conf (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_reporting_data (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... ok
+test_static_routes (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking'>
+test_swaps_used (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworking) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:37:18,695 - FocalCurtinDisableCloudInitNetworking - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:37:18,695 - FocalCurtinDisableCloudInitNetworking - INFO - Starting setup for testclass: FocalCurtinDisableCloudInitNetworking (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:37:19,675 - FocalCurtinDisableCloudInitNetworking - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking
+2021-09-09 14:37:19,676 - FocalCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:37:19,681 - FocalCurtinDisableCloudInitNetworking - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:37:19,681 - FocalCurtinDisableCloudInitNetworking - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:37:19,682 - FocalCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2021-09-09 14:37:19,682 - FocalCurtinDisableCloudInitNetworking - INFO - disk_serials: []
+2021-09-09 14:37:19,682 - FocalCurtinDisableCloudInitNetworking - INFO - nvme_serials: []
+2021-09-09 14:37:19,683 - FocalCurtinDisableCloudInitNetworking - INFO - nvme disks: []
+2021-09-09 14:37:19,733 - FocalCurtinDisableCloudInitNetworking - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:37:19,733 - FocalCurtinDisableCloudInitNetworking - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:37:19,758 - FocalCurtinDisableCloudInitNetworking - INFO - Using root_disk: []
+2021-09-09 14:37:19,759 - FocalCurtinDisableCloudInitNetworking - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking/logs/install-serial.log
+2021-09-09 14:37:43,487 - HirsuteCurtinDisableCloudInitNetworking - INFO - HirsuteCurtinDisableCloudInitNetworking[first_boot]: boot took 35.67 seconds. returned True
+2021-09-09 14:37:43,647 - HirsuteCurtinDisableCloudInitNetworking - INFO - HirsuteCurtinDisableCloudInitNetworking: setUpClass finished. took 256.42 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_dname (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_dname_rules (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking'>
+test_fstab (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_ip_output (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking'>
+test_kernel_img_conf (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_reporting_data (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+test_static_routes (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking'>
+test_swaps_used (vmtests.test_network_disabled.HirsuteCurtinDisableCloudInitNetworking) ... ok
+2021-09-09 14:37:44,078 - FocalTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:37:44,078 - FocalTestNetworkAlias - INFO - Starting setup for testclass: FocalTestNetworkAlias (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:37:45,022 - FocalTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias
+2021-09-09 14:37:45,022 - FocalTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:37:45,045 - FocalTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:37:45,045 - FocalTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:37:45,094 - FocalTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:37:45,111 - FocalTestNetworkAlias - INFO - disk_serials: []
+2021-09-09 14:37:45,111 - FocalTestNetworkAlias - INFO - nvme_serials: []
+2021-09-09 14:37:45,111 - FocalTestNetworkAlias - INFO - nvme disks: []
+2021-09-09 14:37:45,132 - FocalTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:37:45,133 - FocalTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:37:45,152 - FocalTestNetworkAlias - INFO - Using root_disk: []
+2021-09-09 14:37:45,152 - FocalTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias/logs/install-serial.log
+2021-09-09 14:38:55,940 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - ImpishCurtinDisableCloudInitNetworkingVersion1[install]: boot took 340.79 seconds. returned True
+2021-09-09 14:38:56,328 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Install OK
+2021-09-09 14:38:56,328 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishCurtinDisableCloudInitNetworkingVersion1/logs/boot-serial.log
+2021-09-09 14:40:33,587 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1[install]: boot took 217.46 seconds. returned True
+2021-09-09 14:40:33,672 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Install OK
+2021-09-09 14:40:33,672 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1/logs/boot-serial.log
+2021-09-09 14:40:58,199 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking[install]: boot took 218.44 seconds. returned True
+2021-09-09 14:40:58,595 - FocalCurtinDisableCloudInitNetworking - INFO - Install OK
+2021-09-09 14:40:58,595 - FocalCurtinDisableCloudInitNetworking - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking/logs/boot-serial.log
+2021-09-09 14:41:09,835 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1[first_boot]: boot took 36.16 seconds. returned True
+2021-09-09 14:41:10,031 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1: setUpClass finished. took 254.88 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+2021-09-09 14:41:10,337 - BionicTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:41:10,337 - BionicTestNetworkAlias - INFO - Starting setup for testclass: BionicTestNetworkAlias (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:41:11,131 - BionicTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias
+2021-09-09 14:41:11,132 - BionicTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:41:11,156 - BionicTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:41:11,156 - BionicTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:41:11,208 - BionicTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:41:11,226 - BionicTestNetworkAlias - INFO - disk_serials: []
+2021-09-09 14:41:11,226 - BionicTestNetworkAlias - INFO - nvme_serials: []
+2021-09-09 14:41:11,226 - BionicTestNetworkAlias - INFO - nvme disks: []
+2021-09-09 14:41:11,304 - BionicTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:41:11,305 - BionicTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:41:11,350 - BionicTestNetworkAlias - INFO - Using root_disk: []
+2021-09-09 14:41:11,350 - BionicTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias/logs/install-serial.log
+2021-09-09 14:41:23,966 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias[install]: boot took 218.81 seconds. returned True
+2021-09-09 14:41:24,110 - FocalTestNetworkAlias - INFO - Install OK
+2021-09-09 14:41:24,111 - FocalTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias/logs/boot-serial.log
+2021-09-09 14:41:35,135 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking[first_boot]: boot took 36.54 seconds. returned True
+2021-09-09 14:41:35,197 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking: setUpClass finished. took 256.50 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+2021-09-09 14:41:35,555 - ImpishTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:41:35,555 - ImpishTestNetworkAlias - INFO - Starting setup for testclass: ImpishTestNetworkAlias (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:41:36,240 - ImpishTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkAlias
+2021-09-09 14:41:36,241 - ImpishTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:41:36,262 - ImpishTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:41:36,262 - ImpishTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:41:36,313 - ImpishTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:41:36,331 - ImpishTestNetworkAlias - INFO - disk_serials: []
+2021-09-09 14:41:36,331 - ImpishTestNetworkAlias - INFO - nvme_serials: []
+2021-09-09 14:41:36,331 - ImpishTestNetworkAlias - INFO - nvme disks: []
+2021-09-09 14:41:36,342 - ImpishTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:41:36,342 - ImpishTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:41:36,350 - ImpishTestNetworkAlias - INFO - Using root_disk: []
+2021-09-09 14:41:36,350 - ImpishTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkAlias/logs/install-serial.log
+2021-09-09 14:42:02,131 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias[first_boot]: boot took 38.02 seconds. returned True
+2021-09-09 14:42:02,189 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias: setUpClass finished. took 258.11 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.FocalTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.FocalTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+2021-09-09 14:42:02,707 - HirsuteTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:42:02,707 - HirsuteTestNetworkAlias - INFO - Starting setup for testclass: HirsuteTestNetworkAlias (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:42:03,458 - HirsuteTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkAlias
+2021-09-09 14:42:03,459 - HirsuteTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:42:03,481 - HirsuteTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:42:03,481 - HirsuteTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:42:03,532 - HirsuteTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2021-09-09 14:42:03,549 - HirsuteTestNetworkAlias - INFO - disk_serials: []
+2021-09-09 14:42:03,550 - HirsuteTestNetworkAlias - INFO - nvme_serials: []
+2021-09-09 14:42:03,550 - HirsuteTestNetworkAlias - INFO - nvme disks: []
+2021-09-09 14:42:03,561 - HirsuteTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:42:03,561 - HirsuteTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:42:03,569 - HirsuteTestNetworkAlias - INFO - Using root_disk: []
+2021-09-09 14:42:03,569 - HirsuteTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkAlias/logs/install-serial.log
+2021-09-09 14:42:31,087 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - ImpishCurtinDisableCloudInitNetworkingVersion1[first_boot]: boot took 214.76 seconds. returned True
+2021-09-09 14:42:31,153 - ImpishCurtinDisableCloudInitNetworkingVersion1 - INFO - ImpishCurtinDisableCloudInitNetworkingVersion1: setUpClass finished. took 557.51 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname_rules (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1'>
+test_fstab (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_ip_output (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1'>
+test_kernel_img_conf (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_reporting_data (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_static_routes (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1'>
+test_swaps_used (vmtests.test_network_disabled.ImpishCurtinDisableCloudInitNetworkingVersion1) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:42:31,331 - XenialTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:42:31,336 - XenialTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:42:31,339 - FocalTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:42:31,339 - FocalTestBonding - INFO - Starting setup for testclass: FocalTestBonding (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:42:32,220 - FocalTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding
+2021-09-09 14:42:32,220 - FocalTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:42:32,229 - FocalTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:42:32,229 - FocalTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:42:32,241 - FocalTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:42:32,246 - FocalTestBonding - INFO - disk_serials: []
+2021-09-09 14:42:32,246 - FocalTestBonding - INFO - nvme_serials: []
+2021-09-09 14:42:32,246 - FocalTestBonding - INFO - nvme disks: []
+2021-09-09 14:42:32,257 - FocalTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:42:32,257 - FocalTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:42:32,264 - FocalTestBonding - INFO - Using root_disk: []
+2021-09-09 14:42:32,265 - FocalTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding/logs/install-serial.log
+2021-09-09 14:44:18,612 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias[install]: boot took 187.26 seconds. returned True
+2021-09-09 14:44:18,812 - BionicTestNetworkAlias - INFO - Install OK
+2021-09-09 14:44:18,812 - BionicTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias/logs/boot-serial.log
+2021-09-09 14:44:56,703 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias[first_boot]: boot took 37.89 seconds. returned True
+2021-09-09 14:44:56,808 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias: setUpClass finished. took 226.47 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.BionicTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.BionicTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_output_files_exist (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+2021-09-09 14:44:57,118 - ImpishTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:44:57,118 - ImpishTestBonding - INFO - Starting setup for testclass: ImpishTestBonding (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:44:57,824 - ImpishTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBonding
+2021-09-09 14:44:57,825 - ImpishTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:44:57,834 - ImpishTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:44:57,834 - ImpishTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:44:57,847 - ImpishTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:44:57,851 - ImpishTestBonding - INFO - disk_serials: []
+2021-09-09 14:44:57,851 - ImpishTestBonding - INFO - nvme_serials: []
+2021-09-09 14:44:57,851 - ImpishTestBonding - INFO - nvme disks: []
+2021-09-09 14:44:57,910 - ImpishTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:44:57,911 - ImpishTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:44:57,953 - ImpishTestBonding - INFO - Using root_disk: []
+2021-09-09 14:44:57,953 - ImpishTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBonding/logs/install-serial.log
+2021-09-09 14:45:58,672 - HirsuteTestNetworkAlias - INFO - HirsuteTestNetworkAlias[install]: boot took 235.10 seconds. returned True
+2021-09-09 14:45:59,120 - HirsuteTestNetworkAlias - INFO - Install OK
+2021-09-09 14:45:59,120 - HirsuteTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkAlias/logs/boot-serial.log
+2021-09-09 14:46:19,602 - FocalTestBonding - INFO - FocalTestBonding[install]: boot took 227.34 seconds. returned True
+2021-09-09 14:46:19,904 - FocalTestBonding - INFO - Install OK
+2021-09-09 14:46:19,904 - FocalTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding/logs/boot-serial.log
+2021-09-09 14:46:36,287 - HirsuteTestNetworkAlias - INFO - HirsuteTestNetworkAlias[first_boot]: boot took 37.17 seconds. returned True
+2021-09-09 14:46:36,353 - HirsuteTestNetworkAlias - INFO - HirsuteTestNetworkAlias: setUpClass finished. took 273.65 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.HirsuteTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.HirsuteTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.HirsuteTestNetworkAlias) ... ok
+2021-09-09 14:46:36,863 - BionicTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:46:36,864 - BionicTestBonding - INFO - Starting setup for testclass: BionicTestBonding (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:46:37,720 - BionicTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding
+2021-09-09 14:46:37,721 - BionicTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:46:37,730 - BionicTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:46:37,730 - BionicTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:46:37,743 - BionicTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:46:37,747 - BionicTestBonding - INFO - disk_serials: []
+2021-09-09 14:46:37,747 - BionicTestBonding - INFO - nvme_serials: []
+2021-09-09 14:46:37,747 - BionicTestBonding - INFO - nvme disks: []
+2021-09-09 14:46:37,771 - BionicTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:46:37,772 - BionicTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:46:37,806 - BionicTestBonding - INFO - Using root_disk: []
+2021-09-09 14:46:37,806 - BionicTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding/logs/install-serial.log
+2021-09-09 14:46:58,647 - FocalTestBonding - INFO - FocalTestBonding[first_boot]: boot took 38.74 seconds. returned True
+2021-09-09 14:46:58,710 - FocalTestBonding - INFO - FocalTestBonding: setUpClass finished. took 267.37 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.FocalTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.FocalTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.FocalTestBonding) ... ok
+2021-09-09 14:46:59,087 - HirsuteTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:46:59,087 - HirsuteTestBonding - INFO - Starting setup for testclass: HirsuteTestBonding (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:46:59,772 - HirsuteTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBonding
+2021-09-09 14:46:59,772 - HirsuteTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:46:59,782 - HirsuteTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:46:59,782 - HirsuteTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:46:59,795 - HirsuteTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2021-09-09 14:46:59,800 - HirsuteTestBonding - INFO - disk_serials: []
+2021-09-09 14:46:59,800 - HirsuteTestBonding - INFO - nvme_serials: []
+2021-09-09 14:46:59,800 - HirsuteTestBonding - INFO - nvme disks: []
+2021-09-09 14:46:59,811 - HirsuteTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:46:59,811 - HirsuteTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:46:59,819 - HirsuteTestBonding - INFO - Using root_disk: []
+2021-09-09 14:46:59,820 - HirsuteTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBonding/logs/install-serial.log
+2021-09-09 14:47:37,821 - ImpishTestNetworkAlias - INFO - ImpishTestNetworkAlias[install]: boot took 361.47 seconds. returned True
+2021-09-09 14:47:38,108 - ImpishTestNetworkAlias - INFO - Install OK
+2021-09-09 14:47:38,109 - ImpishTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkAlias/logs/boot-serial.log
+2021-09-09 14:49:46,347 - BionicTestBonding - INFO - BionicTestBonding[install]: boot took 188.54 seconds. returned True
+2021-09-09 14:49:46,742 - BionicTestBonding - INFO - Install OK
+2021-09-09 14:49:46,742 - BionicTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding/logs/boot-serial.log
+2021-09-09 14:50:22,391 - BionicTestBonding - INFO - BionicTestBonding[first_boot]: boot took 35.65 seconds. returned True
+2021-09-09 14:50:22,510 - BionicTestBonding - INFO - BionicTestBonding: setUpClass finished. took 225.65 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.BionicTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.BionicTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_output_files_exist (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.BionicTestBonding) ... ok
+2021-09-09 14:50:22,888 - HirsuteTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:50:22,888 - HirsuteTestNetworkOvs - INFO - Starting setup for testclass: HirsuteTestNetworkOvs (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:50:23,622 - HirsuteTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkOvs
+2021-09-09 14:50:23,623 - HirsuteTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:50:23,629 - HirsuteTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:50:23,629 - HirsuteTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:50:23,631 - HirsuteTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:50:23,632 - HirsuteTestNetworkOvs - INFO - disk_serials: []
+2021-09-09 14:50:23,633 - HirsuteTestNetworkOvs - INFO - nvme_serials: []
+2021-09-09 14:50:23,633 - HirsuteTestNetworkOvs - INFO - nvme disks: []
+2021-09-09 14:50:23,713 - HirsuteTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:50:23,713 - HirsuteTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:50:23,780 - HirsuteTestNetworkOvs - INFO - Using root_disk: []
+2021-09-09 14:50:23,780 - HirsuteTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkOvs/logs/install-serial.log
+2021-09-09 14:50:50,134 - ImpishTestBonding - INFO - ImpishTestBonding[install]: boot took 352.18 seconds. returned True
+2021-09-09 14:50:50,162 - HirsuteTestBonding - INFO - HirsuteTestBonding[install]: boot took 230.34 seconds. returned True
+2021-09-09 14:50:50,462 - ImpishTestBonding - INFO - Install OK
+2021-09-09 14:50:50,463 - ImpishTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBonding/logs/boot-serial.log
+2021-09-09 14:50:50,617 - HirsuteTestBonding - INFO - Install OK
+2021-09-09 14:50:50,618 - HirsuteTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBonding/logs/boot-serial.log
+2021-09-09 14:51:15,167 - ImpishTestNetworkAlias - INFO - ImpishTestNetworkAlias[first_boot]: boot took 217.06 seconds. returned True
+2021-09-09 14:51:15,226 - ImpishTestNetworkAlias - INFO - ImpishTestNetworkAlias: setUpClass finished. took 579.67 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.ImpishTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.ImpishTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.ImpishTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.ImpishTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.ImpishTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.ImpishTestNetworkAlias) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.ImpishTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.ImpishTestNetworkAlias) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:51:15,470 - BionicTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:51:15,470 - BionicTestNetworkOvs - INFO - Starting setup for testclass: BionicTestNetworkOvs (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:51:16,385 - BionicTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs
+2021-09-09 14:51:16,386 - BionicTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:51:16,391 - BionicTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:51:16,391 - BionicTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:51:16,393 - BionicTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:51:16,395 - BionicTestNetworkOvs - INFO - disk_serials: []
+2021-09-09 14:51:16,395 - BionicTestNetworkOvs - INFO - nvme_serials: []
+2021-09-09 14:51:16,395 - BionicTestNetworkOvs - INFO - nvme disks: []
+2021-09-09 14:51:16,405 - BionicTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:51:16,406 - BionicTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:51:16,412 - BionicTestNetworkOvs - INFO - Using root_disk: []
+2021-09-09 14:51:16,413 - BionicTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs/logs/install-serial.log
+2021-09-09 14:51:24,175 - HirsuteTestBonding - INFO - HirsuteTestBonding[first_boot]: boot took 33.56 seconds. returned True
+2021-09-09 14:51:24,233 - HirsuteTestBonding - INFO - HirsuteTestBonding: setUpClass finished. took 265.15 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.HirsuteTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.HirsuteTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.HirsuteTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.HirsuteTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.HirsuteTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.HirsuteTestBonding) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.HirsuteTestBonding) ... ok
+2021-09-09 14:51:24,668 - ImpishTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:51:24,668 - ImpishTestNetworkOvs - INFO - Starting setup for testclass: ImpishTestNetworkOvs (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:51:25,512 - ImpishTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkOvs
+2021-09-09 14:51:25,513 - ImpishTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:51:25,518 - ImpishTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:51:25,519 - ImpishTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:51:25,520 - ImpishTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:51:25,522 - ImpishTestNetworkOvs - INFO - disk_serials: []
+2021-09-09 14:51:25,522 - ImpishTestNetworkOvs - INFO - nvme_serials: []
+2021-09-09 14:51:25,522 - ImpishTestNetworkOvs - INFO - nvme disks: []
+2021-09-09 14:51:25,532 - ImpishTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:51:25,533 - ImpishTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:51:25,539 - ImpishTestNetworkOvs - INFO - Using root_disk: []
+2021-09-09 14:51:25,540 - ImpishTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkOvs/logs/install-serial.log
+2021-09-09 14:54:13,037 - HirsuteTestNetworkOvs - INFO - HirsuteTestNetworkOvs[install]: boot took 229.26 seconds. returned True
+2021-09-09 14:54:13,540 - HirsuteTestNetworkOvs - INFO - Install OK
+2021-09-09 14:54:13,540 - HirsuteTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkOvs/logs/boot-serial.log
+2021-09-09 14:54:20,782 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs[install]: boot took 184.37 seconds. returned True
+2021-09-09 14:54:21,067 - BionicTestNetworkOvs - INFO - Install OK
+2021-09-09 14:54:21,067 - BionicTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs/logs/boot-serial.log
+2021-09-09 14:54:31,871 - ImpishTestBonding - INFO - ImpishTestBonding[first_boot]: boot took 221.41 seconds. returned True
+2021-09-09 14:54:31,985 - ImpishTestBonding - INFO - ImpishTestBonding: setUpClass finished. took 574.87 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.ImpishTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.ImpishTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.ImpishTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.ImpishTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.ImpishTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.ImpishTestBonding) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.ImpishTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.ImpishTestBonding) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 14:54:32,164 - FocalTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:54:32,164 - FocalTestNetworkOvs - INFO - Starting setup for testclass: FocalTestNetworkOvs (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:54:33,176 - FocalTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs
+2021-09-09 14:54:33,176 - FocalTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:54:33,183 - FocalTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:54:33,183 - FocalTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:54:33,185 - FocalTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2021-09-09 14:54:33,186 - FocalTestNetworkOvs - INFO - disk_serials: []
+2021-09-09 14:54:33,186 - FocalTestNetworkOvs - INFO - nvme_serials: []
+2021-09-09 14:54:33,187 - FocalTestNetworkOvs - INFO - nvme disks: []
+2021-09-09 14:54:33,269 - FocalTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:54:33,270 - FocalTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:54:33,338 - FocalTestNetworkOvs - INFO - Using root_disk: []
+2021-09-09 14:54:33,338 - FocalTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs/logs/install-serial.log
+2021-09-09 14:54:50,583 - HirsuteTestNetworkOvs - INFO - HirsuteTestNetworkOvs[first_boot]: boot took 37.04 seconds. returned True
+2021-09-09 14:54:50,646 - HirsuteTestNetworkOvs - INFO - HirsuteTestNetworkOvs: setUpClass finished. took 267.76 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.HirsuteTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_openvswitch_package_status (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.HirsuteTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.HirsuteTestNetworkOvs) ... ok
+2021-09-09 14:54:51,021 - BionicTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:54:51,021 - BionicTestNetworkVlan - INFO - Starting setup for testclass: BionicTestNetworkVlan (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 14:54:51,806 - BionicTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan
+2021-09-09 14:54:51,807 - BionicTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:54:51,822 - BionicTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:54:51,822 - BionicTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:54:51,863 - BionicTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:54:51,873 - BionicTestNetworkVlan - INFO - disk_serials: []
+2021-09-09 14:54:51,873 - BionicTestNetworkVlan - INFO - nvme_serials: []
+2021-09-09 14:54:51,874 - BionicTestNetworkVlan - INFO - nvme disks: []
+2021-09-09 14:54:51,885 - BionicTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:54:51,885 - BionicTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:54:51,893 - BionicTestNetworkVlan - INFO - Using root_disk: []
+2021-09-09 14:54:51,893 - BionicTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan/logs/install-serial.log
+2021-09-09 14:54:53,475 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs[first_boot]: boot took 32.41 seconds. returned True
+2021-09-09 14:54:53,535 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs: setUpClass finished. took 218.06 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.BionicTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_openvswitch_package_status (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.BionicTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+2021-09-09 14:54:53,921 - FocalTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:54:53,921 - FocalTestNetworkVlan - INFO - Starting setup for testclass: FocalTestNetworkVlan (ubuntu/focal -> ubuntu/focal)
+2021-09-09 14:54:54,507 - FocalTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan
+2021-09-09 14:54:54,507 - FocalTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:54:54,522 - FocalTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 14:54:54,522 - FocalTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:54:54,562 - FocalTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:54:54,572 - FocalTestNetworkVlan - INFO - disk_serials: []
+2021-09-09 14:54:54,572 - FocalTestNetworkVlan - INFO - nvme_serials: []
+2021-09-09 14:54:54,572 - FocalTestNetworkVlan - INFO - nvme disks: []
+2021-09-09 14:54:54,583 - FocalTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:54:54,583 - FocalTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:54:54,591 - FocalTestNetworkVlan - INFO - Using root_disk: []
+2021-09-09 14:54:54,591 - FocalTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan/logs/install-serial.log
+2021-09-09 14:57:38,109 - ImpishTestNetworkOvs - INFO - ImpishTestNetworkOvs[install]: boot took 372.57 seconds. returned True
+2021-09-09 14:57:38,441 - ImpishTestNetworkOvs - INFO - Install OK
+2021-09-09 14:57:38,441 - ImpishTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkOvs/logs/boot-serial.log
+2021-09-09 14:58:03,154 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan[install]: boot took 191.26 seconds. returned True
+2021-09-09 14:58:03,638 - BionicTestNetworkVlan - INFO - Install OK
+2021-09-09 14:58:03,638 - BionicTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan/logs/boot-serial.log
+2021-09-09 14:58:23,618 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs[install]: boot took 230.28 seconds. returned True
+2021-09-09 14:58:23,726 - FocalTestNetworkOvs - INFO - Install OK
+2021-09-09 14:58:23,726 - FocalTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs/logs/boot-serial.log
+2021-09-09 14:58:46,118 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan[install]: boot took 231.53 seconds. returned True
+2021-09-09 14:58:46,263 - FocalTestNetworkVlan - INFO - Install OK
+2021-09-09 14:58:46,263 - FocalTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan/logs/boot-serial.log
+2021-09-09 14:58:50,711 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan[first_boot]: boot took 47.07 seconds. returned True
+2021-09-09 14:58:50,887 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan: setUpClass finished. took 239.87 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.BionicTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.BionicTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_output_files_exist (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_vlan_enabled (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: release 'bionic' does not need the vlan package
+2021-09-09 14:58:51,233 - XenialTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 14:58:51,236 - HirsuteTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:58:51,236 - HirsuteTestNetworkVlan - INFO - Starting setup for testclass: HirsuteTestNetworkVlan (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:58:51,740 - HirsuteTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkVlan
+2021-09-09 14:58:51,741 - HirsuteTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:58:51,755 - HirsuteTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:58:51,755 - HirsuteTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:58:51,792 - HirsuteTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:58:51,802 - HirsuteTestNetworkVlan - INFO - disk_serials: []
+2021-09-09 14:58:51,802 - HirsuteTestNetworkVlan - INFO - nvme_serials: []
+2021-09-09 14:58:51,802 - HirsuteTestNetworkVlan - INFO - nvme disks: []
+2021-09-09 14:58:51,890 - HirsuteTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:58:51,890 - HirsuteTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:58:51,943 - HirsuteTestNetworkVlan - INFO - Using root_disk: []
+2021-09-09 14:58:51,944 - HirsuteTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkVlan/logs/install-serial.log
+2021-09-09 14:58:59,123 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs[first_boot]: boot took 35.40 seconds. returned True
+2021-09-09 14:58:59,183 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs: setUpClass finished. took 267.02 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.FocalTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_openvswitch_package_status (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.FocalTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+2021-09-09 14:58:59,518 - ImpishTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:58:59,518 - ImpishTestNetworkVlan - INFO - Starting setup for testclass: ImpishTestNetworkVlan (ubuntu/impish -> ubuntu/impish)
+2021-09-09 14:59:00,245 - ImpishTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkVlan
+2021-09-09 14:59:00,245 - ImpishTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:59:00,260 - ImpishTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 14:59:00,260 - ImpishTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:59:00,300 - ImpishTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2021-09-09 14:59:00,309 - ImpishTestNetworkVlan - INFO - disk_serials: []
+2021-09-09 14:59:00,310 - ImpishTestNetworkVlan - INFO - nvme_serials: []
+2021-09-09 14:59:00,310 - ImpishTestNetworkVlan - INFO - nvme disks: []
+2021-09-09 14:59:00,321 - ImpishTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:59:00,321 - ImpishTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:59:00,329 - ImpishTestNetworkVlan - INFO - Using root_disk: []
+2021-09-09 14:59:00,329 - ImpishTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkVlan/logs/install-serial.log
+2021-09-09 14:59:44,219 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan[first_boot]: boot took 57.96 seconds. returned True
+2021-09-09 14:59:44,280 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan: setUpClass finished. took 290.36 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.FocalTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.FocalTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_vlan_enabled (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: release 'focal' does not need the vlan package
+2021-09-09 14:59:44,742 - HirsuteTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 14:59:44,742 - HirsuteTestNetworkStatic - INFO - Starting setup for testclass: HirsuteTestNetworkStatic (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 14:59:45,408 - HirsuteTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStatic
+2021-09-09 14:59:45,408 - HirsuteTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 14:59:45,417 - HirsuteTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 14:59:45,417 - HirsuteTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 14:59:45,420 - HirsuteTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 14:59:45,423 - HirsuteTestNetworkStatic - INFO - disk_serials: []
+2021-09-09 14:59:45,423 - HirsuteTestNetworkStatic - INFO - nvme_serials: []
+2021-09-09 14:59:45,423 - HirsuteTestNetworkStatic - INFO - nvme disks: []
+2021-09-09 14:59:45,434 - HirsuteTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 14:59:45,434 - HirsuteTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 14:59:45,442 - HirsuteTestNetworkStatic - INFO - Using root_disk: []
+2021-09-09 14:59:45,442 - HirsuteTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStatic/logs/install-serial.log
+2021-09-09 15:01:15,543 - ImpishTestNetworkOvs - INFO - ImpishTestNetworkOvs[first_boot]: boot took 217.10 seconds. returned True
+2021-09-09 15:01:15,715 - ImpishTestNetworkOvs - INFO - ImpishTestNetworkOvs: setUpClass finished. took 591.05 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.ImpishTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_openvswitch_package_status (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.ImpishTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.ImpishTestNetworkOvs) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 15:01:15,885 - FocalTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:01:15,886 - FocalTestNetworkStatic - INFO - Starting setup for testclass: FocalTestNetworkStatic (ubuntu/focal -> ubuntu/focal)
+2021-09-09 15:01:16,930 - FocalTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic
+2021-09-09 15:01:16,931 - FocalTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:01:16,938 - FocalTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:01:16,938 - FocalTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:01:16,942 - FocalTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:01:16,945 - FocalTestNetworkStatic - INFO - disk_serials: []
+2021-09-09 15:01:16,945 - FocalTestNetworkStatic - INFO - nvme_serials: []
+2021-09-09 15:01:16,945 - FocalTestNetworkStatic - INFO - nvme disks: []
+2021-09-09 15:01:16,999 - FocalTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:01:16,999 - FocalTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:01:17,020 - FocalTestNetworkStatic - INFO - Using root_disk: []
+2021-09-09 15:01:17,021 - FocalTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic/logs/install-serial.log
+2021-09-09 15:03:02,092 - HirsuteTestNetworkVlan - INFO - HirsuteTestNetworkVlan[install]: boot took 250.15 seconds. returned True
+2021-09-09 15:03:02,336 - HirsuteTestNetworkVlan - INFO - Install OK
+2021-09-09 15:03:02,336 - HirsuteTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkVlan/logs/boot-serial.log
+2021-09-09 15:03:50,711 - HirsuteTestNetworkStatic - INFO - HirsuteTestNetworkStatic[install]: boot took 245.27 seconds. returned True
+2021-09-09 15:03:50,996 - HirsuteTestNetworkStatic - INFO - Install OK
+2021-09-09 15:03:50,996 - HirsuteTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkStatic/logs/boot-serial.log
+2021-09-09 15:03:58,904 - HirsuteTestNetworkVlan - INFO - HirsuteTestNetworkVlan[first_boot]: boot took 56.57 seconds. returned True
+2021-09-09 15:03:59,079 - HirsuteTestNetworkVlan - INFO - HirsuteTestNetworkVlan: setUpClass finished. took 307.84 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.HirsuteTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.HirsuteTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_vlan_enabled (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.HirsuteTestNetworkVlan) ... SKIP: release 'hirsute' does not need the vlan package
+2021-09-09 15:03:59,386 - ImpishTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:03:59,386 - ImpishTestNetworkStatic - INFO - Starting setup for testclass: ImpishTestNetworkStatic (ubuntu/impish -> ubuntu/impish)
+2021-09-09 15:04:00,418 - ImpishTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStatic
+2021-09-09 15:04:00,419 - ImpishTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:04:00,426 - ImpishTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 15:04:00,426 - ImpishTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:04:00,430 - ImpishTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:04:00,432 - ImpishTestNetworkStatic - INFO - disk_serials: []
+2021-09-09 15:04:00,433 - ImpishTestNetworkStatic - INFO - nvme_serials: []
+2021-09-09 15:04:00,433 - ImpishTestNetworkStatic - INFO - nvme disks: []
+2021-09-09 15:04:00,536 - ImpishTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:04:00,537 - ImpishTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:04:00,590 - ImpishTestNetworkStatic - INFO - Using root_disk: []
+2021-09-09 15:04:00,590 - ImpishTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStatic/logs/install-serial.log
+2021-09-09 15:04:25,667 - HirsuteTestNetworkStatic - INFO - HirsuteTestNetworkStatic[first_boot]: boot took 34.67 seconds. returned True
+2021-09-09 15:04:25,730 - HirsuteTestNetworkStatic - INFO - HirsuteTestNetworkStatic: setUpClass finished. took 280.99 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.HirsuteTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.HirsuteTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.HirsuteTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.HirsuteTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.HirsuteTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.HirsuteTestNetworkStatic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.HirsuteTestNetworkStatic) ... ok
+2021-09-09 15:04:26,067 - XenialTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:04:26,070 - BionicTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:04:26,070 - BionicTestNetworkStatic - INFO - Starting setup for testclass: BionicTestNetworkStatic (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 15:04:26,951 - BionicTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic
+2021-09-09 15:04:26,951 - BionicTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:04:26,961 - BionicTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:04:26,961 - BionicTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:04:26,965 - BionicTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2021-09-09 15:04:26,967 - BionicTestNetworkStatic - INFO - disk_serials: []
+2021-09-09 15:04:26,967 - BionicTestNetworkStatic - INFO - nvme_serials: []
+2021-09-09 15:04:26,967 - BionicTestNetworkStatic - INFO - nvme disks: []
+2021-09-09 15:04:26,978 - BionicTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:04:26,978 - BionicTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:04:26,986 - BionicTestNetworkStatic - INFO - Using root_disk: []
+2021-09-09 15:04:26,986 - BionicTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic/logs/install-serial.log
+2021-09-09 15:05:00,351 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic[install]: boot took 223.33 seconds. returned True
+2021-09-09 15:05:00,607 - FocalTestNetworkStatic - INFO - Install OK
+2021-09-09 15:05:00,607 - FocalTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic/logs/boot-serial.log
+2021-09-09 15:05:11,087 - ImpishTestNetworkVlan - INFO - ImpishTestNetworkVlan[install]: boot took 370.76 seconds. returned True
+2021-09-09 15:05:11,242 - ImpishTestNetworkVlan - INFO - Install OK
+2021-09-09 15:05:11,242 - ImpishTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkVlan/logs/boot-serial.log
+2021-09-09 15:05:38,347 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic[first_boot]: boot took 37.74 seconds. returned True
+2021-09-09 15:05:38,438 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic: setUpClass finished. took 262.55 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.FocalTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.FocalTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+2021-09-09 15:05:38,861 - TestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:05:38,864 - HirsuteTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:05:38,865 - HirsuteTestNetworkMtu - INFO - Starting setup for testclass: HirsuteTestNetworkMtu (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 15:05:39,584 - HirsuteTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkMtu
+2021-09-09 15:05:39,585 - HirsuteTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:05:39,599 - HirsuteTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 15:05:39,599 - HirsuteTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:05:39,625 - HirsuteTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:05:39,635 - HirsuteTestNetworkMtu - INFO - disk_serials: []
+2021-09-09 15:05:39,635 - HirsuteTestNetworkMtu - INFO - nvme_serials: []
+2021-09-09 15:05:39,635 - HirsuteTestNetworkMtu - INFO - nvme disks: []
+2021-09-09 15:05:39,646 - HirsuteTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:05:39,647 - HirsuteTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:05:39,661 - HirsuteTestNetworkMtu - INFO - Using root_disk: []
+2021-09-09 15:05:39,661 - HirsuteTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkMtu/logs/install-serial.log
+2021-09-09 15:07:29,624 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic[install]: boot took 182.64 seconds. returned True
+2021-09-09 15:07:30,098 - BionicTestNetworkStatic - INFO - Install OK
+2021-09-09 15:07:30,098 - BionicTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic/logs/boot-serial.log
+2021-09-09 15:08:02,579 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic[first_boot]: boot took 32.48 seconds. returned True
+2021-09-09 15:08:02,744 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic: setUpClass finished. took 216.67 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.BionicTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.BionicTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_output_files_exist (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+2021-09-09 15:08:03,108 - FocalTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:08:03,108 - FocalTestNetworkMtu - INFO - Starting setup for testclass: FocalTestNetworkMtu (ubuntu/focal -> ubuntu/focal)
+2021-09-09 15:08:06,270 - FocalTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu
+2021-09-09 15:08:06,271 - FocalTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:08:06,285 - FocalTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:08:06,286 - FocalTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:08:06,312 - FocalTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:08:06,322 - FocalTestNetworkMtu - INFO - disk_serials: []
+2021-09-09 15:08:06,322 - FocalTestNetworkMtu - INFO - nvme_serials: []
+2021-09-09 15:08:06,322 - FocalTestNetworkMtu - INFO - nvme disks: []
+2021-09-09 15:08:06,412 - FocalTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:08:06,413 - FocalTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:08:06,454 - FocalTestNetworkMtu - INFO - Using root_disk: []
+2021-09-09 15:08:06,455 - FocalTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu/logs/install-serial.log
+2021-09-09 15:09:08,871 - ImpishTestNetworkVlan - INFO - ImpishTestNetworkVlan[first_boot]: boot took 237.63 seconds. returned True
+2021-09-09 15:09:08,945 - ImpishTestNetworkVlan - INFO - ImpishTestNetworkVlan: setUpClass finished. took 609.43 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.ImpishTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.ImpishTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+test_vlan_enabled (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.ImpishTestNetworkVlan) ... SKIP: release 'impish' does not need the vlan package
+2021-09-09 15:09:09,252 - ImpishTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:09:09,252 - ImpishTestNetworkMtu - INFO - Starting setup for testclass: ImpishTestNetworkMtu (ubuntu/impish -> ubuntu/impish)
+2021-09-09 15:09:10,217 - ImpishTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkMtu
+2021-09-09 15:09:10,217 - ImpishTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:09:10,232 - ImpishTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 15:09:10,232 - ImpishTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:09:10,259 - ImpishTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:09:10,269 - ImpishTestNetworkMtu - INFO - disk_serials: []
+2021-09-09 15:09:10,269 - ImpishTestNetworkMtu - INFO - nvme_serials: []
+2021-09-09 15:09:10,269 - ImpishTestNetworkMtu - INFO - nvme disks: []
+2021-09-09 15:09:10,280 - ImpishTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:09:10,281 - ImpishTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:09:10,289 - ImpishTestNetworkMtu - INFO - Using root_disk: []
+2021-09-09 15:09:10,289 - ImpishTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkMtu/logs/install-serial.log
+2021-09-09 15:09:29,707 - HirsuteTestNetworkMtu - INFO - HirsuteTestNetworkMtu[install]: boot took 230.04 seconds. returned True
+2021-09-09 15:09:29,956 - HirsuteTestNetworkMtu - INFO - Install OK
+2021-09-09 15:09:29,956 - HirsuteTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkMtu/logs/boot-serial.log
+2021-09-09 15:09:50,848 - ImpishTestNetworkStatic - INFO - ImpishTestNetworkStatic[install]: boot took 350.26 seconds. returned True
+2021-09-09 15:09:50,865 - ImpishTestNetworkStatic - INFO - Install OK
+2021-09-09 15:09:50,865 - ImpishTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkStatic/logs/boot-serial.log
+2021-09-09 15:10:11,171 - HirsuteTestNetworkMtu - INFO - HirsuteTestNetworkMtu[first_boot]: boot took 41.21 seconds. returned True
+2021-09-09 15:10:11,279 - HirsuteTestNetworkMtu - INFO - HirsuteTestNetworkMtu: setUpClass finished. took 272.41 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.HirsuteTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.HirsuteTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.HirsuteTestNetworkMtu) ... ok
+2021-09-09 15:10:11,823 - BionicTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:10:11,823 - BionicTestNetworkMtu - INFO - Starting setup for testclass: BionicTestNetworkMtu (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 15:10:12,766 - BionicTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu
+2021-09-09 15:10:12,767 - BionicTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:10:12,783 - BionicTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:10:12,783 - BionicTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:10:12,811 - BionicTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2021-09-09 15:10:12,821 - BionicTestNetworkMtu - INFO - disk_serials: []
+2021-09-09 15:10:12,822 - BionicTestNetworkMtu - INFO - nvme_serials: []
+2021-09-09 15:10:12,822 - BionicTestNetworkMtu - INFO - nvme disks: []
+2021-09-09 15:10:12,844 - BionicTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:10:12,844 - BionicTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:10:12,861 - BionicTestNetworkMtu - INFO - Using root_disk: []
+2021-09-09 15:10:12,861 - BionicTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu/logs/install-serial.log
+2021-09-09 15:11:41,891 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu[install]: boot took 215.44 seconds. returned True
+2021-09-09 15:11:41,976 - FocalTestNetworkMtu - INFO - Install OK
+2021-09-09 15:11:41,976 - FocalTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu/logs/boot-serial.log
+2021-09-09 15:12:20,303 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu[first_boot]: boot took 38.33 seconds. returned True
+2021-09-09 15:12:20,379 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu: setUpClass finished. took 257.27 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.FocalTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.FocalTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+2021-09-09 15:12:20,827 - ImpishTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:12:20,827 - ImpishTestNetworkIPV6Vlan - INFO - Starting setup for testclass: ImpishTestNetworkIPV6Vlan (ubuntu/impish -> ubuntu/impish)
+2021-09-09 15:12:21,542 - ImpishTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Vlan
+2021-09-09 15:12:21,543 - ImpishTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:12:21,561 - ImpishTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 15:12:21,561 - ImpishTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:12:21,611 - ImpishTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:12:21,624 - ImpishTestNetworkIPV6Vlan - INFO - disk_serials: []
+2021-09-09 15:12:21,624 - ImpishTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2021-09-09 15:12:21,624 - ImpishTestNetworkIPV6Vlan - INFO - nvme disks: []
+2021-09-09 15:12:21,636 - ImpishTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:12:21,637 - ImpishTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:12:21,645 - ImpishTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2021-09-09 15:12:21,645 - ImpishTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Vlan/logs/install-serial.log
+2021-09-09 15:13:12,794 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu[install]: boot took 179.93 seconds. returned True
+2021-09-09 15:13:13,176 - BionicTestNetworkMtu - INFO - Install OK
+2021-09-09 15:13:13,176 - BionicTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu/logs/boot-serial.log
+2021-09-09 15:13:30,076 - ImpishTestNetworkStatic - INFO - ImpishTestNetworkStatic[first_boot]: boot took 219.21 seconds. returned True
+2021-09-09 15:13:30,146 - ImpishTestNetworkStatic - INFO - ImpishTestNetworkStatic: setUpClass finished. took 570.76 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.ImpishTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.ImpishTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.ImpishTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.ImpishTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.ImpishTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.ImpishTestNetworkStatic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.ImpishTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.ImpishTestNetworkStatic) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 15:13:30,408 - HirsuteTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:13:30,409 - HirsuteTestNetworkIPV6Vlan - INFO - Starting setup for testclass: HirsuteTestNetworkIPV6Vlan (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 15:13:31,358 - HirsuteTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Vlan
+2021-09-09 15:13:31,359 - HirsuteTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:13:31,375 - HirsuteTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 15:13:31,375 - HirsuteTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:13:31,420 - HirsuteTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:13:31,431 - HirsuteTestNetworkIPV6Vlan - INFO - disk_serials: []
+2021-09-09 15:13:31,431 - HirsuteTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2021-09-09 15:13:31,431 - HirsuteTestNetworkIPV6Vlan - INFO - nvme disks: []
+2021-09-09 15:13:31,442 - HirsuteTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:13:31,443 - HirsuteTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:13:31,450 - HirsuteTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2021-09-09 15:13:31,451 - HirsuteTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Vlan/logs/install-serial.log
+2021-09-09 15:13:47,524 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu[first_boot]: boot took 34.35 seconds. returned True
+2021-09-09 15:13:47,589 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu: setUpClass finished. took 215.77 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.BionicTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.BionicTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_output_files_exist (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+2021-09-09 15:13:48,025 - XenialTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:13:48,028 - FocalTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:13:48,028 - FocalTestNetworkIPV6Vlan - INFO - Starting setup for testclass: FocalTestNetworkIPV6Vlan (ubuntu/focal -> ubuntu/focal)
+2021-09-09 15:13:48,637 - FocalTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan
+2021-09-09 15:13:48,637 - FocalTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:13:48,654 - FocalTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:13:48,654 - FocalTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:13:48,701 - FocalTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:13:48,713 - FocalTestNetworkIPV6Vlan - INFO - disk_serials: []
+2021-09-09 15:13:48,713 - FocalTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2021-09-09 15:13:48,714 - FocalTestNetworkIPV6Vlan - INFO - nvme disks: []
+2021-09-09 15:13:48,725 - FocalTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:13:48,725 - FocalTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:13:48,733 - FocalTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2021-09-09 15:13:48,733 - FocalTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan/logs/install-serial.log
+2021-09-09 15:15:04,571 - ImpishTestNetworkMtu - INFO - ImpishTestNetworkMtu[install]: boot took 354.28 seconds. returned True
+2021-09-09 15:15:04,964 - ImpishTestNetworkMtu - INFO - Install OK
+2021-09-09 15:15:04,965 - ImpishTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkMtu/logs/boot-serial.log
+2021-09-09 15:17:21,351 - HirsuteTestNetworkIPV6Vlan - INFO - HirsuteTestNetworkIPV6Vlan[install]: boot took 229.90 seconds. returned True
+2021-09-09 15:17:21,804 - HirsuteTestNetworkIPV6Vlan - INFO - Install OK
+2021-09-09 15:17:21,804 - HirsuteTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6Vlan/logs/boot-serial.log
+2021-09-09 15:17:35,103 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan[install]: boot took 226.37 seconds. returned True
+2021-09-09 15:17:35,164 - FocalTestNetworkIPV6Vlan - INFO - Install OK
+2021-09-09 15:17:35,164 - FocalTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan/logs/boot-serial.log
+2021-09-09 15:18:10,638 - ImpishTestNetworkIPV6Vlan - INFO - ImpishTestNetworkIPV6Vlan[install]: boot took 348.99 seconds. returned True
+2021-09-09 15:18:10,983 - ImpishTestNetworkIPV6Vlan - INFO - Install OK
+2021-09-09 15:18:10,983 - ImpishTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6Vlan/logs/boot-serial.log
+2021-09-09 15:18:17,971 - HirsuteTestNetworkIPV6Vlan - INFO - HirsuteTestNetworkIPV6Vlan[first_boot]: boot took 56.17 seconds. returned True
+2021-09-09 15:18:18,167 - HirsuteTestNetworkIPV6Vlan - INFO - HirsuteTestNetworkIPV6Vlan: setUpClass finished. took 287.76 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.HirsuteTestNetworkIPV6Vlan) ... SKIP: release 'hirsute' does not need the vlan package
+2021-09-09 15:18:18,634 - BionicTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:18:18,634 - BionicTestNetworkIPV6Vlan - INFO - Starting setup for testclass: BionicTestNetworkIPV6Vlan (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 15:18:19,585 - BionicTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan
+2021-09-09 15:18:19,586 - BionicTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:18:19,600 - BionicTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:18:19,600 - BionicTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:18:19,641 - BionicTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2021-09-09 15:18:19,651 - BionicTestNetworkIPV6Vlan - INFO - disk_serials: []
+2021-09-09 15:18:19,651 - BionicTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2021-09-09 15:18:19,652 - BionicTestNetworkIPV6Vlan - INFO - nvme disks: []
+2021-09-09 15:18:19,671 - BionicTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:18:19,671 - BionicTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:18:19,678 - BionicTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2021-09-09 15:18:19,678 - BionicTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan/logs/install-serial.log
+2021-09-09 15:18:36,703 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan[first_boot]: boot took 61.54 seconds. returned True
+2021-09-09 15:18:36,760 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan: setUpClass finished. took 288.73 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: release 'focal' does not need the vlan package
+2021-09-09 15:18:37,210 - BionicTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:18:37,211 - BionicTestBridging - INFO - Starting setup for testclass: BionicTestBridging (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 15:18:37,879 - BionicTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging
+2021-09-09 15:18:37,880 - BionicTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:18:37,890 - BionicTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:18:37,890 - BionicTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:18:37,903 - BionicTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:18:37,907 - BionicTestBridging - INFO - disk_serials: []
+2021-09-09 15:18:37,907 - BionicTestBridging - INFO - nvme_serials: []
+2021-09-09 15:18:37,908 - BionicTestBridging - INFO - nvme disks: []
+2021-09-09 15:18:37,918 - BionicTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:18:37,918 - BionicTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:18:37,927 - BionicTestBridging - INFO - Using root_disk: []
+2021-09-09 15:18:37,927 - BionicTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging/logs/install-serial.log
+2021-09-09 15:18:45,747 - ImpishTestNetworkMtu - INFO - ImpishTestNetworkMtu[first_boot]: boot took 220.78 seconds. returned True
+2021-09-09 15:18:45,806 - ImpishTestNetworkMtu - INFO - ImpishTestNetworkMtu: setUpClass finished. took 576.55 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.ImpishTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.ImpishTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.ImpishTestNetworkMtu) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 15:18:45,995 - XenialTestBridgingV2 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:18:45,998 - FocalTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:18:45,998 - FocalTestBridging - INFO - Starting setup for testclass: FocalTestBridging (ubuntu/focal -> ubuntu/focal)
+2021-09-09 15:18:46,894 - FocalTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging
+2021-09-09 15:18:46,895 - FocalTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:18:46,905 - FocalTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:18:46,905 - FocalTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:18:46,918 - FocalTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:18:46,923 - FocalTestBridging - INFO - disk_serials: []
+2021-09-09 15:18:46,923 - FocalTestBridging - INFO - nvme_serials: []
+2021-09-09 15:18:46,923 - FocalTestBridging - INFO - nvme disks: []
+2021-09-09 15:18:46,934 - FocalTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:18:46,934 - FocalTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:18:46,942 - FocalTestBridging - INFO - Using root_disk: []
+2021-09-09 15:18:46,942 - FocalTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging/logs/install-serial.log
+2021-09-09 15:21:17,029 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan[install]: boot took 177.35 seconds. returned True
+2021-09-09 15:21:17,274 - BionicTestNetworkIPV6Vlan - INFO - Install OK
+2021-09-09 15:21:17,274 - BionicTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan/logs/boot-serial.log
+2021-09-09 15:21:41,946 - BionicTestBridging - INFO - BionicTestBridging[install]: boot took 184.02 seconds. returned True
+2021-09-09 15:21:41,976 - BionicTestBridging - INFO - Install OK
+2021-09-09 15:21:41,977 - BionicTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging/logs/boot-serial.log
+2021-09-09 15:22:02,259 - ImpishTestNetworkIPV6Vlan - INFO - ImpishTestNetworkIPV6Vlan[first_boot]: boot took 231.28 seconds. returned True
+2021-09-09 15:22:02,338 - ImpishTestNetworkIPV6Vlan - INFO - ImpishTestNetworkIPV6Vlan: setUpClass finished. took 581.51 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.ImpishTestNetworkIPV6Vlan) ... SKIP: release 'impish' does not need the vlan package
+2021-09-09 15:22:02,550 - HirsuteTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:22:02,551 - HirsuteTestBridging - INFO - Starting setup for testclass: HirsuteTestBridging (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 15:22:03,467 - HirsuteTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBridging
+2021-09-09 15:22:03,467 - HirsuteTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:22:03,476 - HirsuteTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 15:22:03,476 - HirsuteTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:22:03,489 - HirsuteTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:22:03,494 - HirsuteTestBridging - INFO - disk_serials: []
+2021-09-09 15:22:03,494 - HirsuteTestBridging - INFO - nvme_serials: []
+2021-09-09 15:22:03,494 - HirsuteTestBridging - INFO - nvme disks: []
+2021-09-09 15:22:03,537 - HirsuteTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:22:03,537 - HirsuteTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:22:03,556 - HirsuteTestBridging - INFO - Using root_disk: []
+2021-09-09 15:22:03,556 - HirsuteTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBridging/logs/install-serial.log
+2021-09-09 15:22:06,091 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan[first_boot]: boot took 48.82 seconds. returned True
+2021-09-09 15:22:06,150 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan: setUpClass finished. took 227.52 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: release 'bionic' does not need the vlan package
+2021-09-09 15:22:06,629 - ImpishTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:22:06,629 - ImpishTestBridging - INFO - Starting setup for testclass: ImpishTestBridging (ubuntu/impish -> ubuntu/impish)
+2021-09-09 15:22:07,227 - ImpishTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBridging
+2021-09-09 15:22:07,228 - ImpishTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:22:07,238 - ImpishTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 15:22:07,238 - ImpishTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:22:07,252 - ImpishTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2021-09-09 15:22:07,258 - ImpishTestBridging - INFO - disk_serials: []
+2021-09-09 15:22:07,258 - ImpishTestBridging - INFO - nvme_serials: []
+2021-09-09 15:22:07,258 - ImpishTestBridging - INFO - nvme disks: []
+2021-09-09 15:22:07,269 - ImpishTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:22:07,270 - ImpishTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:22:07,277 - ImpishTestBridging - INFO - Using root_disk: []
+2021-09-09 15:22:07,277 - ImpishTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBridging/logs/install-serial.log
+2021-09-09 15:22:16,747 - BionicTestBridging - INFO - BionicTestBridging[first_boot]: boot took 34.77 seconds. returned True
+2021-09-09 15:22:16,810 - BionicTestBridging - INFO - BionicTestBridging: setUpClass finished. took 219.60 seconds. Running testcases.
+2021-09-09 15:22:16,817 - BionicTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.BionicTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.BionicTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.BionicTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_output_files_exist (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.BionicTestBridging) ... ok
+2021-09-09 15:22:17,206 - XenialTestNetworkENISource - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:22:17,209 - ImpishTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:22:17,209 - ImpishTestNetworkIPV6 - INFO - Starting setup for testclass: ImpishTestNetworkIPV6 (ubuntu/impish -> ubuntu/impish)
+2021-09-09 15:22:17,805 - ImpishTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6
+2021-09-09 15:22:17,806 - ImpishTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:22:17,819 - ImpishTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/impish/amd64/20210812/squashfs:root/squashfs
+2021-09-09 15:22:17,819 - ImpishTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:22:17,842 - ImpishTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:22:17,850 - ImpishTestNetworkIPV6 - INFO - disk_serials: []
+2021-09-09 15:22:17,850 - ImpishTestNetworkIPV6 - INFO - nvme_serials: []
+2021-09-09 15:22:17,850 - ImpishTestNetworkIPV6 - INFO - nvme disks: []
+2021-09-09 15:22:17,861 - ImpishTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:22:17,862 - ImpishTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:22:17,870 - ImpishTestNetworkIPV6 - INFO - Using root_disk: []
+2021-09-09 15:22:17,870 - ImpishTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6/logs/install-serial.log
+2021-09-09 15:22:28,771 - FocalTestBridging - INFO - FocalTestBridging[install]: boot took 221.83 seconds. returned True
+2021-09-09 15:22:29,087 - FocalTestBridging - INFO - Install OK
+2021-09-09 15:22:29,088 - FocalTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging/logs/boot-serial.log
+2021-09-09 15:23:07,115 - FocalTestBridging - INFO - FocalTestBridging[first_boot]: boot took 38.03 seconds. returned True
+2021-09-09 15:23:07,182 - FocalTestBridging - INFO - FocalTestBridging: setUpClass finished. took 261.18 seconds. Running testcases.
+2021-09-09 15:23:07,189 - FocalTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.FocalTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.FocalTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.FocalTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.FocalTestBridging) ... ok
+2021-09-09 15:23:07,619 - XenialTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:23:07,622 - FocalTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:23:07,622 - FocalTestNetworkIPV6 - INFO - Starting setup for testclass: FocalTestNetworkIPV6 (ubuntu/focal -> ubuntu/focal)
+2021-09-09 15:23:08,313 - FocalTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6
+2021-09-09 15:23:08,313 - FocalTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:23:08,326 - FocalTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:23:08,326 - FocalTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:23:08,349 - FocalTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:23:08,357 - FocalTestNetworkIPV6 - INFO - disk_serials: []
+2021-09-09 15:23:08,357 - FocalTestNetworkIPV6 - INFO - nvme_serials: []
+2021-09-09 15:23:08,357 - FocalTestNetworkIPV6 - INFO - nvme disks: []
+2021-09-09 15:23:08,369 - FocalTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:23:08,369 - FocalTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:23:08,377 - FocalTestNetworkIPV6 - INFO - Using root_disk: []
+2021-09-09 15:23:08,377 - FocalTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6/logs/install-serial.log
+2021-09-09 15:26:01,006 - HirsuteTestBridging - INFO - HirsuteTestBridging[install]: boot took 237.43 seconds. returned True
+2021-09-09 15:26:01,276 - HirsuteTestBridging - INFO - Install OK
+2021-09-09 15:26:01,276 - HirsuteTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestBridging/logs/boot-serial.log
+2021-09-09 15:26:35,668 - HirsuteTestBridging - INFO - HirsuteTestBridging[first_boot]: boot took 34.39 seconds. returned True
+2021-09-09 15:26:35,977 - HirsuteTestBridging - INFO - HirsuteTestBridging: setUpClass finished. took 273.43 seconds. Running testcases.
+2021-09-09 15:26:35,984 - HirsuteTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.HirsuteTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.HirsuteTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.HirsuteTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.HirsuteTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.HirsuteTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.HirsuteTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.HirsuteTestBridging) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.HirsuteTestBridging) ... ok
+2021-09-09 15:26:36,216 - HirsuteTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:26:36,216 - HirsuteTestNetworkIPV6 - INFO - Starting setup for testclass: HirsuteTestNetworkIPV6 (ubuntu/hirsute -> ubuntu/hirsute)
+2021-09-09 15:26:37,632 - HirsuteTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6
+2021-09-09 15:26:37,632 - HirsuteTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:26:37,644 - HirsuteTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/hirsute/amd64/20210804/squashfs:root/squashfs
+2021-09-09 15:26:37,644 - HirsuteTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:26:37,667 - HirsuteTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:26:37,675 - HirsuteTestNetworkIPV6 - INFO - disk_serials: []
+2021-09-09 15:26:37,675 - HirsuteTestNetworkIPV6 - INFO - nvme_serials: []
+2021-09-09 15:26:37,675 - HirsuteTestNetworkIPV6 - INFO - nvme disks: []
+2021-09-09 15:26:37,907 - HirsuteTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:26:37,907 - HirsuteTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:26:37,953 - HirsuteTestNetworkIPV6 - INFO - Using root_disk: []
+2021-09-09 15:26:37,954 - HirsuteTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6/logs/install-serial.log
+2021-09-09 15:26:55,710 - FocalTestNetworkIPV6 - INFO - FocalTestNetworkIPV6[install]: boot took 227.33 seconds. returned True
+2021-09-09 15:26:55,890 - FocalTestNetworkIPV6 - INFO - Install OK
+2021-09-09 15:26:55,890 - FocalTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6/logs/boot-serial.log
+2021-09-09 15:27:37,839 - FocalTestNetworkIPV6 - INFO - FocalTestNetworkIPV6[first_boot]: boot took 41.95 seconds. returned True
+2021-09-09 15:27:37,903 - FocalTestNetworkIPV6 - INFO - FocalTestNetworkIPV6: setUpClass finished. took 270.28 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.FocalTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.FocalTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.FocalTestNetworkIPV6) ... ok
+2021-09-09 15:27:38,287 - BionicTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2021-09-09 15:27:38,287 - BionicTestNetworkIPV6 - INFO - Starting setup for testclass: BionicTestNetworkIPV6 (ubuntu/bionic -> ubuntu/bionic)
+2021-09-09 15:27:38,985 - BionicTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6
+2021-09-09 15:27:38,985 - BionicTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:27:38,999 - BionicTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20210811/squashfs:root/squashfs
+2021-09-09 15:27:38,999 - BionicTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2021-09-09 15:27:39,022 - BionicTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2021-09-09 15:27:39,029 - BionicTestNetworkIPV6 - INFO - disk_serials: []
+2021-09-09 15:27:39,030 - BionicTestNetworkIPV6 - INFO - nvme_serials: []
+2021-09-09 15:27:39,030 - BionicTestNetworkIPV6 - INFO - nvme disks: []
+2021-09-09 15:27:39,041 - BionicTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2021-09-09 15:27:39,042 - BionicTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2021-09-09 15:27:39,050 - BionicTestNetworkIPV6 - INFO - Using root_disk: []
+2021-09-09 15:27:39,050 - BionicTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6/logs/install-serial.log
+2021-09-09 15:28:09,825 - ImpishTestBridging - INFO - ImpishTestBridging[install]: boot took 362.55 seconds. returned True
+2021-09-09 15:28:09,952 - ImpishTestBridging - INFO - Install OK
+2021-09-09 15:28:09,953 - ImpishTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestBridging/logs/boot-serial.log
+2021-09-09 15:28:22,887 - ImpishTestNetworkIPV6 - INFO - ImpishTestNetworkIPV6[install]: boot took 365.02 seconds. returned True
+2021-09-09 15:28:22,973 - ImpishTestNetworkIPV6 - INFO - Install OK
+2021-09-09 15:28:22,974 - ImpishTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/ImpishTestNetworkIPV6/logs/boot-serial.log
+2021-09-09 15:30:19,350 - HirsuteTestNetworkIPV6 - INFO - HirsuteTestNetworkIPV6[install]: boot took 221.40 seconds. returned True
+2021-09-09 15:30:19,617 - HirsuteTestNetworkIPV6 - INFO - Install OK
+2021-09-09 15:30:19,617 - HirsuteTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/HirsuteTestNetworkIPV6/logs/boot-serial.log
+2021-09-09 15:30:35,154 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6[install]: boot took 176.10 seconds. returned True
+2021-09-09 15:30:35,229 - BionicTestNetworkIPV6 - INFO - Install OK
+2021-09-09 15:30:35,229 - BionicTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6/logs/boot-serial.log
+2021-09-09 15:31:12,275 - HirsuteTestNetworkIPV6 - INFO - HirsuteTestNetworkIPV6[first_boot]: boot took 52.66 seconds. returned True
+2021-09-09 15:31:12,429 - HirsuteTestNetworkIPV6 - INFO - HirsuteTestNetworkIPV6: setUpClass finished. took 276.21 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.HirsuteTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.HirsuteTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.HirsuteTestNetworkIPV6) ... ok
+2021-09-09 15:31:12,868 - XenialTestNetworkIPV6ENISource - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+SKIP: "xenial" is unsupported release.
+2021-09-09 15:31:23,535 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6[first_boot]: boot took 48.31 seconds. returned True
+2021-09-09 15:31:23,589 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6: setUpClass finished. took 225.30 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.BionicTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.BionicTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_output_files_exist (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+2021-09-09 15:31:48,107 - ImpishTestBridging - INFO - ImpishTestBridging[first_boot]: boot took 218.15 seconds. returned True
+2021-09-09 15:31:48,165 - ImpishTestBridging - INFO - ImpishTestBridging: setUpClass finished. took 581.54 seconds. Running testcases.
+2021-09-09 15:31:48,172 - ImpishTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.ImpishTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.ImpishTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.ImpishTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.ImpishTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.ImpishTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.ImpishTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.ImpishTestBridging) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.ImpishTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.ImpishTestBridging) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+2021-09-09 15:32:13,971 - ImpishTestNetworkIPV6 - INFO - ImpishTestNetworkIPV6[first_boot]: boot took 231.00 seconds. returned True
+2021-09-09 15:32:14,028 - ImpishTestNetworkIPV6 - INFO - ImpishTestNetworkIPV6: setUpClass finished. took 596.82 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.ImpishTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.ImpishTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.ImpishTestNetworkIPV6) ... SKIP: skip_by_date(test_swaps_used) LP: #1894910 fixby=2020-10-15 removeby=2020-11-01: 
+
+----------------------------------------------------------------------
+Ran 1052 tests in 4936.560s
+
+OK (SKIP=298)
+Thu, 09 Sep 2021 15:32:14 +0000: vmtest end [0] in 4941s
+cleanup: deleting links and image files
+Sending e-mails to: michael.hudson@canonical.com daniel.bungert@canonical.com
+Archiving artifacts

--- a/21.3-1/integration_tests/azure_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/azure_bionic_integration_tests.txt
@@ -1,0 +1,4194 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:30:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 00:30:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 00:30:56 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for azure
+2021-09-09 00:30:56 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+2021-09-09 00:30:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+2021-09-09 00:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:32:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:32:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:32:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a79710>
+2021-09-09 00:32:34 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a79710>
+2021-09-09 00:32:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:32:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:32:35 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 00:32:35 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 00:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 00:32:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 00:32:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 00:32:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:32:56 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:32:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 00:32:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 00:32:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 00:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 00:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+2021-09-09 00:34:00 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+Done with environment setup
+2021-09-09 00:34:40 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 00:34:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 00:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:35:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:35:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:35:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a81630>
+2021-09-09 00:35:30 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a81630>
+2021-09-09 00:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:35:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:35:31 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-09 00:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:36:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:36:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 00:36:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 00:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:36:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:36:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:37:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045f5e5c0>
+2021-09-09 00:37:01 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045f5e5c0>
+2021-09-09 00:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:37:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:37:02 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 00:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 00:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 00:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 00:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 00:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 00:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 00:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 00:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 00:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-09 00:37:05 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 00:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 00:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 00:37:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 00:37:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:37:25 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:37:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 00:37:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 00:37:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-09 00:37:26 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 00:37:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:38:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:38:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:38:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 00:38:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 00:38:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-09 00:38:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 00:38:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 00:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 00:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 00:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 00:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 00:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 00:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 00:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.836s (kernel) + 18.485s (userspace) = 23.322s
+graphical.target reached after 17.666s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.829s (kernel) + 11.152s (userspace) = 15.982s
+graphical.target reached after 10.424s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+          4.448s cloud-init.service
+          3.629s snapd.seeded.service
+          2.083s cloud-config.service
+          1.983s systemd-networkd-wait-online.service
+          1.330s snapd.service
+          1.320s pollinate.service
+          1.216s dev-sda1.device
+          1.211s cloud-init-local.service
+          1.160s lxd-containers.service
+           958ms apparmor.service
+=== `systemd-analyze blame` after (first 10 lines):
+          1.952s cloud-config.service
+          1.708s systemd-networkd-wait-online.service
+          1.631s dev-sda1.device
+          1.499s cloud-init.service
+          1.354s cloud-init-local.service
+          1.149s networkd-dispatcher.service
+          1.086s walinuxagent-network-setup.service
+           928ms snapd.service
+           716ms cloud-final.service
+           451ms accounts-daemon.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00700 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.25000 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.25000 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.38800 seconds
+Finished stage: (azure-ds/_get_data) 00.40500 seconds
+Finished stage: (init-local/search-Azure) 00.40900 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00000 seconds
+Finished stage: (init-local) 00.61200 seconds
+Total Time: 2.32600 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00900 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01500 seconds
+Finished stage: (azure-ds/_post_health_report) 00.66100 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.66200 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.67300 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.67300 seconds
+Finished stage: (azure-ds/_negotiate) 00.67800 seconds
+Finished stage: (azure-ds/setup) 00.67800 seconds
+Finished stage: (init-network/setup-datasource) 00.67800 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.08700 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.16100 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.16100 seconds
+Total Time: 5.16200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02300 seconds
+Finished stage: (azure-ds/activate) 00.18500 seconds
+Finished stage: (init-network/activate-datasource) 00.18900 seconds
+Finished stage: (init-network/config-users-groups) 00.18700 seconds
+Finished stage: (init-network/config-ssh) 00.23100 seconds
+Finished stage: (init-network) 03.89700 seconds
+Finished stage: (modules-config) 01.38200 seconds
+Finished stage: (modules-final) 00.17600 seconds
+Total Time: 6.27000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00600 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.14500 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.14500 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.49300 seconds
+Finished stage: (azure-ds/_get_data) 00.51000 seconds
+Finished stage: (init-local/search-Azure) 00.51400 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.70200 seconds
+Total Time: 2.52100 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01000 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.00900 seconds
+Finished stage: (azure-ds/_post_health_report) 00.01600 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.01700 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.02900 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.02900 seconds
+Finished stage: (azure-ds/_negotiate) 00.03200 seconds
+Finished stage: (azure-ds/setup) 00.03400 seconds
+Finished stage: (init-network/setup-datasource) 00.03400 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.09500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.09500 seconds
+Total Time: 0.42800 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02000 seconds
+Finished stage: (azure-ds/activate) 00.11600 seconds
+Finished stage: (init-network/activate-datasource) 00.11700 seconds
+Finished stage: (init-network/config-users-groups) 00.08900 seconds
+Finished stage: (init-network/config-ssh) 00.19400 seconds
+Finished stage: (init-network) 00.94300 seconds
+Finished stage: (modules-config) 00.56800 seconds
+Finished stage: (modules-final) 00.15800 seconds
+Finished stage: (init-network/setup-datasource) 00.00100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.08200 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.08200 seconds
+Total Time: 2.37000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.09500 seconds
+Finished stage: (init-network/activate-datasource) 00.09800 seconds
+Finished stage: (init-network) 00.27200 seconds
+Total Time: 0.47700 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.21500s (azure-ds/obtain-dhcp-lease)
+     00.03200s (azure-ds/list_possible_azure_ds_devs)
+     00.01800s (init-network/check-cache)
+     00.01300s (azure-ds/get_boot_telemetry)
+     00.01300s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/get_public_ssh_keys)
+     00.00100s (azure-ds/check-platform-viability)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.10800s (azure-ds/obtain-dhcp-lease)
+     00.01800s (init-network/check-cache)
+     00.01500s (azure-ds/_get_metadata_from_imds)
+     00.01300s (azure-ds/get_boot_telemetry)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/get_public_ssh_keys)
+     00.00100s (azure-ds/check-platform-viability)
+
+2021-09-09 00:38:19 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 4.836s (kernel) + 18.485s (userspace) = 23.322s
+graphical.target reached after 17.666s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.829s (kernel) + 11.152s (userspace) = 15.982s
+graphical.target reached after 10.424s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+          4.448s cloud-init.service
+          3.629s snapd.seeded.service
+          2.083s cloud-config.service
+          1.983s systemd-networkd-wait-online.service
+          1.330s snapd.service
+          1.320s pollinate.service
+          1.216s dev-sda1.device
+          1.211s cloud-init-local.service
+          1.160s lxd-containers.service
+           958ms apparmor.service
+=== `systemd-analyze blame` after (first 10 lines):
+          1.952s cloud-config.service
+          1.708s systemd-networkd-wait-online.service
+          1.631s dev-sda1.device
+          1.499s cloud-init.service
+          1.354s cloud-init-local.service
+          1.149s networkd-dispatcher.service
+          1.086s walinuxagent-network-setup.service
+           928ms snapd.service
+           716ms cloud-final.service
+           451ms accounts-daemon.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00700 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.25000 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.25000 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.38800 seconds
+Finished stage: (azure-ds/_get_data) 00.40500 seconds
+Finished stage: (init-local/search-Azure) 00.40900 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00000 seconds
+Finished stage: (init-local) 00.61200 seconds
+Total Time: 2.32600 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00900 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01500 seconds
+Finished stage: (azure-ds/_post_health_report) 00.66100 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.66200 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.67300 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.67300 seconds
+Finished stage: (azure-ds/_negotiate) 00.67800 seconds
+Finished stage: (azure-ds/setup) 00.67800 seconds
+Finished stage: (init-network/setup-datasource) 00.67800 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.08700 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.16100 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.16100 seconds
+Total Time: 5.16200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02300 seconds
+Finished stage: (azure-ds/activate) 00.18500 seconds
+Finished stage: (init-network/activate-datasource) 00.18900 seconds
+Finished stage: (init-network/config-users-groups) 00.18700 seconds
+Finished stage: (init-network/config-ssh) 00.23100 seconds
+Finished stage: (init-network) 03.89700 seconds
+Finished stage: (modules-config) 01.38200 seconds
+Finished stage: (modules-final) 00.17600 seconds
+Total Time: 6.27000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00600 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.14500 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.14500 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.49300 seconds
+Finished stage: (azure-ds/_get_data) 00.51000 seconds
+Finished stage: (init-local/search-Azure) 00.51400 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.70200 seconds
+Total Time: 2.52100 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01000 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.00900 seconds
+Finished stage: (azure-ds/_post_health_report) 00.01600 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.01700 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.02900 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.02900 seconds
+Finished stage: (azure-ds/_negotiate) 00.03200 seconds
+Finished stage: (azure-ds/setup) 00.03400 seconds
+Finished stage: (init-network/setup-datasource) 00.03400 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.09500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.09500 seconds
+Total Time: 0.42800 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02000 seconds
+Finished stage: (azure-ds/activate) 00.11600 seconds
+Finished stage: (init-network/activate-datasource) 00.11700 seconds
+Finished stage: (init-network/config-users-groups) 00.08900 seconds
+Finished stage: (init-network/config-ssh) 00.19400 seconds
+Finished stage: (init-network) 00.94300 seconds
+Finished stage: (modules-config) 00.56800 seconds
+Finished stage: (modules-final) 00.15800 seconds
+Finished stage: (init-network/setup-datasource) 00.00100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.08200 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.08200 seconds
+Total Time: 2.37000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.09500 seconds
+Finished stage: (init-network/activate-datasource) 00.09800 seconds
+Finished stage: (init-network) 00.27200 seconds
+Total Time: 0.47700 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.21500s (azure-ds/obtain-dhcp-lease)
+     00.03200s (azure-ds/list_possible_azure_ds_devs)
+     00.01800s (init-network/check-cache)
+     00.01300s (azure-ds/get_boot_telemetry)
+     00.01300s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/get_public_ssh_keys)
+     00.00100s (azure-ds/check-platform-viability)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.10800s (azure-ds/obtain-dhcp-lease)
+     00.01800s (init-network/check-cache)
+     00.01500s (azure-ds/_get_metadata_from_imds)
+     00.01300s (azure-ds/get_boot_telemetry)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/get_public_ssh_keys)
+     00.00100s (azure-ds/check-platform-viability)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:39:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:39:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+2021-09-09 00:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:39:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:39:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:39:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04ce32e10>
+2021-09-09 00:39:50 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04ce32e10>
+2021-09-09 00:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:39:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:39:51 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 00:39:51 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 00:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 00:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 00:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 00:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:40:13 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-09 00:40:13 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 00:40:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:40:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:40:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:41:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 00:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:41:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirements!??'}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:41:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirements!??'}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 00:42:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:42:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:42:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:42:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448fc9e8>
+2021-09-09 00:42:32 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448fc9e8>
+2021-09-09 00:42:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:42:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:42:33 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 00:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+2021-09-09 00:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 00:42:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 00:42:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision -force'
+Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirementsNow!??'}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-194141-image
+user_data=None
+2021-09-09 00:43:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirementsNow!??'}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-194141-image
+user_data=None
+2021-09-09 00:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:45:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:45:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:45:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448ac6d8>
+2021-09-09 00:45:15 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448ac6d8>
+2021-09-09 00:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:45:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:45:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 00:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+PASSED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:46:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 00:46:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 00:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:47:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:47:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:47:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d7358>
+2021-09-09 00:47:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d7358>
+2021-09-09 00:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:47:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:47:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:48:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 00:48:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 00:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:48:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:48:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:48:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044914320>
+2021-09-09 00:49:03 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044914320>
+2021-09-09 00:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:49:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:49:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:49:04 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:49:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:49:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:49:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-pro-bionic-fips:pro-fips-18_04:18.04.202010201
+user_data=None
+2021-09-09 00:49:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-pro-bionic-fips:pro-fips-18_04:18.04.202010201
+user_data=None
+2021-09-09 00:50:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:50:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.9p1)
+2021-09-09 00:50:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:50:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045ac5fd0>
+2021-09-09 00:51:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045ac5fd0>
+2021-09-09 00:51:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:51:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 00:51:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210802
+2021-09-09 00:51:26 INFO      integration_testing:clouds.py:183 image serial: 20210802
+Installing proposed image
+2021-09-09 00:51:26 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 00:51:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 00:51:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 00:51:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 00:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:51:39 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /sys/class/dmi/id/product_uuid'
+2021-09-09 00:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'uname -r'
+2021-09-09 00:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update'
+2021-09-09 00:51:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install linux-azure --assume-yes'
+2021-09-09 00:52:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ua disable fips --assume-yes'
+Restarting instance and waiting for boot
+2021-09-09 00:52:38 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 00:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:53:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:53:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:53:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.9p1)
+2021-09-09 00:53:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:53:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 00:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'uname -r'
+2021-09-09 00:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /sys/class/dmi/id/product_uuid'
+2021-09-09 00:53:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:54:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 00:54:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 00:55:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:55:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:55:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:55:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045aa70b8>
+2021-09-09 00:55:04 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045aa70b8>
+2021-09-09 00:55:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:55:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:55:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:55:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:55:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:55:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 00:55:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 00:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:56:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:56:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:56:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045aa0390>
+2021-09-09 00:56:36 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045aa0390>
+2021-09-09 00:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:56:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:56:36 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 00:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-09 00:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:57:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 00:57:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 00:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:58:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:58:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:58:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448a3ba8>
+2021-09-09 00:58:08 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448a3ba8>
+2021-09-09 00:58:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:58:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 00:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 00:58:09 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-09 00:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-09 00:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 00:58:09 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 00:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 00:59:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 00:59:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 00:59:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 00:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-09 00:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 00:59:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+instance_type=Standard_DS1_v2
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 00:59:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+instance_type=Standard_DS1_v2
+user_data=None
+2021-09-09 01:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:00:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:00:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:00:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04487c978>
+2021-09-09 01:00:45 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04487c978>
+2021-09-09 01:00:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:00:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:00:46 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+2021-09-09 01:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_resource-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:01:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+instance_type=Standard_D2s_v4
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:01:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+instance_type=Standard_D2s_v4
+user_data=None
+2021-09-09 01:02:13 INFO      adal-python:log.py:114 ad390d77-f858-42f5-80b9-92976728becf - CacheDriver:Cached token is expired at 2021-09-08 20:07:13.112888.  Refreshing
+2021-09-09 01:02:13 INFO      adal-python:log.py:114 ad390d77-f858-42f5-80b9-92976728becf - TokenRequest:Getting a new token from a refresh token
+2021-09-09 01:02:14 INFO      adal-python:log.py:114 ad390d77-f858-42f5-80b9-92976728becf - CacheDriver:Returning token refreshed after expiry.
+2021-09-09 01:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:02:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:02:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:02:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448912e8>
+2021-09-09 01:02:17 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448912e8>
+2021-09-09 01:02:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:02:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:02:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 01:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 01:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 01:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 01:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:02:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', 'path': '/home/ubuntu/.ssh/authorized_keys'}]}}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:02:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', 'path': '/home/ubuntu/.ssh/authorized_keys'}]}}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+2021-09-09 01:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:03:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:03:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:03:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044902c50>
+2021-09-09 01:03:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044902c50>
+2021-09-09 01:03:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:03:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:03:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:03:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 01:03:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 01:04:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 01:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:04:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:04:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:04:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0451530b8>
+2021-09-09 01:04:48 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0451530b8>
+2021-09-09 01:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:04:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:04:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-09 01:04:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:04:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:04:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:05:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 01:05:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 01:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:06:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:06:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:06:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0451a1710>
+2021-09-09 01:06:21 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0451a1710>
+2021-09-09 01:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:06:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:06:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:07:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 01:07:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 01:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:07:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:07:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:07:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a86b00>
+2021-09-09 01:07:53 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a86b00>
+2021-09-09 01:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:07:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:07:54 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:07:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:08:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 01:08:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 01:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:09:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:09:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:09:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044902e80>
+2021-09-09 01:09:24 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044902e80>
+2021-09-09 01:09:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:09:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:09:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:09:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:10:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 01:10:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 01:10:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:10:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:10:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:10:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044826630>
+2021-09-09 01:10:56 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044826630>
+2021-09-09 01:10:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:10:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:10:57 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:10:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:11:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 01:11:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 01:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:12:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:12:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:12:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d2a58>
+2021-09-09 01:12:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d2a58>
+2021-09-09 01:12:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:12:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:12:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:12:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:12:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:13:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 01:13:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 01:13:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:13:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:13:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:13:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04483c828>
+2021-09-09 01:14:00 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04483c828>
+2021-09-09 01:14:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:14:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:14:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:14:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:14:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 01:14:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 01:15:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:15:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:15:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:15:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448468d0>
+2021-09-09 01:15:32 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448468d0>
+2021-09-09 01:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:15:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:15:33 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 01:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:15:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:15:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:15:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:15:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:15:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 01:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:16:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 01:16:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 01:17:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:17:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:17:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044855a20>
+2021-09-09 01:17:04 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044855a20>
+2021-09-09 01:17:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:17:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:17:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:17:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:17:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:17:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 01:17:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 01:18:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:18:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:18:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:18:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d1278>
+2021-09-09 01:18:36 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448d1278>
+2021-09-09 01:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:18:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:18:37 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 01:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:19:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 01:19:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 01:20:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:20:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:20:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:20:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6128>
+2021-09-09 01:20:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6128>
+2021-09-09 01:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:20:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:20:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:20:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:20:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:20:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:20:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:20:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:20:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:20:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:20:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:20:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 01:20:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 01:21:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:21:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:21:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:21:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6f28>
+2021-09-09 01:21:37 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6f28>
+2021-09-09 01:21:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:21:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:21:38 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:21:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 01:22:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 01:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:23:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:23:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:23:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04483f438>
+2021-09-09 01:23:09 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04483f438>
+2021-09-09 01:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:23:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:23:10 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:23:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 01:23:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 01:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:24:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:24:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:24:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6160>
+2021-09-09 01:24:41 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447e6160>
+2021-09-09 01:24:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:24:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:24:42 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:24:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:24:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 01:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-09 01:24:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:25:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 01:25:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 01:26:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:26:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:26:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:26:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04482ed30>
+2021-09-09 01:26:29 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04482ed30>
+2021-09-09 01:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:26:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:26:30 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:27:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 01:27:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 01:27:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:27:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:28:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:28:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:28:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:28:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:28:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447a98d0>
+2021-09-09 01:28:38 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447a98d0>
+2021-09-09 01:28:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:28:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:28:39 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-09 01:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:29:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 01:29:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 01:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:30:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:30:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:30:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447a9898>
+2021-09-09 01:30:11 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447a9898>
+2021-09-09 01:30:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:30:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:30:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:30:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:30:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:30:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 01:30:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 01:31:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:31:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:31:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:31:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044802ef0>
+2021-09-09 01:32:01 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044802ef0>
+2021-09-09 01:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:32:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:32:02 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-09 01:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-09 01:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:32:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 01:32:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 01:33:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:33:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:33:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:33:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04482e0b8>
+2021-09-09 01:34:46 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04482e0b8>
+2021-09-09 01:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:34:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:34:47 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:34:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:34:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:34:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:34:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:34:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:35:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 01:35:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 01:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:36:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:36:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:36:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448916a0>
+2021-09-09 01:36:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0448916a0>
+2021-09-09 01:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:36:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:36:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:36:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 01:36:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:37:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:37:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:37:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04480b390>
+2021-09-09 01:37:48 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04480b390>
+2021-09-09 01:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:37:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:37:50 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:38:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 01:38:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 01:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:39:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:39:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:39:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447d66d8>
+2021-09-09 01:39:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447d66d8>
+2021-09-09 01:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:39:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:39:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:40:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 01:40:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 01:40:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:40:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:40:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:40:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447dedd8>
+2021-09-09 01:40:50 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447dedd8>
+2021-09-09 01:40:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:40:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:40:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:40:51 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:40:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:41:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 01:41:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 01:42:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:42:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:42:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:42:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044816860>
+2021-09-09 01:42:21 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044816860>
+2021-09-09 01:42:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:42:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:42:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:42:21 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:42:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 01:42:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-09 01:42:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 01:43:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 01:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:43:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:43:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:43:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447f0240>
+2021-09-09 01:43:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447f0240>
+2021-09-09 01:43:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:43:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:44:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 01:44:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 01:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:45:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:45:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:45:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044722c18>
+2021-09-09 01:45:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044722c18>
+2021-09-09 01:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:46:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 01:46:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 01:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:46:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:46:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:46:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04472b470>
+2021-09-09 01:47:39 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04472b470>
+2021-09-09 01:47:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:47:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:47:40 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:48:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 01:48:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 01:49:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:49:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:49:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:49:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447229b0>
+2021-09-09 01:49:20 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447229b0>
+2021-09-09 01:49:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:49:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:49:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:49:21 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:49:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:50:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 01:50:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 01:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:50:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:50:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:50:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447225c0>
+2021-09-09 01:50:50 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447225c0>
+2021-09-09 01:50:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:50:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:50:51 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:51:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 01:51:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 01:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:52:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:52:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:52:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447c5ac8>
+2021-09-09 01:52:21 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447c5ac8>
+2021-09-09 01:52:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:52:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:52:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:53:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 01:53:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 01:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:53:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:53:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:53:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04479a518>
+2021-09-09 01:53:53 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04479a518>
+2021-09-09 01:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:53:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:53:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:53:54 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:53:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:54:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 01:54:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 01:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:55:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:55:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:55:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447bfc88>
+2021-09-09 01:55:24 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447bfc88>
+2021-09-09 01:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:56:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 01:56:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 01:56:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:56:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:56:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:56:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0446ee160>
+2021-09-09 01:56:56 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0446ee160>
+2021-09-09 01:56:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:56:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:56:57 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-09 01:56:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:56:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 01:56:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:56:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 01:56:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:56:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 01:56:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:56:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:56:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 01:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 01:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 01:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-09 01:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 01:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 01:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 01:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-09 01:56:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 01:57:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 01:57:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 01:57:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 01:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 01:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 01:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 01:57:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 01:57:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 01:57:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 01:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 01:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 01:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 01:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 01:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 01:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 01:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-09 01:57:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 01:57:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 01:57:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:57:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 01:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 01:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 01:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-09 01:57:17 INFO      adal-python:log.py:114 070f75f9-044f-45aa-99c5-fa60fb9200c8 - CacheDriver:Cached token is expired at 2021-09-08 21:02:13.332506.  Refreshing
+2021-09-09 01:57:17 INFO      adal-python:log.py:114 070f75f9-044f-45aa-99c5-fa60fb9200c8 - TokenRequest:Getting a new token from a refresh token
+2021-09-09 01:57:18 INFO      adal-python:log.py:114 070f75f9-044f-45aa-99c5-fa60fb9200c8 - CacheDriver:Returning token refreshed after expiry.
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:57:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 01:57:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 01:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 01:58:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 01:58:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a79a58>
+2021-09-09 01:58:36 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a79a58>
+2021-09-09 01:58:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:58:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 01:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 01:58:37 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 01:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 01:58:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 01:58:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 01:58:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 01:58:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 01:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 01:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 01:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 01:58:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 01:58:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 01:58:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 01:58:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 01:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 01:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 01:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 01:58:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 01:58:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 01:58:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 01:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 01:58:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 01:58:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 01:58:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 01:58:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 01:58:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-09 01:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 01:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 01:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 01:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 01:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 01:59:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 01:59:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 02:00:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:00:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:00:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a57080>
+2021-09-09 02:00:14 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a57080>
+2021-09-09 02:00:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:00:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:00:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:00:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:00:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 02:00:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 02:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 02:00:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 02:00:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 02:00:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 02:00:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 02:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 02:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 02:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 02:00:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 02:00:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 02:00:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 02:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 02:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:00:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 02:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 02:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:01:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 02:01:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 02:01:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:01:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:01:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0446dc400>
+2021-09-09 02:01:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0446dc400>
+2021-09-09 02:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:01:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:01:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 02:01:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 02:01:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 02:01:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 02:01:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 02:01:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 02:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 02:01:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 02:01:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 02:01:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 02:01:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 02:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 02:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 02:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 02:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 02:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 02:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 02:01:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 02:01:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 02:01:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 02:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 02:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 02:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 02:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 02:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 02:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-09 02:01:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:01:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 02:02:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:02:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 02:02:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:02:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:02:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 02:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 02:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 02:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-09 02:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 02:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 02:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 02:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 02:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:02:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 02:02:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 02:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:03:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:03:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:03:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a04828>
+2021-09-09 02:03:31 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a04828>
+2021-09-09 02:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:03:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:03:31 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:04:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:04:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:04:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:04:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:04:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:05:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a6f8d0>
+2021-09-09 02:05:01 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a6f8d0>
+2021-09-09 02:05:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:05:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:05:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:05:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:05:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 02:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:05:03 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 02:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/6ff07abd-991c-4e67-af0f-a3b49cb4b66b.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 02:05:03 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:05:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:07:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:07:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:07:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:08:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 02:08:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 02:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:09:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:09:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:09:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044722780>
+2021-09-09 02:09:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044722780>
+2021-09-09 02:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:09:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:09:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:09:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 02:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/c7a28fd8-9cc6-4900-99ae-a817cefea984.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 02:09:20 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:09:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:10:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 02:10:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 02:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:11:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:11:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:11:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044713320>
+2021-09-09 02:11:22 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044713320>
+2021-09-09 02:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:11:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:11:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:11:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:12:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 02:12:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 02:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:12:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:12:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:12:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04472b0f0>
+2021-09-09 02:12:55 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa04472b0f0>
+2021-09-09 02:12:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:12:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:12:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:12:55 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:12:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:13:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:13:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:14:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:14:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:14:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447b6438>
+2021-09-09 02:14:24 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0447b6438>
+2021-09-09 02:14:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:14:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:14:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:14:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:14:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 02:14:26 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:15:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:15:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:15:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:15:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:15:13 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-09 02:15:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/82ff5221-cb8e-4a6f-a50c-46f19c2b43f4.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-09 02:15:14 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:15:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:15:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:15:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:16:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:16:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:17:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:17:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:17:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:17:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a6f748>
+2021-09-09 02:17:14 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a6f748>
+2021-09-09 02:17:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:17:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:17:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:17:15 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:17:15 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 02:17:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/18afad0f-868c-4bf7-bc86-1f6f001abba7.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 02:17:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-09 02:17:15 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:17:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:18:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:18:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:18:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:18:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:18:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:18:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=None
+2021-09-09 02:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:19:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:19:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:19:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a34fd0>
+2021-09-09 02:19:33 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa045a34fd0>
+2021-09-09 02:19:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:19:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:19:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:19:34 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:19:34 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 02:19:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/15bfbf81-552e-488e-954d-3fb99de762ab.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 02:19:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 02:19:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 02:19:34 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:20:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:20:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:20:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:20:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:20:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:20:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:20:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 02:20:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 02:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:21:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:21:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:21:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0458bd160>
+2021-09-09 02:21:48 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa0458bd160>
+2021-09-09 02:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:21:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 02:21:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:21:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:21:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:21:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:21:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-09 02:22:31 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+
+
+=================================== FAILURES ===================================
+___________________________ test_boot_event_enabled ____________________________
+
+client = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7fa045a6b390>
+
+    @pytest.mark.not_xenial
+    @pytest.mark.user_data(USER_DATA)
+    def test_boot_event_enabled(client: IntegrationInstance):
+>       _test_network_config_applied_on_reboot(client)
+
+tests/integration_tests/modules/test_user_events.py:106: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/modules/test_user_events.py:83: in _test_network_config_applied_on_reboot
+    log = client.read_from_file('/var/log/cloud-init.log')
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7fa045a6b390>
+remote_path = '/var/log/cloud-init.log'
+
+    def read_from_file(self, remote_path) -> str:
+        result = self.execute('cat {}'.format(remote_path))
+        if result.failed:
+            # TODO: Raise here whatever pycloudlib raises when it has
+            # a consistent error response
+            raise IOError(
+                'Failed reading remote file via cat: {}\n'
+                'Return code: {}\n'
+                'Stderr: {}\n'
+                'Stdout: {}'.format(
+                    remote_path, result.return_code,
+>                   result.stderr, result.stdout)
+            )
+E           OSError: Failed reading remote file via cat: /var/log/cloud-init.log
+E           Return code: 1
+E           Stderr: cat: /var/log/cloud-init.log: No such file or directory
+E           Stdout:
+
+tests/integration_tests/instances.py:97: OSError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 02:08:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 02:08:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-193056-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-193056-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 02:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:09:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 02:09:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:09:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:09:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa044722780>
+2021-09-09 02:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 02:09:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 02:09:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+------------------------------ Captured log call -------------------------------
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 02:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:09:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 02:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/c7a28fd8-9cc6-4900-99ae-a817cefea984.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-09 02:09:20 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:09:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 40 warnings
+tests/integration_tests/test_upgrade.py: 22 warnings
+tests/integration_tests/bugs/test_gh671.py: 41 warnings
+tests/integration_tests/bugs/test_gh868.py: 9 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 9 warnings
+tests/integration_tests/bugs/test_lp1835584.py: 11 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 9 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 9 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 11 warnings
+tests/integration_tests/bugs/test_lp1901011.py: 17 warnings
+tests/integration_tests/bugs/test_lp1910835.py: 9 warnings
+tests/integration_tests/modules/test_apt.py: 36 warnings
+tests/integration_tests/modules/test_ca_certs.py: 9 warnings
+tests/integration_tests/modules/test_cli.py: 18 warnings
+tests/integration_tests/modules/test_combined.py: 9 warnings
+tests/integration_tests/modules/test_command_output.py: 9 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 9 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 27 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 9 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 36 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 9 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 9 warnings
+tests/integration_tests/modules/test_set_hostname.py: 36 warnings
+tests/integration_tests/modules/test_set_password.py: 18 warnings
+tests/integration_tests/modules/test_snap.py: 9 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 18 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 9 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 36 warnings
+tests/integration_tests/modules/test_timezone.py: 9 warnings
+tests/integration_tests/modules/test_user_events.py: 22 warnings
+tests/integration_tests/modules/test_users_groups.py: 18 warnings
+tests/integration_tests/modules/test_version_change.py: 35 warnings
+tests/integration_tests/modules/test_write_files.py: 11 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled
+===== 1 failed, 124 passed, 24 skipped, 607 warnings in 6696.30s (1:51:36) =====

--- a/21.3-1/integration_tests/azure_bionic_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/azure_bionic_integration_tests_rerun.txt
@@ -1,0 +1,139 @@
+=================================================================================================================================== test session starts ====================================================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 1 item
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------------
+2021-09-09 13:23:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 13:23:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 13:23:09 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for azure
+2021-09-09 13:23:09 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+2021-09-09 13:23:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:UbuntuServer:18.04-DAILY-LTS
+user_data=None
+2021-09-09 13:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 13:25:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 13:25:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 13:25:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa6b66347b8>
+2021-09-09 13:25:16 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa6b66347b8>
+2021-09-09 13:25:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 13:25:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 13:25:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 13:25:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 13:25:17 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 13:25:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 13:25:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 13:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 13:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 13:25:42 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 13:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 13:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 13:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 13:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 13:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+2021-09-09 13:26:45 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+Done with environment setup
+2021-09-09 13:27:26 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 13:27:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 13:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 13:28:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 13:28:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 13:28:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa6b5ccecf8>
+2021-09-09 13:28:15 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fa6b5ccecf8>
+2021-09-09 13:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 13:28:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 13:28:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 13:28:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b0502b37-20e4-44e4-825e-f456dc8d55db.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 13:28:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 13:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 13:29:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 13:29:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 13:29:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 13:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 13:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+
+------------------------------------------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------------------------------------------
+2021-09-09 13:29:46 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-082309-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-082309-image
+------------------------------------------------------------------------------------------------------------------------------------ live log logreport ------------------------------------------------------------------------------------------------------------------------------------
+2021-09-09 13:29:47 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+
+===================================================================================================================================== warnings summary =====================================================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_user_events.py: 45 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+======================================================================================================================== 1 passed, 46 warnings in 398.51s (0:06:38) ========================================================================================================================

--- a/21.3-1/integration_tests/azure_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/azure_focal_integration_tests.txt
@@ -1,0 +1,4055 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:22:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 02:22:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 02:22:35 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for azure
+2021-09-09 02:22:35 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+user_data=None
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+2021-09-09 02:22:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+2021-09-09 02:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:24:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:24:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:24:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa47e6d8>
+2021-09-09 02:24:12 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa47e6d8>
+2021-09-09 02:24:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:24:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:24:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:24:13 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 02:24:13 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 02:24:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 02:24:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 02:24:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 02:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:24:34 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 02:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 02:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 02:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 02:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:25:38 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+Done with environment setup
+2021-09-09 02:26:19 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:26:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:27:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:27:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:27:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:27:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa48e198>
+2021-09-09 02:27:09 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa48e198>
+2021-09-09 02:27:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:27:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:27:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:27:10 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:27:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-09 02:27:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:27:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:27:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+2021-09-09 02:27:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+2021-09-09 02:28:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:28:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:28:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:28:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9b32f60>
+2021-09-09 02:28:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9b32f60>
+2021-09-09 02:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:28:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:28:41 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 02:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 02:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 02:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 02:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 02:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 02:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 02:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-09 02:28:43 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 02:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 02:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 02:28:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 02:29:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:29:04 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:29:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 02:29:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 02:29:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-09 02:29:05 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:29:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:29:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:29:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 02:29:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 02:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 02:29:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 02:30:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 02:30:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 1.988s (kernel) + 24.346s (userspace) = 26.335s 
+graphical.target reached after 23.742s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.049s (kernel) + 15.383s (userspace) = 17.433s 
+graphical.target reached after 14.770s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.827s cloud-init.service                                   
+6.601s snapd.seeded.service                                 
+2.420s snapd.apparmor.service                               
+2.234s snapd.service                                        
+1.885s cloud-init-local.service                             
+1.507s systemd-networkd-wait-online.service                 
+1.474s snap.lxd.activate.service                            
+1.466s cloud-config.service                                 
+1.417s pollinate.service                                    
+1.269s lvm2-monitor.service                                 
+=== `systemd-analyze blame` after (first 10 lines):
+4.645s snap.lxd.activate.service                                  
+4.528s snapd.service                                              
+2.087s cloud-init.service                                         
+1.868s systemd-networkd-wait-online.service                       
+1.697s lvm2-monitor.service                                       
+1.571s dev-sda1.device                                            
+1.481s cloud-init-local.service                                   
+1.355s networkd-dispatcher.service                                
+1.337s cloud-config.service                                       
+1.293s systemd-udev-settle.service                                
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00600 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00900 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01200 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.28500 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.28600 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.50200 seconds
+Finished stage: (azure-ds/_get_data) 00.53200 seconds
+Finished stage: (init-local/search-Azure) 00.54100 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.96300 seconds
+Total Time: 3.13700 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00800 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01500 seconds
+Finished stage: (azure-ds/_post_health_report) 01.43400 seconds
+Finished stage: (azure-ds/send_ready_signal) 01.43400 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 01.44500 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 01.44500 seconds
+Finished stage: (azure-ds/_negotiate) 01.44900 seconds
+Finished stage: (azure-ds/setup) 01.45000 seconds
+Finished stage: (init-network/setup-datasource) 01.45000 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.06100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.22200 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.22200 seconds
+Total Time: 10.66000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.00900 seconds
+Finished stage: (azure-ds/activate) 00.23200 seconds
+Finished stage: (init-network/activate-datasource) 00.23300 seconds
+Finished stage: (init-network/config-users-groups) 00.18500 seconds
+Finished stage: (init-network/config-ssh) 00.28800 seconds
+Finished stage: (init-network) 06.39100 seconds
+Finished stage: (modules-config) 01.04600 seconds
+Finished stage: (modules-final) 00.16300 seconds
+Total Time: 8.54700 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00600 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.13700 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.13800 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.48600 seconds
+Finished stage: (azure-ds/_get_data) 00.50900 seconds
+Finished stage: (init-local/search-Azure) 00.51300 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.76300 seconds
+Total Time: 2.55900 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00900 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01000 seconds
+Finished stage: (azure-ds/_post_health_report) 00.01700 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.01700 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.02800 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.02800 seconds
+Finished stage: (azure-ds/_negotiate) 00.03300 seconds
+Finished stage: (azure-ds/setup) 00.03300 seconds
+Finished stage: (init-network/setup-datasource) 00.03300 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.15500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.15500 seconds
+Total Time: 0.54400 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01000 seconds
+Finished stage: (azure-ds/activate) 00.16600 seconds
+Finished stage: (init-network/activate-datasource) 00.16800 seconds
+Finished stage: (init-network/config-users-groups) 00.04800 seconds
+Finished stage: (init-network/config-ssh) 00.33100 seconds
+Finished stage: (init-network) 01.62400 seconds
+Finished stage: (modules-config) 00.40300 seconds
+Finished stage: (modules-final) 00.16700 seconds
+Finished stage: (init-network/setup-datasource) 00.00000 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.08900 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.08900 seconds
+Total Time: 3.09500 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.10200 seconds
+Finished stage: (init-network/activate-datasource) 00.10300 seconds
+Finished stage: (init-network) 00.30400 seconds
+Total Time: 0.52100 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.17700s (azure-ds/obtain-dhcp-lease)
+     00.08200s (azure-ds/_get_metadata_from_imds)
+     00.06500s (azure-ds/list_possible_azure_ds_devs)
+     00.02500s (azure-ds/get_boot_telemetry)
+     00.01800s (init-network/check-cache)
+     00.00500s (init-local/check-cache)
+     00.00500s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.10700s (azure-ds/obtain-dhcp-lease)
+     00.01900s (init-network/check-cache)
+     00.01900s (azure-ds/get_boot_telemetry)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/check-platform-viability)
+     00.00100s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00000s (init-local/check-cache)
+
+2021-09-09 02:30:00 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 1.988s (kernel) + 24.346s (userspace) = 26.335s 
+graphical.target reached after 23.742s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.049s (kernel) + 15.383s (userspace) = 17.433s 
+graphical.target reached after 14.770s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.827s cloud-init.service                                   
+6.601s snapd.seeded.service                                 
+2.420s snapd.apparmor.service                               
+2.234s snapd.service                                        
+1.885s cloud-init-local.service                             
+1.507s systemd-networkd-wait-online.service                 
+1.474s snap.lxd.activate.service                            
+1.466s cloud-config.service                                 
+1.417s pollinate.service                                    
+1.269s lvm2-monitor.service                                 
+=== `systemd-analyze blame` after (first 10 lines):
+4.645s snap.lxd.activate.service                                  
+4.528s snapd.service                                              
+2.087s cloud-init.service                                         
+1.868s systemd-networkd-wait-online.service                       
+1.697s lvm2-monitor.service                                       
+1.571s dev-sda1.device                                            
+1.481s cloud-init-local.service                                   
+1.355s networkd-dispatcher.service                                
+1.337s cloud-config.service                                       
+1.293s systemd-udev-settle.service                                
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00600 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00900 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01200 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.28500 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.28600 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.50200 seconds
+Finished stage: (azure-ds/_get_data) 00.53200 seconds
+Finished stage: (init-local/search-Azure) 00.54100 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.96300 seconds
+Total Time: 3.13700 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00800 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01500 seconds
+Finished stage: (azure-ds/_post_health_report) 01.43400 seconds
+Finished stage: (azure-ds/send_ready_signal) 01.43400 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 01.44500 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 01.44500 seconds
+Finished stage: (azure-ds/_negotiate) 01.44900 seconds
+Finished stage: (azure-ds/setup) 01.45000 seconds
+Finished stage: (init-network/setup-datasource) 01.45000 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.06100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.22200 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.22200 seconds
+Total Time: 10.66000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.00900 seconds
+Finished stage: (azure-ds/activate) 00.23200 seconds
+Finished stage: (init-network/activate-datasource) 00.23300 seconds
+Finished stage: (init-network/config-users-groups) 00.18500 seconds
+Finished stage: (init-network/config-ssh) 00.28800 seconds
+Finished stage: (init-network) 06.39100 seconds
+Finished stage: (modules-config) 01.04600 seconds
+Finished stage: (modules-final) 00.16300 seconds
+Total Time: 8.54700 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00100 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00600 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.13700 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.13800 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.48600 seconds
+Finished stage: (azure-ds/_get_data) 00.50900 seconds
+Finished stage: (init-local/search-Azure) 00.51300 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 00.76300 seconds
+Total Time: 2.55900 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.00900 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01000 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.01100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01000 seconds
+Finished stage: (azure-ds/_post_health_report) 00.01700 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.01700 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.02800 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.02800 seconds
+Finished stage: (azure-ds/_negotiate) 00.03300 seconds
+Finished stage: (azure-ds/setup) 00.03300 seconds
+Finished stage: (init-network/setup-datasource) 00.03300 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.15500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.15500 seconds
+Total Time: 0.54400 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01000 seconds
+Finished stage: (azure-ds/activate) 00.16600 seconds
+Finished stage: (init-network/activate-datasource) 00.16800 seconds
+Finished stage: (init-network/config-users-groups) 00.04800 seconds
+Finished stage: (init-network/config-ssh) 00.33100 seconds
+Finished stage: (init-network) 01.62400 seconds
+Finished stage: (modules-config) 00.40300 seconds
+Finished stage: (modules-final) 00.16700 seconds
+Finished stage: (init-network/setup-datasource) 00.00000 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.08900 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.08900 seconds
+Total Time: 3.09500 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.10200 seconds
+Finished stage: (init-network/activate-datasource) 00.10300 seconds
+Finished stage: (init-network) 00.30400 seconds
+Total Time: 0.52100 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.17700s (azure-ds/obtain-dhcp-lease)
+     00.08200s (azure-ds/_get_metadata_from_imds)
+     00.06500s (azure-ds/list_possible_azure_ds_devs)
+     00.02500s (azure-ds/get_boot_telemetry)
+     00.01800s (init-network/check-cache)
+     00.00500s (init-local/check-cache)
+     00.00500s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.10700s (azure-ds/obtain-dhcp-lease)
+     00.01900s (init-network/check-cache)
+     00.01900s (azure-ds/get_boot_telemetry)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/check-platform-viability)
+     00.00100s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00000s (init-local/check-cache)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:30:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:30:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+2021-09-09 02:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:31:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:31:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:32:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4f4e10>
+2021-09-09 02:32:01 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4f4e10>
+2021-09-09 02:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:32:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 02:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:32:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 02:32:01 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 02:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 02:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 02:32:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 02:32:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:32:22 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-09 02:32:22 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:32:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:33:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:33:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:33:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:33:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:33:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+vm_params={'os_profile': {'admin_password': 'DoIM33tTheComplexityRequirements!??', 'linux_configuration': {'disable_password_authentication': False}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:33:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+vm_params={'os_profile': {'admin_password': 'DoIM33tTheComplexityRequirements!??', 'linux_configuration': {'disable_password_authentication': False}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:34:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:34:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:34:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f930c358>
+2021-09-09 02:34:42 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f930c358>
+2021-09-09 02:34:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:34:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:34:43 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+2021-09-09 02:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 02:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 02:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision -force'
+Launching instance with launch_kwargs:
+user_data=None
+vm_params={'os_profile': {'admin_password': 'DoIM33tTheComplexityRequirementsNow!??', 'linux_configuration': {'disable_password_authentication': False}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-213352-image
+2021-09-09 02:35:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+vm_params={'os_profile': {'admin_password': 'DoIM33tTheComplexityRequirementsNow!??', 'linux_configuration': {'disable_password_authentication': False}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-213352-image
+2021-09-09 02:37:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:37:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:37:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:37:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d2e8>
+2021-09-09 02:37:23 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d2e8>
+2021-09-09 02:37:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:37:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:37:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:37:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:37:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+PASSED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:38:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:38:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:39:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:39:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:39:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:39:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4898d0>
+2021-09-09 02:39:48 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4898d0>
+2021-09-09 02:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:39:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:39:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:40:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:40:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:41:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:41:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:41:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:41:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d400>
+2021-09-09 02:41:22 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d400>
+2021-09-09 02:41:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:41:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:41:23 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:42:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:42:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:42:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:42:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:42:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92b5208>
+2021-09-09 02:42:54 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92b5208>
+2021-09-09 02:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:42:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:42:54 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:43:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:44:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:44:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:44:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:44:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92b0080>
+2021-09-09 02:44:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92b0080>
+2021-09-09 02:44:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:44:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:44:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:44:26 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-09 02:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:45:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:45:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:45:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:45:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:45:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:45:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa48eac8>
+2021-09-09 02:45:57 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa48eac8>
+2021-09-09 02:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:45:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:45:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-09 02:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-09 02:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 02:45:58 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 02:46:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:46:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:46:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:46:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 02:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-09 02:46:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:47:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+instance_type=Standard_DS1_v2
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:47:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+instance_type=Standard_DS1_v2
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:48:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:48:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:48:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:48:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92cfdd8>
+2021-09-09 02:48:17 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92cfdd8>
+2021-09-09 02:48:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:48:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:48:18 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+2021-09-09 02:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_resource-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:48:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+instance_type=Standard_D2s_v4
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:48:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+instance_type=Standard_D2s_v4
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:49:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:49:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:49:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:49:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d358>
+2021-09-09 02:49:49 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f931d358>
+2021-09-09 02:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:49:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:49:50 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 02:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 02:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 02:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:50:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', 'path': '/home/ubuntu/.ssh/authorized_keys'}]}}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:50:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', 'path': '/home/ubuntu/.ssh/authorized_keys'}]}}}}
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:51:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:51:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:51:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:51:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9283eb8>
+2021-09-09 02:51:20 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9283eb8>
+2021-09-09 02:51:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:51:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:51:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:51:21 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 02:51:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:52:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:52:48 INFO      adal-python:log.py:114 29920820-322f-4f40-9048-59565e79948f - CacheDriver:Cached token is expired at 2021-09-08 21:57:17.101396.  Refreshing
+2021-09-09 02:52:48 INFO      adal-python:log.py:114 29920820-322f-4f40-9048-59565e79948f - TokenRequest:Getting a new token from a refresh token
+2021-09-09 02:52:48 INFO      adal-python:log.py:114 29920820-322f-4f40-9048-59565e79948f - CacheDriver:Returning token refreshed after expiry.
+2021-09-09 02:52:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:52:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:52:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:52:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92831d0>
+2021-09-09 02:52:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92831d0>
+2021-09-09 02:52:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:52:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:52:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-09 02:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:52:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:52:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:53:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:53:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:54:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:54:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:54:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92cfb70>
+2021-09-09 02:54:23 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f92cfb70>
+2021-09-09 02:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:54:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:54:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:55:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:55:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:55:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:55:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:55:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9babb70>
+2021-09-09 02:55:55 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9babb70>
+2021-09-09 02:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:55:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:55:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:56:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:56:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:57:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:57:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:57:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:57:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4a72b0>
+2021-09-09 02:57:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4a72b0>
+2021-09-09 02:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:57:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:57:25 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:57:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:58:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:58:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:58:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 02:58:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 02:58:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 02:58:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f930c6a0>
+2021-09-09 02:58:56 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f930c6a0>
+2021-09-09 02:58:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:58:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 02:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 02:58:57 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-09 02:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-09 02:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-09 02:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:58:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 02:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 02:59:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 02:59:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:00:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:00:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:00:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9230668>
+2021-09-09 03:00:27 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9230668>
+2021-09-09 03:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:00:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:00:28 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:01:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:01:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:01:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:01:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:02:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9230dd8>
+2021-09-09 03:02:03 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9230dd8>
+2021-09-09 03:02:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:02:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:02:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:02:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:02:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:02:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:02:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:03:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:03:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:03:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:03:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f923bb00>
+2021-09-09 03:03:35 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f923bb00>
+2021-09-09 03:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:03:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:03:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-09 03:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 03:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:04:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:04:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:05:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:05:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:05:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:05:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9251fd0>
+2021-09-09 03:05:08 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9251fd0>
+2021-09-09 03:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:05:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:05:09 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:05:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:05:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:06:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:06:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:06:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91f1780>
+2021-09-09 03:06:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91f1780>
+2021-09-09 03:06:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:06:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:06:41 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 03:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:07:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:07:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:08:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:08:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:08:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fdc50>
+2021-09-09 03:08:12 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fdc50>
+2021-09-09 03:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:08:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:08:13 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:08:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:08:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:08:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:08:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:08:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:09:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:09:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:09:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:09:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9233ba8>
+2021-09-09 03:09:44 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9233ba8>
+2021-09-09 03:09:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:09:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:09:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:09:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:09:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:10:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:10:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:11:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:11:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:11:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f924d0b8>
+2021-09-09 03:11:16 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f924d0b8>
+2021-09-09 03:11:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:11:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:11:17 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:11:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:11:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:11:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:11:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:11:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:12:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:12:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:12:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:12:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:12:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9211fd0>
+2021-09-09 03:12:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9211fd0>
+2021-09-09 03:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:12:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:12:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:12:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:12:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-09 03:12:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:13:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:13:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:14:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:14:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:14:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:14:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91b5f98>
+2021-09-09 03:14:44 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91b5f98>
+2021-09-09 03:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:14:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:14:44 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:14:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:14:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:14:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:15:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:15:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:16:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:16:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:16:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:16:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91caa20>
+2021-09-09 03:16:14 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91caa20>
+2021-09-09 03:16:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:16:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:16:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-09 03:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:16:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:16:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:17:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:17:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:17:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:17:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91b5080>
+2021-09-09 03:17:47 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91b5080>
+2021-09-09 03:17:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:17:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:17:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:17:48 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:17:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:18:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:18:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:19:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:19:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:19:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:19:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f928d710>
+2021-09-09 03:19:37 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f928d710>
+2021-09-09 03:19:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:19:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:19:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:19:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:19:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-09 03:19:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-09 03:19:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:20:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:20:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:21:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:21:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:21:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9319eb8>
+2021-09-09 03:22:00 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9319eb8>
+2021-09-09 03:22:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:22:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:22:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:22:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:22:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:22:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:22:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:23:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:23:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:23:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:23:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f928d128>
+2021-09-09 03:23:32 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f928d128>
+2021-09-09 03:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:23:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:23:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:24:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:24:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:25:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:25:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:25:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fab70>
+2021-09-09 03:25:07 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fab70>
+2021-09-09 03:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:25:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:25:08 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:25:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:26:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:26:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:26:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:26:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f924de10>
+2021-09-09 03:26:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f924de10>
+2021-09-09 03:26:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:26:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:26:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:26:40 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:26:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:27:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:27:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:28:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:28:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:28:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:28:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9233828>
+2021-09-09 03:28:10 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9233828>
+2021-09-09 03:28:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:28:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:28:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:28:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:28:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:28:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:28:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:29:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:29:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:29:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:29:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:29:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9253f28>
+2021-09-09 03:29:49 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9253f28>
+2021-09-09 03:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:29:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:29:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 03:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-09 03:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:30:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:30:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:31:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:31:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:31:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:31:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91735c0>
+2021-09-09 03:31:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91735c0>
+2021-09-09 03:31:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:31:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:31:20 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:31:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:32:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:32:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:32:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:32:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:32:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f923bac8>
+2021-09-09 03:32:50 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f923bac8>
+2021-09-09 03:32:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:32:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:32:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:33:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:33:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:34:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:34:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:34:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9192dd8>
+2021-09-09 03:34:52 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9192dd8>
+2021-09-09 03:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:34:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:34:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:35:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:36:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:36:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:36:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91207f0>
+2021-09-09 03:36:22 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91207f0>
+2021-09-09 03:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:36:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:36:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:38:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:38:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:39:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:39:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:39:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9169b00>
+2021-09-09 03:39:02 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9169b00>
+2021-09-09 03:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:39:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:39:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:39:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:39:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:40:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:40:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:40:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa960da0>
+2021-09-09 03:40:32 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa960da0>
+2021-09-09 03:40:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:40:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:41:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:41:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:42:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:42:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:42:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:42:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91c1128>
+2021-09-09 03:42:03 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91c1128>
+2021-09-09 03:42:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:42:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:42:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:42:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:42:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:42:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:42:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:43:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:43:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:43:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:43:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9157048>
+2021-09-09 03:43:34 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9157048>
+2021-09-09 03:43:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:43:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:43:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:43:34 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:43:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:44:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:44:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:45:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:45:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f915c128>
+2021-09-09 03:45:05 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f915c128>
+2021-09-09 03:45:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:45:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:45:06 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-09 03:45:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 03:45:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 03:45:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 03:45:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 03:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 03:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-09 03:45:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 03:45:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 03:45:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 03:45:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 03:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 03:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 03:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 03:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 03:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:45:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 03:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 03:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 03:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:46:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:46:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:47:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:47:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91347b8>
+2021-09-09 03:47:13 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91347b8>
+2021-09-09 03:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:47:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:47:14 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 03:47:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 03:47:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 03:47:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 03:47:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 03:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 03:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 03:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 03:47:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 03:47:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 03:47:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 03:47:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 03:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 03:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 03:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 03:47:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 03:47:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 03:47:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 03:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 03:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:47:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 03:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 03:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-09 03:48:02 INFO      adal-python:log.py:114 d3a2f92b-2625-4967-b65a-18ca70068b5b - CacheDriver:Cached token is expired at 2021-09-08 22:52:47.656624.  Refreshing
+2021-09-09 03:48:02 INFO      adal-python:log.py:114 d3a2f92b-2625-4967-b65a-18ca70068b5b - TokenRequest:Getting a new token from a refresh token
+2021-09-09 03:48:02 INFO      adal-python:log.py:114 d3a2f92b-2625-4967-b65a-18ca70068b5b - CacheDriver:Returning token refreshed after expiry.
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:48:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:48:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:48:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:48:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:48:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fa5f8>
+2021-09-09 03:48:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f91fa5f8>
+2021-09-09 03:48:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:48:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:48:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:48:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:48:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 03:48:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 03:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 03:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 03:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 03:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 03:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 03:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 03:48:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 03:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 03:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 03:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 03:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-09 03:48:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 03:48:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 03:48:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:48:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 03:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 03:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 03:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-09 03:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 03:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 03:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 03:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:49:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:49:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:50:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:50:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4f47f0>
+2021-09-09 03:50:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa4f47f0>
+2021-09-09 03:50:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:50:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:50:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:50:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:50:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 03:50:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 03:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 03:50:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 03:50:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 03:50:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 03:50:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 03:50:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 03:50:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:50:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 03:50:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 03:50:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-09 03:50:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 03:50:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 03:50:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:50:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:50:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 03:50:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 03:50:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 03:50:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-09 03:50:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 03:50:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 03:50:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 03:50:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 03:50:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:51:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:51:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:52:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:52:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:52:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3ce978>
+2021-09-09 03:52:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3ce978>
+2021-09-09 03:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:52:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:52:06 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:52:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:52:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:53:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:53:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3cea90>
+2021-09-09 03:53:36 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3cea90>
+2021-09-09 03:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:53:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:53:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:53:37 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/04ca8576-c855-42e2-9f4c-18fd70aa2eed.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 03:53:38 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 03:54:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:54:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 03:54:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:54:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:54:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:55:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:55:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:55:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa474400>
+2021-09-09 03:55:38 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa474400>
+2021-09-09 03:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:55:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:55:39 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:55:39 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/91088b27-2218-4117-90ad-bd96d19e93b8.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 03:55:40 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 03:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:56:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:56:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:56:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 03:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:57:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:57:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:57:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:57:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:57:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa44c7b8>
+2021-09-09 03:57:57 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa44c7b8>
+2021-09-09 03:57:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:57:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 03:58:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:58:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:59:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:59:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:59:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:59:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa29bf98>
+2021-09-09 03:59:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa29bf98>
+2021-09-09 03:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:59:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:59:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 03:59:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 03:59:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:00:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:00:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:00:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:00:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:00:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:00:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa2ae550>
+2021-09-09 04:00:58 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa2ae550>
+2021-09-09 04:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:00:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 04:00:59 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 04:00:59 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:01:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 04:01:31 INFO      paramiko.transport.sftp:sftp.py:158 [chan 8] Opened sftp connection (server version 3)
+2021-09-09 04:01:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/d7f48a41-c7d6-49bc-b0ee-e6a574e3df74.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-09 04:01:31 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:02:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:02:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:02:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:02:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:02:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:02:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:03:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:03:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:03:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa296080>
+2021-09-09 04:03:35 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa296080>
+2021-09-09 04:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:03:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 04:03:35 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:03:35 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 04:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/8657ba91-da9d-42f9-9c4d-b9d7d3bf2f3a.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 04:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-09 04:03:36 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:04:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:04:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:05:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:05:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:05:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:05:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:05:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:05:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9157da0>
+2021-09-09 04:05:54 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9f9157da0>
+2021-09-09 04:05:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:05:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 04:05:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:05:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 04:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/f1dca83d-2c89-4083-af20-b65faece4ae7.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 04:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 04:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 04:05:55 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:06:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:06:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:06:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:06:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:06:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:07:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:07:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 04:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:08:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 04:08:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:08:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3f1940>
+2021-09-09 04:08:15 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3f1940>
+2021-09-09 04:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:08:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 04:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 04:08:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:08:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:08:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:08:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:08:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:08:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:08:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-09 04:08:57 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+
+
+=================================== FAILURES ===================================
+_____________________ test_boot_event_disabled_by_default ______________________
+
+client = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7fc9fa3c34a8>
+
+    @pytest.mark.lxd_container
+    @pytest.mark.lxd_vm
+    @pytest.mark.ec2
+    @pytest.mark.gce
+    @pytest.mark.oci
+    @pytest.mark.openstack
+    @pytest.mark.azure
+    @pytest.mark.not_xenial
+    def test_boot_event_disabled_by_default(client: IntegrationInstance):
+        log = client.read_from_file('/var/log/cloud-init.log')
+        if 'network config is disabled' in log:
+            pytest.skip("network config disabled. Test doesn't apply")
+        assert 'Applying network configuration' in log
+        assert 'dummy0' not in client.execute('ls /sys/class/net')
+    
+        _add_dummy_bridge_to_netplan(client)
+        client.execute('rm /var/log/cloud-init.log')
+    
+        client.restart()
+>       log2 = client.read_from_file('/var/log/cloud-init.log')
+
+tests/integration_tests/modules/test_user_events.py:47: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7fc9fa3c34a8>
+remote_path = '/var/log/cloud-init.log'
+
+    def read_from_file(self, remote_path) -> str:
+        result = self.execute('cat {}'.format(remote_path))
+        if result.failed:
+            # TODO: Raise here whatever pycloudlib raises when it has
+            # a consistent error response
+            raise IOError(
+                'Failed reading remote file via cat: {}\n'
+                'Return code: {}\n'
+                'Stderr: {}\n'
+                'Stdout: {}'.format(
+                    remote_path, result.return_code,
+>                   result.stderr, result.stdout)
+            )
+E           OSError: Failed reading remote file via cat: /var/log/cloud-init.log
+E           Return code: 1
+E           Stderr: cat: /var/log/cloud-init.log: No such file or directory
+E           Stdout:
+
+tests/integration_tests/instances.py:97: OSError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 03:52:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 03:52:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-212234-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-212235-image
+2021-09-09 03:53:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 03:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 03:53:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 03:53:36 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fc9fa3cea90>
+2021-09-09 03:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 03:53:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 03:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 03:53:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+------------------------------ Captured log call -------------------------------
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:53:37 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/04ca8576-c855-42e2-9f4c-18fd70aa2eed.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 03:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-09 03:53:38 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 03:54:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 03:54:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 03:54:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 40 warnings
+tests/integration_tests/test_upgrade.py: 23 warnings
+tests/integration_tests/bugs/test_gh671.py: 41 warnings
+tests/integration_tests/bugs/test_gh868.py: 9 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 9 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 9 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 9 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 11 warnings
+tests/integration_tests/bugs/test_lp1901011.py: 18 warnings
+tests/integration_tests/bugs/test_lp1910835.py: 9 warnings
+tests/integration_tests/modules/test_apt.py: 36 warnings
+tests/integration_tests/modules/test_ca_certs.py: 9 warnings
+tests/integration_tests/modules/test_cli.py: 18 warnings
+tests/integration_tests/modules/test_combined.py: 9 warnings
+tests/integration_tests/modules/test_command_output.py: 9 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 9 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 27 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 9 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 36 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 9 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 9 warnings
+tests/integration_tests/modules/test_set_hostname.py: 36 warnings
+tests/integration_tests/modules/test_set_password.py: 18 warnings
+tests/integration_tests/modules/test_snap.py: 9 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 16 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 9 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 37 warnings
+tests/integration_tests/modules/test_timezone.py: 9 warnings
+tests/integration_tests/modules/test_user_events.py: 22 warnings
+tests/integration_tests/modules/test_users_groups.py: 18 warnings
+tests/integration_tests/modules/test_version_change.py: 35 warnings
+tests/integration_tests/modules/test_write_files.py: 11 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:313: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:320: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    return type(self)(**params)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default
+===== 1 failed, 123 passed, 25 skipped, 599 warnings in 6384.43s (1:46:24) =====

--- a/21.3-1/integration_tests/azure_focal_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/azure_focal_integration_tests_rerun.txt
@@ -1,0 +1,133 @@
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 1 item
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-09 14:03:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 14:03:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 14:03:42 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for azure
+2021-09-09 14:03:42 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+user_data=None
+2021-09-09 14:03:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
+user_data=None
+2021-09-09 14:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 14:05:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 14:05:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 14:05:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fe57540e160>
+2021-09-09 14:05:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fe57540e160>
+2021-09-09 14:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 14:05:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 14:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 14:05:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 14:05:19 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 14:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 14:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 14:05:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 14:05:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 14:05:43 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 14:05:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 14:05:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 14:05:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 14:05:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 14:05:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+2021-09-09 14:06:47 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+Done with environment setup
+2021-09-09 14:07:27 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+user_data=None
+2021-09-09 14:07:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+user_data=None
+2021-09-09 14:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 14:08:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 14:08:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 14:08:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fe5753f2128>
+2021-09-09 14:08:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fe5753f2128>
+2021-09-09 14:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 14:08:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 14:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 14:08:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-09 14:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 14:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 14:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 14:08:19 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 14:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/656eae6d-990c-4d9d-a505-03e75cc3bb45.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 14:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 14:08:19 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 14:08:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 14:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 14:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 14:09:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 14:09:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 14:09:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 14:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 14:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+
+------------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------------
+2021-09-09 14:09:54 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0909-090342-rg/providers/Microsoft.Compute/images/azure-integration-test-0909-090342-image
+------------------------------------------------------------------------------------------------ live log logreport -------------------------------------------------------------------------------------------------
+2021-09-09 14:09:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+
+================================================================================================= warnings summary ==================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_user_events.py: 44 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+==================================================================================== 1 passed, 45 warnings in 372.87s (0:06:12) =====================================================================================

--- a/21.3-1/integration_tests/azure_hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/azure_hirsute_integration_tests.txt
@@ -1,0 +1,7739 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:09:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 04:09:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 04:09:01 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for azure
+2021-09-09 04:09:01 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+2021-09-09 04:09:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+2021-09-09 04:17:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:17:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:17:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:17:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39969d19e8>
+2021-09-09 04:17:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39969d19e8>
+2021-09-09 04:17:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:17:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:17:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 04:17:41 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 04:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 04:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 04:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 04:18:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:18:01 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 04:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 04:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 04:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 04:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+2021-09-09 04:19:05 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+Done with environment setup
+2021-09-09 04:19:46 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 04:19:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 04:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:20:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:20:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:20:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:20:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399607bc88>
+2021-09-09 04:20:47 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399607bc88>
+2021-09-09 04:20:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:20:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:20:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:20:48 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:20:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-09 04:20:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 04:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:23:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:23:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:23:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:23:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8fd0>
+2021-09-09 04:23:16 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8fd0>
+2021-09-09 04:23:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:23:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:23:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 04:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 04:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-09 04:23:21 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 04:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 04:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:23:49 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-09 04:23:50 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:24:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:24:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:24:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 04:24:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:24:22 INFO      paramiko.transport:transport.py:1819 Auth banner: b'System is going down. Unprivileged users are not permitted to log in anymore. For technical details, see pam_nologin(8).\n\n'
+FAILED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:25:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:25:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+2021-09-09 04:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:26:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:27:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:27:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:27:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996a0ff60>
+2021-09-09 04:27:43 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996a0ff60>
+2021-09-09 04:27:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:27:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:27:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:27:44 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-09 04:27:44 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 04:27:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 04:27:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 04:27:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 04:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:28:16 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+Restarting instance and waiting for boot
+2021-09-09 04:28:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:29:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:29:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:29:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:29:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:30:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirements!??'}}
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:30:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirements!??'}}
+2021-09-09 04:31:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:32:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:32:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:32:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399608c438>
+2021-09-09 04:32:12 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399608c438>
+2021-09-09 04:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:32:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:32:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+2021-09-09 04:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 04:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 04:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision -force'
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-233034-image
+user_data=None
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirementsNow!??'}}
+2021-09-09 04:33:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-233034-image
+user_data=None
+vm_params={'os_profile': {'linux_configuration': {'disable_password_authentication': False}, 'admin_password': 'DoIM33tTheComplexityRequirementsNow!??'}}
+2021-09-09 04:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:34:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:36:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:36:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:36:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957a10b8>
+2021-09-09 04:36:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957a10b8>
+2021-09-09 04:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:36:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:36:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'getent shadow ubuntu'
+PASSED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:37:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 04:37:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 04:38:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:38:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:38:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:38:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995580a20>
+2021-09-09 04:38:31 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995580a20>
+2021-09-09 04:38:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:38:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:38:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:38:31 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:38:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:39:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 04:39:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 04:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:40:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:40:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:40:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:40:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8b70>
+2021-09-09 04:40:26 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8b70>
+2021-09-09 04:40:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:40:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:40:27 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:41:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:41:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:41:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 04:41:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 04:41:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:41:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:42:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:42:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:42:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e88d0>
+2021-09-09 04:42:27 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e88d0>
+2021-09-09 04:42:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:42:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:42:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:42:28 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:42:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-09 04:43:09 INFO      adal-python:log.py:114 550ac341-91fb-4d2e-a914-7e223ae52081 - CacheDriver:Cached token is expired at 2021-09-08 23:48:01.803489.  Refreshing
+2021-09-09 04:43:09 INFO      adal-python:log.py:114 550ac341-91fb-4d2e-a914-7e223ae52081 - TokenRequest:Getting a new token from a refresh token
+2021-09-09 04:43:09 INFO      adal-python:log.py:114 550ac341-91fb-4d2e-a914-7e223ae52081 - CacheDriver:Returning token refreshed after expiry.
+
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:43:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 04:43:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 04:43:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:43:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:43:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:44:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:45:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:45:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:45:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957c8b70>
+2021-09-09 04:45:43 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957c8b70>
+2021-09-09 04:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:45:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:45:43 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 04:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-09 04:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:46:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 04:46:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 04:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:47:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:47:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:47:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957cd518>
+2021-09-09 04:48:02 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957cd518>
+2021-09-09 04:48:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:48:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:48:03 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-09 04:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-09 04:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 04:48:04 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:48:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:48:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-09 04:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+instance_type=Standard_DS1_v2
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:49:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+instance_type=Standard_DS1_v2
+2021-09-09 04:50:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:50:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:50:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:50:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:50:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:50:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:50:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996a33e48>
+2021-09-09 04:50:15 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996a33e48>
+2021-09-09 04:50:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:50:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:50:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 04:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 04:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 04:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+2021-09-09 04:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_resource-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:50:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+instance_type=Standard_D2s_v4
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:50:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+instance_type=Standard_D2s_v4
+2021-09-09 04:52:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:52:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:52:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:52:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995580c88>
+2021-09-09 04:52:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995580c88>
+2021-09-09 04:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:52:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:52:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 04:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /dev/disk/cloud'
+2021-09-09 04:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk -pPo NAME,TYPE,MOUNTPOINT'
+2021-09-09 04:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'realpath /dev/disk/cloud/azure_root-part1'
+PASSED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:53:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'path': '/home/ubuntu/.ssh/authorized_keys', 'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n'}]}}}}
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:53:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt
+
+vm_params={'os_profile': {'linux_configuration': {'ssh': {'public_keys': [{'path': '/home/ubuntu/.ssh/authorized_keys', 'key_data': 'ssh-rsa AAAAB3NzaC1y\r\nc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n'}]}}}}
+2021-09-09 04:53:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:53:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:53:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:53:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39956476d8>
+2021-09-09 04:53:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39956476d8>
+2021-09-09 04:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:53:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:53:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:54:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 04:54:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 04:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:55:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:57:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:58:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:59:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:59:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:59:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:59:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957f1cf8>
+2021-09-09 04:59:20 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957f1cf8>
+2021-09-09 04:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:59:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 04:59:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-09 04:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 04:59:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 04:59:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:00:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 05:00:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 05:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:01:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:01:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:01:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:01:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:01:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:01:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995656710>
+2021-09-09 05:01:12 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995656710>
+2021-09-09 05:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:01:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:01:13 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:01:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 05:01:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 05:02:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:02:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:02:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:02:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955a7cc0>
+2021-09-09 05:03:04 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955a7cc0>
+2021-09-09 05:03:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:03:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:03:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:03:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:03:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:03:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 05:03:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 05:04:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:04:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:04:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:05:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957f1780>
+2021-09-09 05:05:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957f1780>
+2021-09-09 05:05:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:05:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:05:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:05:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:05:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 05:05:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 05:06:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:07:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:08:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:09:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:10:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:10:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:10:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39969c5b70>
+2021-09-09 05:10:22 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39969c5b70>
+2021-09-09 05:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:10:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:10:23 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-09 05:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-09 05:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-09 05:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:10:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:10:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:11:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 05:11:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 05:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:11:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:11:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:11:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:11:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399564dc50>
+2021-09-09 05:12:03 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399564dc50>
+2021-09-09 05:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:12:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:12:03 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:12:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 05:12:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 05:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:13:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:13:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:13:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955aeac8>
+2021-09-09 05:14:00 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955aeac8>
+2021-09-09 05:14:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:14:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:14:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:14:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:14:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 05:14:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 05:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:15:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:15:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:15:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955d7a58>
+2021-09-09 05:15:33 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955d7a58>
+2021-09-09 05:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:15:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:15:34 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 05:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:15:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:15:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:15:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:15:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:15:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 05:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:16:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 05:16:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 05:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:17:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:17:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:17:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955d7b00>
+2021-09-09 05:17:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955d7b00>
+2021-09-09 05:17:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:17:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:17:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:17:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 05:17:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 05:18:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:18:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:18:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:19:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996080b70>
+2021-09-09 05:19:05 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3996080b70>
+2021-09-09 05:19:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:19:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:19:06 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 05:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:19:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 05:19:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 05:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:20:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:21:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:21:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:22:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399564def0>
+2021-09-09 05:22:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399564def0>
+2021-09-09 05:22:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:22:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:22:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:22:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:22:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:22:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:22:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:22:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:22:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:22:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:22:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 05:22:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 05:23:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:23:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:23:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:23:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f0f0>
+2021-09-09 05:23:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f0f0>
+2021-09-09 05:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:23:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:23:40 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:23:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:23:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:24:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 05:24:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 05:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:25:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:25:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:25:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590c50>
+2021-09-09 05:25:23 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590c50>
+2021-09-09 05:25:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:25:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:25:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:25:23 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:26:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 05:26:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 05:26:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:26:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:26:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:26:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399559a780>
+2021-09-09 05:27:01 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399559a780>
+2021-09-09 05:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:27:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:27:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:27:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:27:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 05:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-09 05:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:27:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 05:27:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 05:28:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:28:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:28:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:28:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590ef0>
+2021-09-09 05:29:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590ef0>
+2021-09-09 05:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:29:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:29:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:29:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:29:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:29:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:30:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 05:30:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 05:30:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:30:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:30:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:30:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555d9e8>
+2021-09-09 05:30:59 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555d9e8>
+2021-09-09 05:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:31:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:31:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-09 05:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:31:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 05:31:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 05:32:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:32:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:32:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:32:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f358>
+2021-09-09 05:32:30 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f358>
+2021-09-09 05:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:32:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:32:31 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:33:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 05:33:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 05:33:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:34:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:34:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:34:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952cecf8>
+2021-09-09 05:34:45 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952cecf8>
+2021-09-09 05:34:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:34:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:34:46 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-09 05:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-09 05:34:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 05:35:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 05:36:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:36:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:36:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:36:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952a86a0>
+2021-09-09 05:37:07 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952a86a0>
+2021-09-09 05:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:37:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:37:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:37:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:37:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:37:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 05:37:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 05:38:35 INFO      adal-python:log.py:114 fada30f3-88de-450c-9353-c6472062f59c - CacheDriver:Cached token is expired at 2021-09-09 00:43:08.414840.  Refreshing
+2021-09-09 05:38:35 INFO      adal-python:log.py:114 fada30f3-88de-450c-9353-c6472062f59c - TokenRequest:Getting a new token from a refresh token
+2021-09-09 05:38:36 INFO      adal-python:log.py:114 fada30f3-88de-450c-9353-c6472062f59c - CacheDriver:Returning token refreshed after expiry.
+2021-09-09 05:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:41:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:42:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:42:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:42:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:42:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955e6f28>
+2021-09-09 05:42:38 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955e6f28>
+2021-09-09 05:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:42:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:42:39 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:43:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 05:43:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 05:44:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:44:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:45:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:45:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:45:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f3c8>
+2021-09-09 05:45:45 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f3c8>
+2021-09-09 05:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:45:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:45:45 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:46:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 05:46:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 05:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:47:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:47:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:47:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555d668>
+2021-09-09 05:47:21 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555d668>
+2021-09-09 05:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:47:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:47:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:48:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 05:48:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 05:48:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:49:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:49:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:49:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952c52b0>
+2021-09-09 05:49:47 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952c52b0>
+2021-09-09 05:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:49:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:49:48 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:50:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 05:50:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 05:51:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:52:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:53:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:53:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:53:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590518>
+2021-09-09 05:53:21 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995590518>
+2021-09-09 05:53:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:53:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:53:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:53:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 05:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-09 05:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 05:54:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 05:54:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:54:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:54:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:54:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952ce128>
+2021-09-09 05:54:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39952ce128>
+2021-09-09 05:54:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:54:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:54:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:54:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:55:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 05:55:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 05:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:56:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:56:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:56:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399558fc88>
+2021-09-09 05:56:52 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399558fc88>
+2021-09-09 05:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:56:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:56:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:56:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:57:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 05:57:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 05:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 05:58:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 05:58:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 05:58:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399552ceb8>
+2021-09-09 05:59:17 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399552ceb8>
+2021-09-09 05:59:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:59:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 05:59:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 05:59:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 05:59:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 05:59:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 05:59:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 06:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:01:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:01:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:01:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399552c9e8>
+2021-09-09 06:01:51 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399552c9e8>
+2021-09-09 06:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:01:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:01:51 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:02:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 06:02:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 06:03:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:03:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:03:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:03:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399554fb70>
+2021-09-09 06:03:24 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399554fb70>
+2021-09-09 06:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:03:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:03:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 06:04:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 06:04:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:04:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:04:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:04:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995534940>
+2021-09-09 06:04:55 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995534940>
+2021-09-09 06:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:04:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:04:55 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:04:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:05:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 06:05:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 06:06:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:07:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:08:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:08:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:08:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995617710>
+2021-09-09 06:08:14 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995617710>
+2021-09-09 06:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:08:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:08:15 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:08:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 06:08:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 06:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:09:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:09:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:09:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955259b0>
+2021-09-09 06:09:45 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39955259b0>
+2021-09-09 06:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:09:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:09:45 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:09:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:10:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:11:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:11:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:13:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:13:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954ff9b0>
+2021-09-09 06:13:19 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954ff9b0>
+2021-09-09 06:13:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:13:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:13:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-09 06:13:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 06:13:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 06:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 06:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 06:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 06:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 06:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-09 06:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 06:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 06:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 06:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-09 06:13:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 06:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 06:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 06:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 06:13:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 06:13:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 06:13:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 06:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 06:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 06:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 06:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 06:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 06:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 06:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:13:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 06:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 06:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 06:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-09 06:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 06:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 06:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 06:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:14:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:14:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:14:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:14:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:14:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995507b38>
+2021-09-09 06:14:58 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995507b38>
+2021-09-09 06:14:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:14:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:14:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:14:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:14:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 06:14:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:14:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 06:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 06:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 06:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 06:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 06:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 06:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 06:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 06:15:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 06:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 06:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 06:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 06:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 06:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 06:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 06:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 06:15:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 06:15:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 06:15:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 06:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 06:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 06:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-09 06:15:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 06:15:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 06:15:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:15:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 06:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 06:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 06:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:15:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:15:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:16:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:16:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:16:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954fb358>
+2021-09-09 06:16:37 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954fb358>
+2021-09-09 06:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:16:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:16:37 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 06:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 06:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 06:16:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 06:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 06:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 06:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 06:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 06:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 06:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 06:16:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 06:16:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 06:16:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 06:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 06:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:16:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 06:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 06:16:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:17:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:17:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 06:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:18:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:18:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954bdfd0>
+2021-09-09 06:18:33 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954bdfd0>
+2021-09-09 06:18:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:18:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:18:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:18:34 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:18:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 06:18:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 06:18:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 06:18:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 06:18:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 06:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 06:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 06:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 06:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 06:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 06:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 06:18:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 06:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 06:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 06:18:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 06:18:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 06:18:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 06:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 06:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 06:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 06:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 06:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 06:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-09 06:18:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 06:18:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 06:18:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:18:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 06:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:19:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 06:19:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 06:20:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:20:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:20:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:20:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399553d3c8>
+2021-09-09 06:20:11 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399553d3c8>
+2021-09-09 06:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:20:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:20:11 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:20:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:20:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:21:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:25:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:25:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995422748>
+2021-09-09 06:25:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995422748>
+2021-09-09 06:25:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:25:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:25:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:25:29 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 06:25:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/e02b7a9d-f215-4420-809b-5e45af380bc6.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:25:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 06:25:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:26:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:26:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:26:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 06:26:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 06:27:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:27:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:28:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:29:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:29:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:29:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954a5710>
+2021-09-09 06:30:04 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39954a5710>
+2021-09-09 06:30:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:30:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:30:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:30:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:30:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:30:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 06:30:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:30:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 06:30:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/2110b8fa-89cc-4ec3-962a-480d5ec3f7e0.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:30:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 06:30:06 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:30:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:30:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:33:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:33:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:33:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:33:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-09 06:33:41 INFO      adal-python:log.py:114 a0fc1721-be24-49bb-8542-6b9862c32cce - CacheDriver:Cached token is expired at 2021-09-09 01:38:35.219041.  Refreshing
+2021-09-09 06:33:41 INFO      adal-python:log.py:114 a0fc1721-be24-49bb-8542-6b9862c32cce - TokenRequest:Getting a new token from a refresh token
+2021-09-09 06:33:41 INFO      adal-python:log.py:114 a0fc1721-be24-49bb-8542-6b9862c32cce - CacheDriver:Returning token refreshed after expiry.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:34:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 06:34:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 06:35:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:35:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:35:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:35:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399549ba20>
+2021-09-09 06:35:26 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399549ba20>
+2021-09-09 06:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:35:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:36:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 06:36:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 06:36:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:36:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:37:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:40:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:40:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:40:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995425588>
+2021-09-09 06:40:48 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995425588>
+2021-09-09 06:40:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:40:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:40:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:40:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:40:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:40:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-09 06:40:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-09 06:40:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 06:40:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Restarting instance and waiting for boot
+2021-09-09 06:40:51 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:41:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:41:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:41:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:41:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:41:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:42:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:42:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:43:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:43:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:43:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:43:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995434eb8>
+2021-09-09 06:43:08 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995434eb8>
+2021-09-09 06:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:43:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:43:09 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 06:43:10 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:43:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:43:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:43:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:43:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:44:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:44:00 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-09 06:44:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/1a01b0a3-dc05-482a-a0f6-9cf629e939fc.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-09 06:44:00 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:44:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:44:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:44:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:44:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:44:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:45:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:45:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:46:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:19 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+2021-09-09 06:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:47:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:47:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399540a7b8>
+2021-09-09 06:47:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399540a7b8>
+2021-09-09 06:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:47:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:47:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:47:41 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/cd960339-2861-46f2-860b-a4c4def5afb4.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-09 06:47:41 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+FAILED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 06:48:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:48:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:50:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:50:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:50:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:50:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39953eb320>
+2021-09-09 06:50:13 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39953eb320>
+2021-09-09 06:50:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:50:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 06:50:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 06:50:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/e17d7858-f61d-4251-8b6f-f27cc4bf258c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 06:50:15 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:50:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:50:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:50:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+FAILED
+------------------------------ live log teardown -------------------------------
+2021-09-09 07:50:46 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - CacheDriver:Cached token is expired at 2021-09-09 02:33:40.590416.  Refreshing
+2021-09-09 07:50:46 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - TokenRequest:Getting a new token from a refresh token
+2021-09-09 07:50:47 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - CacheDriver:Returning token refreshed after expiry.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 07:51:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 07:51:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 07:52:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:52:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:53:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:54:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:55:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 07:56:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 07:56:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 07:56:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f400>
+2021-09-09 07:56:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399555f400>
+2021-09-09 07:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 07:56:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 07:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-09 07:56:26 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-09 07:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 07:56:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 07:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 07:56:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 07:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 07:56:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 07:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 07:56:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-09 07:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-09 07:57:08 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+
+
+=================================== FAILURES ===================================
+_____________________ test_clean_boot_of_upgraded_package ______________________
+
+self = <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8fd0>
+
+    def _ssh_connect(self):
+        """Connect to instance via SSH."""
+        if self._ssh_client and self._ssh_client.get_transport().is_active():
+            return self._ssh_client
+    
+        logging.getLogger("paramiko").setLevel(logging.INFO)
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    
+        # Paramiko can barf on valid keys when initializing this way,
+        # so the check here is _only_ for checking if we have a
+        # password protected keyfile. The filename is passed directly
+        # when connecting
+        try:
+            paramiko.RSAKey.from_private_key_file(
+                self.key_pair.private_key_path)
+        except PasswordRequiredException:
+            self._log.warning(
+                "The specified key (%s) requires a passphrase. If you have not"
+                " added this key to a running SSH agent, you will see failures"
+                " to connect after a long timeout.",
+                self.key_pair.private_key_path,
+            )
+        except SSHException:
+            pass
+    
+        try:
+            client.connect(
+                username=self.username,
+                hostname=self.ip,
+                port=int(self.port),
+                timeout=self.connect_timeout,
+                banner_timeout=self.banner_timeout,
+>               key_filename=self.key_pair.private_key_path,
+            )
+
+../pycloudlib/pycloudlib/instance.py:337: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.client.SSHClient object at 0x7f39957f11d0>
+hostname = '20.98.179.207', port = 22, username = 'ubuntu', password = None
+pkey = None, key_filename = '/home/james/.ssh/id_rsa', timeout = 60
+allow_agent = True, look_for_keys = True, compress = False
+sock = <socket.socket [closed] fd=-1, family=AddressFamily.AF_INET, type=2049, proto=0>
+gss_auth = False, gss_kex = False, gss_deleg_creds = True, gss_host = None
+banner_timeout = 60, auth_timeout = None, gss_trust_dns = True
+passphrase = None, disabled_algorithms = None
+
+    def connect(
+        self,
+        hostname,
+        port=SSH_PORT,
+        username=None,
+        password=None,
+        pkey=None,
+        key_filename=None,
+        timeout=None,
+        allow_agent=True,
+        look_for_keys=True,
+        compress=False,
+        sock=None,
+        gss_auth=False,
+        gss_kex=False,
+        gss_deleg_creds=True,
+        gss_host=None,
+        banner_timeout=None,
+        auth_timeout=None,
+        gss_trust_dns=True,
+        passphrase=None,
+        disabled_algorithms=None,
+    ):
+        """
+        Connect to an SSH server and authenticate to it.  The server's host key
+        is checked against the system host keys (see `load_system_host_keys`)
+        and any local host keys (`load_host_keys`).  If the server's hostname
+        is not found in either set of host keys, the missing host key policy
+        is used (see `set_missing_host_key_policy`).  The default policy is
+        to reject the key and raise an `.SSHException`.
+    
+        Authentication is attempted in the following order of priority:
+    
+            - The ``pkey`` or ``key_filename`` passed in (if any)
+    
+              - ``key_filename`` may contain OpenSSH public certificate paths
+                as well as regular private-key paths; when files ending in
+                ``-cert.pub`` are found, they are assumed to match a private
+                key, and both components will be loaded. (The private key
+                itself does *not* need to be listed in ``key_filename`` for
+                this to occur - *just* the certificate.)
+    
+            - Any key we can find through an SSH agent
+            - Any "id_rsa", "id_dsa" or "id_ecdsa" key discoverable in
+              ``~/.ssh/``
+    
+              - When OpenSSH-style public certificates exist that match an
+                existing such private key (so e.g. one has ``id_rsa`` and
+                ``id_rsa-cert.pub``) the certificate will be loaded alongside
+                the private key and used for authentication.
+    
+            - Plain username/password auth, if a password was given
+    
+        If a private key requires a password to unlock it, and a password is
+        passed in, that password will be used to attempt to unlock the key.
+    
+        :param str hostname: the server to connect to
+        :param int port: the server port to connect to
+        :param str username:
+            the username to authenticate as (defaults to the current local
+            username)
+        :param str password:
+            Used for password authentication; is also used for private key
+            decryption if ``passphrase`` is not given.
+        :param str passphrase:
+            Used for decrypting private keys.
+        :param .PKey pkey: an optional private key to use for authentication
+        :param str key_filename:
+            the filename, or list of filenames, of optional private key(s)
+            and/or certs to try for authentication
+        :param float timeout:
+            an optional timeout (in seconds) for the TCP connect
+        :param bool allow_agent:
+            set to False to disable connecting to the SSH agent
+        :param bool look_for_keys:
+            set to False to disable searching for discoverable private key
+            files in ``~/.ssh/``
+        :param bool compress: set to True to turn on compression
+        :param socket sock:
+            an open socket or socket-like object (such as a `.Channel`) to use
+            for communication to the target host
+        :param bool gss_auth:
+            ``True`` if you want to use GSS-API authentication
+        :param bool gss_kex:
+            Perform GSS-API Key Exchange and user authentication
+        :param bool gss_deleg_creds: Delegate GSS-API client credentials or not
+        :param str gss_host:
+            The targets name in the kerberos database. default: hostname
+        :param bool gss_trust_dns:
+            Indicates whether or not the DNS is trusted to securely
+            canonicalize the name of the host being connected to (default
+            ``True``).
+        :param float banner_timeout: an optional timeout (in seconds) to wait
+            for the SSH banner to be presented.
+        :param float auth_timeout: an optional timeout (in seconds) to wait for
+            an authentication response.
+        :param dict disabled_algorithms:
+            an optional dict passed directly to `.Transport` and its keyword
+            argument of the same name.
+    
+        :raises:
+            `.BadHostKeyException` -- if the server's host key could not be
+            verified
+        :raises: `.AuthenticationException` -- if authentication failed
+        :raises:
+            `.SSHException` -- if there was any other error connecting or
+            establishing an SSH session
+        :raises socket.error: if a socket error occurred while connecting
+    
+        .. versionchanged:: 1.15
+            Added the ``banner_timeout``, ``gss_auth``, ``gss_kex``,
+            ``gss_deleg_creds`` and ``gss_host`` arguments.
+        .. versionchanged:: 2.3
+            Added the ``gss_trust_dns`` argument.
+        .. versionchanged:: 2.4
+            Added the ``passphrase`` argument.
+        .. versionchanged:: 2.6
+            Added the ``disabled_algorithms`` argument.
+        """
+        if not sock:
+            errors = {}
+            # Try multiple possible address families (e.g. IPv4 vs IPv6)
+            to_try = list(self._families_and_addresses(hostname, port))
+            for af, addr in to_try:
+                try:
+                    sock = socket.socket(af, socket.SOCK_STREAM)
+                    if timeout is not None:
+                        try:
+                            sock.settimeout(timeout)
+                        except:
+                            pass
+                    retry_on_signal(lambda: sock.connect(addr))
+                    # Break out of the loop on success
+                    break
+                except socket.error as e:
+                    # Raise anything that isn't a straight up connection error
+                    # (such as a resolution error)
+                    if e.errno not in (ECONNREFUSED, EHOSTUNREACH):
+                        raise
+                    # Capture anything else so we know how the run looks once
+                    # iteration is complete. Retain info about which attempt
+                    # this was.
+                    errors[addr] = e
+    
+            # Make sure we explode usefully if no address family attempts
+            # succeeded. We've no way of knowing which error is the "right"
+            # one, so we construct a hybrid exception containing all the real
+            # ones, of a subclass that client code should still be watching for
+            # (socket.error)
+            if len(errors) == len(to_try):
+                raise NoValidConnectionsError(errors)
+    
+        t = self._transport = Transport(
+            sock,
+            gss_kex=gss_kex,
+            gss_deleg_creds=gss_deleg_creds,
+            disabled_algorithms=disabled_algorithms,
+        )
+        t.use_compression(compress=compress)
+        t.set_gss_host(
+            # t.hostname may be None, but GSS-API requires a target name.
+            # Therefore use hostname as fallback.
+            gss_host=gss_host or hostname,
+            trust_dns=gss_trust_dns,
+            gssapi_requested=gss_auth or gss_kex,
+        )
+        if self._log_channel is not None:
+            t.set_log_channel(self._log_channel)
+        if banner_timeout is not None:
+            t.banner_timeout = banner_timeout
+        if auth_timeout is not None:
+            t.auth_timeout = auth_timeout
+    
+        if port == SSH_PORT:
+            server_hostkey_name = hostname
+        else:
+            server_hostkey_name = "[{}]:{}".format(hostname, port)
+        our_server_keys = None
+    
+        our_server_keys = self._system_host_keys.get(server_hostkey_name)
+        if our_server_keys is None:
+            our_server_keys = self._host_keys.get(server_hostkey_name)
+        if our_server_keys is not None:
+            keytype = our_server_keys.keys()[0]
+            sec_opts = t.get_security_options()
+            other_types = [x for x in sec_opts.key_types if x != keytype]
+            sec_opts.key_types = [keytype] + other_types
+    
+        t.start_client(timeout=timeout)
+    
+        # If GSS-API Key Exchange is performed we are not required to check the
+        # host key, because the host is authenticated via GSS-API / SSPI as
+        # well as our client.
+        if not self._transport.gss_kex_used:
+            server_key = t.get_remote_server_key()
+            if our_server_keys is None:
+                # will raise exception if the key is rejected
+                self._policy.missing_host_key(
+                    self, server_hostkey_name, server_key
+                )
+            else:
+                our_key = our_server_keys.get(server_key.get_name())
+                if our_key != server_key:
+                    if our_key is None:
+                        our_key = list(our_server_keys.values())[0]
+                    raise BadHostKeyException(hostname, server_key, our_key)
+    
+        if username is None:
+            username = getpass.getuser()
+    
+        if key_filename is None:
+            key_filenames = []
+        elif isinstance(key_filename, string_types):
+            key_filenames = [key_filename]
+        else:
+            key_filenames = key_filename
+    
+        self._auth(
+            username,
+            password,
+            pkey,
+            key_filenames,
+            allow_agent,
+            look_for_keys,
+            gss_auth,
+            gss_kex,
+            gss_deleg_creds,
+            t.gss_host,
+>           passphrase,
+        )
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:446: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.client.SSHClient object at 0x7f39957f11d0>, username = 'ubuntu'
+password = None, pkey = None, key_filenames = ['/home/james/.ssh/id_rsa']
+allow_agent = True, look_for_keys = True, gss_auth = False, gss_kex = False
+gss_deleg_creds = True, gss_host = None, passphrase = None
+
+    def _auth(
+        self,
+        username,
+        password,
+        pkey,
+        key_filenames,
+        allow_agent,
+        look_for_keys,
+        gss_auth,
+        gss_kex,
+        gss_deleg_creds,
+        gss_host,
+        passphrase,
+    ):
+        """
+        Try, in order:
+    
+            - The key(s) passed in, if one was passed in.
+            - Any key we can find through an SSH agent (if allowed).
+            - Any "id_rsa", "id_dsa" or "id_ecdsa" key discoverable in ~/.ssh/
+              (if allowed).
+            - Plain username/password auth, if a password was given.
+    
+        (The password might be needed to unlock a private key [if 'passphrase'
+        isn't also given], or for two-factor authentication [for which it is
+        required].)
+        """
+        saved_exception = None
+        two_factor = False
+        allowed_types = set()
+        two_factor_types = {"keyboard-interactive", "password"}
+        if passphrase is None and password is not None:
+            passphrase = password
+    
+        # If GSS-API support and GSS-PI Key Exchange was performed, we attempt
+        # authentication with gssapi-keyex.
+        if gss_kex and self._transport.gss_kex_used:
+            try:
+                self._transport.auth_gssapi_keyex(username)
+                return
+            except Exception as e:
+                saved_exception = e
+    
+        # Try GSS-API authentication (gssapi-with-mic) only if GSS-API Key
+        # Exchange is not performed, because if we use GSS-API for the key
+        # exchange, there is already a fully established GSS-API context, so
+        # why should we do that again?
+        if gss_auth:
+            try:
+                return self._transport.auth_gssapi_with_mic(
+                    username, gss_host, gss_deleg_creds
+                )
+            except Exception as e:
+                saved_exception = e
+    
+        if pkey is not None:
+            try:
+                self._log(
+                    DEBUG,
+                    "Trying SSH key {}".format(
+                        hexlify(pkey.get_fingerprint())
+                    ),
+                )
+                allowed_types = set(
+                    self._transport.auth_publickey(username, pkey)
+                )
+                two_factor = allowed_types & two_factor_types
+                if not two_factor:
+                    return
+            except SSHException as e:
+                saved_exception = e
+    
+        if not two_factor:
+            for key_filename in key_filenames:
+                for pkey_class in (RSAKey, DSSKey, ECDSAKey, Ed25519Key):
+                    try:
+                        key = self._key_from_filepath(
+                            key_filename, pkey_class, passphrase
+                        )
+                        allowed_types = set(
+                            self._transport.auth_publickey(username, key)
+                        )
+                        two_factor = allowed_types & two_factor_types
+                        if not two_factor:
+                            return
+                        break
+                    except SSHException as e:
+                        saved_exception = e
+    
+        if not two_factor and allow_agent:
+            if self._agent is None:
+                self._agent = Agent()
+    
+            for key in self._agent.get_keys():
+                try:
+                    id_ = hexlify(key.get_fingerprint())
+                    self._log(DEBUG, "Trying SSH agent key {}".format(id_))
+                    # for 2-factor auth a successfully auth'd key password
+                    # will return an allowed 2fac auth method
+                    allowed_types = set(
+                        self._transport.auth_publickey(username, key)
+                    )
+                    two_factor = allowed_types & two_factor_types
+                    if not two_factor:
+                        return
+                    break
+                except SSHException as e:
+                    saved_exception = e
+    
+        if not two_factor:
+            keyfiles = []
+    
+            for keytype, name in [
+                (RSAKey, "rsa"),
+                (DSSKey, "dsa"),
+                (ECDSAKey, "ecdsa"),
+                (Ed25519Key, "ed25519"),
+            ]:
+                # ~/ssh/ is for windows
+                for directory in [".ssh", "ssh"]:
+                    full_path = os.path.expanduser(
+                        "~/{}/id_{}".format(directory, name)
+                    )
+                    if os.path.isfile(full_path):
+                        # TODO: only do this append if below did not run
+                        keyfiles.append((keytype, full_path))
+                        if os.path.isfile(full_path + "-cert.pub"):
+                            keyfiles.append((keytype, full_path + "-cert.pub"))
+    
+            if not look_for_keys:
+                keyfiles = []
+    
+            for pkey_class, filename in keyfiles:
+                try:
+                    key = self._key_from_filepath(
+                        filename, pkey_class, passphrase
+                    )
+                    # for 2-factor auth a successfully auth'd key will result
+                    # in ['password']
+                    allowed_types = set(
+                        self._transport.auth_publickey(username, key)
+                    )
+                    two_factor = allowed_types & two_factor_types
+                    if not two_factor:
+                        return
+                    break
+                except (SSHException, IOError) as e:
+                    saved_exception = e
+    
+        if password is not None:
+            try:
+                self._transport.auth_password(username, password)
+                return
+            except SSHException as e:
+                saved_exception = e
+        elif two_factor:
+            try:
+                self._transport.auth_interactive_dumb(username)
+                return
+            except SSHException as e:
+                saved_exception = e
+    
+        # if we got an auth-failed exception earlier, re-raise it
+        if saved_exception is not None:
+>           raise saved_exception
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:764: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.client.SSHClient object at 0x7f39957f11d0>, username = 'ubuntu'
+password = None, pkey = None, key_filenames = ['/home/james/.ssh/id_rsa']
+allow_agent = True, look_for_keys = True, gss_auth = False, gss_kex = False
+gss_deleg_creds = True, gss_host = None, passphrase = None
+
+    def _auth(
+        self,
+        username,
+        password,
+        pkey,
+        key_filenames,
+        allow_agent,
+        look_for_keys,
+        gss_auth,
+        gss_kex,
+        gss_deleg_creds,
+        gss_host,
+        passphrase,
+    ):
+        """
+        Try, in order:
+    
+            - The key(s) passed in, if one was passed in.
+            - Any key we can find through an SSH agent (if allowed).
+            - Any "id_rsa", "id_dsa" or "id_ecdsa" key discoverable in ~/.ssh/
+              (if allowed).
+            - Plain username/password auth, if a password was given.
+    
+        (The password might be needed to unlock a private key [if 'passphrase'
+        isn't also given], or for two-factor authentication [for which it is
+        required].)
+        """
+        saved_exception = None
+        two_factor = False
+        allowed_types = set()
+        two_factor_types = {"keyboard-interactive", "password"}
+        if passphrase is None and password is not None:
+            passphrase = password
+    
+        # If GSS-API support and GSS-PI Key Exchange was performed, we attempt
+        # authentication with gssapi-keyex.
+        if gss_kex and self._transport.gss_kex_used:
+            try:
+                self._transport.auth_gssapi_keyex(username)
+                return
+            except Exception as e:
+                saved_exception = e
+    
+        # Try GSS-API authentication (gssapi-with-mic) only if GSS-API Key
+        # Exchange is not performed, because if we use GSS-API for the key
+        # exchange, there is already a fully established GSS-API context, so
+        # why should we do that again?
+        if gss_auth:
+            try:
+                return self._transport.auth_gssapi_with_mic(
+                    username, gss_host, gss_deleg_creds
+                )
+            except Exception as e:
+                saved_exception = e
+    
+        if pkey is not None:
+            try:
+                self._log(
+                    DEBUG,
+                    "Trying SSH key {}".format(
+                        hexlify(pkey.get_fingerprint())
+                    ),
+                )
+                allowed_types = set(
+                    self._transport.auth_publickey(username, pkey)
+                )
+                two_factor = allowed_types & two_factor_types
+                if not two_factor:
+                    return
+            except SSHException as e:
+                saved_exception = e
+    
+        if not two_factor:
+            for key_filename in key_filenames:
+                for pkey_class in (RSAKey, DSSKey, ECDSAKey, Ed25519Key):
+                    try:
+                        key = self._key_from_filepath(
+                            key_filename, pkey_class, passphrase
+                        )
+                        allowed_types = set(
+                            self._transport.auth_publickey(username, key)
+                        )
+                        two_factor = allowed_types & two_factor_types
+                        if not two_factor:
+                            return
+                        break
+                    except SSHException as e:
+                        saved_exception = e
+    
+        if not two_factor and allow_agent:
+            if self._agent is None:
+                self._agent = Agent()
+    
+            for key in self._agent.get_keys():
+                try:
+                    id_ = hexlify(key.get_fingerprint())
+                    self._log(DEBUG, "Trying SSH agent key {}".format(id_))
+                    # for 2-factor auth a successfully auth'd key password
+                    # will return an allowed 2fac auth method
+                    allowed_types = set(
+                        self._transport.auth_publickey(username, key)
+                    )
+                    two_factor = allowed_types & two_factor_types
+                    if not two_factor:
+                        return
+                    break
+                except SSHException as e:
+                    saved_exception = e
+    
+        if not two_factor:
+            keyfiles = []
+    
+            for keytype, name in [
+                (RSAKey, "rsa"),
+                (DSSKey, "dsa"),
+                (ECDSAKey, "ecdsa"),
+                (Ed25519Key, "ed25519"),
+            ]:
+                # ~/ssh/ is for windows
+                for directory in [".ssh", "ssh"]:
+                    full_path = os.path.expanduser(
+                        "~/{}/id_{}".format(directory, name)
+                    )
+                    if os.path.isfile(full_path):
+                        # TODO: only do this append if below did not run
+                        keyfiles.append((keytype, full_path))
+                        if os.path.isfile(full_path + "-cert.pub"):
+                            keyfiles.append((keytype, full_path + "-cert.pub"))
+    
+            if not look_for_keys:
+                keyfiles = []
+    
+            for pkey_class, filename in keyfiles:
+                try:
+                    key = self._key_from_filepath(
+                        filename, pkey_class, passphrase
+                    )
+                    # for 2-factor auth a successfully auth'd key will result
+                    # in ['password']
+                    allowed_types = set(
+>                       self._transport.auth_publickey(username, key)
+                    )
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:740: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.Transport at 0x9604ab38 (unconnected)>, username = 'ubuntu'
+key = <paramiko.rsakey.RSAKey object at 0x7f39969c5b00>, event = None
+
+    def auth_publickey(self, username, key, event=None):
+        """
+        Authenticate to the server using a private key.  The key is used to
+        sign data from the server, so it must include the private part.
+    
+        If an ``event`` is passed in, this method will return immediately, and
+        the event will be triggered once authentication succeeds or fails.  On
+        success, `is_authenticated` will return ``True``.  On failure, you may
+        use `get_exception` to get more detailed error information.
+    
+        Since 1.1, if no event is passed, this method will block until the
+        authentication succeeds or fails.  On failure, an exception is raised.
+        Otherwise, the method simply returns.
+    
+        If the server requires multi-step authentication (which is very rare),
+        this method will return a list of auth types permissible for the next
+        step.  Otherwise, in the normal case, an empty list is returned.
+    
+        :param str username: the username to authenticate as
+        :param .PKey key: the private key to authenticate with
+        :param .threading.Event event:
+            an event to trigger when the authentication attempt is complete
+            (whether it was successful or not)
+        :return:
+            list of auth types permissible for the next stage of
+            authentication (normally empty)
+    
+        :raises:
+            `.BadAuthenticationType` -- if public-key authentication isn't
+            allowed by the server for this user (and no event was passed in)
+        :raises:
+            `.AuthenticationException` -- if the authentication failed (and no
+            event was passed in)
+        :raises: `.SSHException` -- if there was a network error
+        """
+        if (not self.active) or (not self.initial_kex_done):
+            # we should never try to authenticate unless we're on a secure link
+>           raise SSHException("No existing session")
+E           paramiko.ssh_exception.SSHException: No existing session
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1570: SSHException
+
+The above exception was the direct cause of the following exception:
+
+session_cloud = <tests.integration_tests.clouds.AzureCloud object at 0x7f3997033630>
+
+    def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
+        source = get_validated_source(session_cloud)
+        if not source.installs_new_version():
+            pytest.skip(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
+            return  # type checking doesn't understand that skip raises
+        if (ImageSpecification.from_os_image().release == 'bionic' and
+                session_cloud.settings.PLATFORM == 'lxd_vm'):
+            # The issues that we see on Bionic VMs don't appear anywhere
+            # else, including when calling KVM directly. It likely has to
+            # do with the extra lxd-agent setup happening on bionic.
+            # Given that we still have Bionic covered on all other platforms,
+            # the risk of skipping bionic here seems low enough.
+            pytest.skip("Upgrade test doesn't run on LXD VMs and bionic")
+            return
+    
+        launch_kwargs = {
+            'image_id': session_cloud.released_image_id,
+        }
+    
+        with session_cloud.launch(
+            launch_kwargs=launch_kwargs, user_data=USER_DATA,
+        ) as instance:
+            # get pre values
+            pre_hostname = instance.execute('hostname')
+            pre_cloud_id = instance.execute('cloud-id')
+            pre_result = instance.execute('cat /run/cloud-init/result.json')
+            pre_network = instance.execute('cat /etc/netplan/50-cloud-init.yaml')
+            pre_systemd_analyze = instance.execute('systemd-analyze')
+            pre_systemd_blame = instance.execute('systemd-analyze blame')
+            pre_cloud_analyze = instance.execute('cloud-init analyze show')
+            pre_cloud_blame = instance.execute('cloud-init analyze blame')
+    
+            # Ensure no issues pre-upgrade
+            assert not json.loads(pre_result)['v1']['errors']
+    
+            log = instance.read_from_file('/var/log/cloud-init.log')
+            verify_clean_log(log)
+    
+            # Upgrade and reboot
+            instance.install_new_cloud_init(source, take_snapshot=False)
+            instance.execute('hostname something-else')
+            instance.restart()
+>           assert instance.execute('cloud-init status --wait --long').ok
+
+tests/integration_tests/test_upgrade.py:86: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/instances.py:72: in execute
+    return self.instance.execute(command, use_sudo=use_sudo)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:282: in _ssh
+    client = self._ssh_connect()
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8fd0>
+
+    def _ssh_connect(self):
+        """Connect to instance via SSH."""
+        if self._ssh_client and self._ssh_client.get_transport().is_active():
+            return self._ssh_client
+    
+        logging.getLogger("paramiko").setLevel(logging.INFO)
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    
+        # Paramiko can barf on valid keys when initializing this way,
+        # so the check here is _only_ for checking if we have a
+        # password protected keyfile. The filename is passed directly
+        # when connecting
+        try:
+            paramiko.RSAKey.from_private_key_file(
+                self.key_pair.private_key_path)
+        except PasswordRequiredException:
+            self._log.warning(
+                "The specified key (%s) requires a passphrase. If you have not"
+                " added this key to a running SSH agent, you will see failures"
+                " to connect after a long timeout.",
+                self.key_pair.private_key_path,
+            )
+        except SSHException:
+            pass
+    
+        try:
+            client.connect(
+                username=self.username,
+                hostname=self.ip,
+                port=int(self.port),
+                timeout=self.connect_timeout,
+                banner_timeout=self.banner_timeout,
+                key_filename=self.key_pair.private_key_path,
+            )
+        except (ConnectionRefusedError, AuthenticationException,
+                BadHostKeyException, ConnectionResetError, SSHException,
+                OSError) as e:
+>           raise SSHException from e
+E           paramiko.ssh_exception.SSHException
+
+../pycloudlib/pycloudlib/instance.py:342: SSHException
+------------------------------ Captured log setup ------------------------------
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+------------------------------ Captured log call -------------------------------
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 04:21:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 04:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:23:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:23:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:23:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 04:23:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:23:16 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39957e8fd0>
+2021-09-09 04:23:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 04:23:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 04:23:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 04:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 04:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 04:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 04:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 04:23:21 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 04:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 04:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 04:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-09 04:23:49 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 04:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+2021-09-09 04:23:50 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 04:24:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 04:24:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 04:24:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 04:24:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 04:24:22 INFO      paramiko.transport:transport.py:1819 Auth banner: b'System is going down. Unprivileged users are not permitted to log in anymore. For technical details, see pam_nologin(8).\n\n'
+_____________________ test_boot_event_disabled_by_default ______________________
+
+client = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7f399542a5f8>
+
+    @pytest.mark.lxd_container
+    @pytest.mark.lxd_vm
+    @pytest.mark.ec2
+    @pytest.mark.gce
+    @pytest.mark.oci
+    @pytest.mark.openstack
+    @pytest.mark.azure
+    @pytest.mark.not_xenial
+    def test_boot_event_disabled_by_default(client: IntegrationInstance):
+        log = client.read_from_file('/var/log/cloud-init.log')
+        if 'network config is disabled' in log:
+            pytest.skip("network config disabled. Test doesn't apply")
+        assert 'Applying network configuration' in log
+        assert 'dummy0' not in client.execute('ls /sys/class/net')
+    
+        _add_dummy_bridge_to_netplan(client)
+        client.execute('rm /var/log/cloud-init.log')
+    
+        client.restart()
+>       log2 = client.read_from_file('/var/log/cloud-init.log')
+
+tests/integration_tests/modules/test_user_events.py:47: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7f399542a5f8>
+remote_path = '/var/log/cloud-init.log'
+
+    def read_from_file(self, remote_path) -> str:
+        result = self.execute('cat {}'.format(remote_path))
+        if result.failed:
+            # TODO: Raise here whatever pycloudlib raises when it has
+            # a consistent error response
+            raise IOError(
+                'Failed reading remote file via cat: {}\n'
+                'Return code: {}\n'
+                'Stderr: {}\n'
+                'Stdout: {}'.format(
+                    remote_path, result.return_code,
+>                   result.stderr, result.stdout)
+            )
+E           OSError: Failed reading remote file via cat: /var/log/cloud-init.log
+E           Return code: 1
+E           Stderr: cat: /var/log/cloud-init.log: No such file or directory
+E           Stdout:
+
+tests/integration_tests/instances.py:97: OSError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 06:20:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:20:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:21:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:21:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:25:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:25:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:25:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:25:28 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f3995422748>
+2021-09-09 06:25:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 06:25:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 06:25:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+------------------------------ Captured log call -------------------------------
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 06:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:25:29 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 06:25:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/e02b7a9d-f215-4420-809b-5e45af380bc6.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 06:25:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-09 06:25:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:26:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:26:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+_____________________ test_cache_purged_on_version_change ______________________
+
+client = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7f3995457f28>
+
+    def test_cache_purged_on_version_change(client: IntegrationInstance):
+        # Start by pushing the invalid pickle so we'll hit an error if the
+        # cache didn't actually get purged
+        client.push_file(TEST_PICKLE, PICKLE_PATH)
+        client.execute("echo '1.0' > /var/lib/cloud/data/python-version")
+>       client.restart()
+
+tests/integration_tests/modules/test_version_change.py:46: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/instances.py:67: in restart
+    self.instance.restart()
+../pycloudlib/pycloudlib/azure/instance.py:139: in restart
+    self.wait()
+../pycloudlib/pycloudlib/instance.py:101: in wait
+    self._wait_for_execute()
+../pycloudlib/pycloudlib/instance.py:381: in _wait_for_execute
+    result = self.execute(test_instance_command)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:514: in exec_command
+    chan.exec_command(command)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/channel.py:72: in _check
+    return func(self, *args, **kwds)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/channel.py:257: in exec_command
+    self._wait_for_event()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/channel.py:1226: in _wait_for_event
+    raise e
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:2055: in run
+    ptype, m = self.packetizer.read_message()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:459: in read_message
+    header = self.read_all(self.__block_size_in, check_rekey=True)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.packet.Packetizer object at 0x7f39954307b8>, n = 16
+check_rekey = True
+
+    def read_all(self, n, check_rekey=False):
+        """
+        Read as close to N bytes as possible, blocking as long as necessary.
+    
+        :param int n: number of bytes to read
+        :return: the data read, as a `str`
+    
+        :raises:
+            ``EOFError`` -- if the socket was closed before all the bytes could
+            be read
+        """
+        out = bytes()
+        # handle over-reading from reading the banner line
+        if len(self.__remainder) > 0:
+            out = self.__remainder[:n]
+            self.__remainder = self.__remainder[n:]
+            n -= len(out)
+        while n > 0:
+            got_timeout = False
+            if self.handshake_timed_out():
+                raise EOFError()
+            try:
+                x = self.__socket.recv(n)
+                if len(x) == 0:
+>                   raise EOFError()
+E                   EOFError
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:303: EOFError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 06:45:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:45:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:46:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:46:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:19 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+2021-09-09 06:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:47:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:47:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:47:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:47:40 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f399540a7b8>
+2021-09-09 06:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 06:47:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 06:47:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+------------------------------ Captured log call -------------------------------
+2021-09-09 06:47:41 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/cd960339-2861-46f2-860b-a4c4def5afb4.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 06:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-09 06:47:41 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+___________________ test_log_message_on_missing_version_file ___________________
+
+client = <tests.integration_tests.instances.IntegrationAzureInstance object at 0x7f39953e6c50>
+
+    def test_log_message_on_missing_version_file(client: IntegrationInstance):
+        # Start by pushing a pickle so we can see the log message
+        client.push_file(TEST_PICKLE, PICKLE_PATH)
+        client.execute("rm /var/lib/cloud/data/python-version")
+        client.execute("rm /var/log/cloud-init.log")
+        client.restart()
+>       log = client.read_from_file('/var/log/cloud-init.log')
+
+tests/integration_tests/modules/test_version_change.py:58: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/instances.py:87: in read_from_file
+    result = self.execute('cat {}'.format(remote_path))
+tests/integration_tests/instances.py:72: in execute
+    return self.instance.execute(command, use_sudo=use_sudo)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:508: in exec_command
+    chan = self._transport.open_session(timeout=timeout)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:879: in open_session
+    timeout=timeout,
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.Transport at 0x954d9eb8 (cipher aes128-ctr, 128 bits) (active; 1 open channel(s))>
+kind = 'session', dest_addr = None, src_addr = None, window_size = 2097152
+max_packet_size = 32768, timeout = 3600
+
+    def open_channel(
+        self,
+        kind,
+        dest_addr=None,
+        src_addr=None,
+        window_size=None,
+        max_packet_size=None,
+        timeout=None,
+    ):
+        """
+        Request a new channel to the server. `Channels <.Channel>` are
+        socket-like objects used for the actual transfer of data across the
+        session. You may only request a channel after negotiating encryption
+        (using `connect` or `start_client`) and authenticating.
+    
+        .. note:: Modifying the the window and packet sizes might have adverse
+            effects on the channel created. The default values are the same
+            as in the OpenSSH code base and have been battle tested.
+    
+        :param str kind:
+            the kind of channel requested (usually ``"session"``,
+            ``"forwarded-tcpip"``, ``"direct-tcpip"``, or ``"x11"``)
+        :param tuple dest_addr:
+            the destination address (address + port tuple) of this port
+            forwarding, if ``kind`` is ``"forwarded-tcpip"`` or
+            ``"direct-tcpip"`` (ignored for other channel types)
+        :param src_addr: the source address of this port forwarding, if
+            ``kind`` is ``"forwarded-tcpip"``, ``"direct-tcpip"``, or ``"x11"``
+        :param int window_size:
+            optional window size for this session.
+        :param int max_packet_size:
+            optional max packet size for this session.
+        :param float timeout:
+            optional timeout opening a channel, default 3600s (1h)
+    
+        :return: a new `.Channel` on success
+    
+        :raises:
+            `.SSHException` -- if the request is rejected, the session ends
+            prematurely or there is a timeout openning a channel
+    
+        .. versionchanged:: 1.15
+            Added the ``window_size`` and ``max_packet_size`` arguments.
+        """
+        if not self.active:
+            raise SSHException("SSH session not active")
+        timeout = 3600 if timeout is None else timeout
+        self.lock.acquire()
+        try:
+            window_size = self._sanitize_window_size(window_size)
+            max_packet_size = self._sanitize_packet_size(max_packet_size)
+            chanid = self._next_channel()
+            m = Message()
+            m.add_byte(cMSG_CHANNEL_OPEN)
+            m.add_string(kind)
+            m.add_int(chanid)
+            m.add_int(window_size)
+            m.add_int(max_packet_size)
+            if (kind == "forwarded-tcpip") or (kind == "direct-tcpip"):
+                m.add_string(dest_addr[0])
+                m.add_int(dest_addr[1])
+                m.add_string(src_addr[0])
+                m.add_int(src_addr[1])
+            elif kind == "x11":
+                m.add_string(src_addr[0])
+                m.add_int(src_addr[1])
+            chan = Channel(chanid)
+            self._channels.put(chanid, chan)
+            self.channel_events[chanid] = event = threading.Event()
+            self.channels_seen[chanid] = True
+            chan._set_transport(self)
+            chan._set_window(window_size, max_packet_size)
+        finally:
+            self.lock.release()
+        self._send_user_message(m)
+        start_ts = time.time()
+        while True:
+            event.wait(0.1)
+            if not self.active:
+                e = self.get_exception()
+                if e is None:
+                    e = SSHException("Unable to open channel.")
+                raise e
+            if event.is_set():
+                break
+            elif start_ts + timeout < time.time():
+>               raise SSHException("Timeout opening channel.")
+E               paramiko.ssh_exception.SSHException: Timeout opening channel.
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1010: SSHException
+------------------------------ Captured log setup ------------------------------
+2021-09-09 06:48:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-09 06:48:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0908-230901-rg/providers/Microsoft.Compute/images/azure-integration-test-0908-230901-image
+user_data=None
+2021-09-09 06:50:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:50:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:50:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 06:50:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:50:13 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f39953eb320>
+2021-09-09 06:50:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-09 06:50:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-09 06:50:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+------------------------------ Captured log call -------------------------------
+2021-09-09 06:50:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/e17d7858-f61d-4251-8b6f-f27cc4bf258c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 06:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-09 06:50:15 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 06:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 06:50:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 06:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 06:50:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-09 06:50:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+---------------------------- Captured log teardown -----------------------------
+2021-09-09 07:50:46 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - CacheDriver:Cached token is expired at 2021-09-09 02:33:40.590416.  Refreshing
+2021-09-09 07:50:46 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - TokenRequest:Getting a new token from a refresh token
+2021-09-09 07:50:47 INFO      adal-python:log.py:114 a47eee7d-fa0d-4c09-858b-eef7a0b1c459 - CacheDriver:Returning token refreshed after expiry.
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 148 warnings
+tests/integration_tests/test_upgrade.py: 23 warnings
+tests/integration_tests/bugs/test_gh671.py: 42 warnings
+tests/integration_tests/bugs/test_gh868.py: 9 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 9 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 9 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 9 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 11 warnings
+tests/integration_tests/bugs/test_lp1901011.py: 19 warnings
+tests/integration_tests/bugs/test_lp1910835.py: 9 warnings
+tests/integration_tests/modules/test_apt.py: 36 warnings
+tests/integration_tests/modules/test_ca_certs.py: 9 warnings
+tests/integration_tests/modules/test_cli.py: 18 warnings
+tests/integration_tests/modules/test_combined.py: 9 warnings
+tests/integration_tests/modules/test_command_output.py: 9 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 9 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 27 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 9 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 36 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 9 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 9 warnings
+tests/integration_tests/modules/test_set_hostname.py: 36 warnings
+tests/integration_tests/modules/test_set_password.py: 18 warnings
+tests/integration_tests/modules/test_snap.py: 9 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 18 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 9 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 9 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 36 warnings
+tests/integration_tests/modules/test_timezone.py: 9 warnings
+tests/integration_tests/modules/test_user_events.py: 22 warnings
+tests/integration_tests/modules/test_users_groups.py: 20 warnings
+tests/integration_tests/modules/test_version_change.py: 36 warnings
+tests/integration_tests/modules/test_write_files.py: 11 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package
+FAILED tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default
+FAILED tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change
+FAILED tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file
+==== 4 failed, 121 passed, 24 skipped, 711 warnings in 13688.50s (3:48:08) =====

--- a/21.3-1/integration_tests/azure_hirsute_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/azure_hirsute_integration_tests_rerun.txt
@@ -1,0 +1,1081 @@
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 5 items
+
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 13:51:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 13:51:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-10 13:51:42 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=azure
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 13:51:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-10 13:51:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-10 13:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:53:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:54:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:55:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:57:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 13:57:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 13:57:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8b713780>
+2021-09-10 13:57:18 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8b713780>
+2021-09-10 13:57:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 13:57:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 13:57:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 13:57:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-10 13:57:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 13:57:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-10 13:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-10 13:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 13:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-10 13:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-10 13:57:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-10 13:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-10 13:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+There were errors/warnings/tracebacks pre-upgrade. Any failures may be due to pre-upgrade problem
+2021-09-10 13:57:22 WARNING   integration_testing.test_upgrade:test_upgrade.py:84 There were errors/warnings/tracebacks pre-upgrade. Any failures may be due to pre-upgrade problem
+Installing proposed image
+2021-09-10 13:57:22 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 13:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 13:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 13:57:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 13:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 13:57:44 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 13:57:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 13:57:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 13:57:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-10 13:57:45 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 13:58:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:58:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 13:58:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 13:58:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 13:58:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 13:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-10 13:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-10 13:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 13:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-10 13:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-10 13:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 13:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-10 13:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-10 13:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-10 13:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-10 13:58:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 2.485s (kernel) + 4min 31.803s (userspace) = 4min 34.288s
+graphical.target reached after 4min 31.132s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.541s (kernel) + 18.125s (userspace) = 20.666s
+graphical.target reached after 17.466s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+4min 5.484s cloud-init.service
+    13.049s snapd.seeded.service
+     3.592s snapd.service
+     2.879s snap.lxd.activate.service
+     2.857s snapd.apparmor.service
+     2.067s cloud-init-local.service
+     1.760s pollinate.service
+     1.653s systemd-networkd-wait-online.service
+     1.388s lvm2-monitor.service
+     1.307s cloud-config.service
+=== `systemd-analyze blame` after (first 10 lines):
+5.867s snap.lxd.activate.service
+5.635s snapd.service
+3.285s cloud-init.service
+1.953s systemd-networkd-wait-online.service
+1.933s lvm2-monitor.service
+1.824s networkd-dispatcher.service
+1.759s dev-sda1.device
+1.509s udisks2.service
+1.453s cloud-init-local.service
+1.428s systemd-udev-settle.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00400 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00700 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01100 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.25800 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.25800 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.52400 seconds
+Finished stage: (azure-ds/_get_data) 00.56000 seconds
+Finished stage: (init-local/search-Azure) 00.57000 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 01.09000 seconds
+Total Time: 3.28300 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00900 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01700 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01800 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.02000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.03800 seconds
+Finished stage: (azure-ds/_post_health_report) 00.49100 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.49200 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.51200 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.51300 seconds
+Finished stage: (azure-ds/_negotiate) 00.52300 seconds
+Finished stage: (azure-ds/setup) 00.52300 seconds
+Finished stage: (init-network/setup-datasource) 00.52400 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.07900 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.11500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.11500 seconds
+Total Time: 3.99100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01800 seconds
+Finished stage: (azure-ds/activate) 00.14100 seconds
+Finished stage: (init-network/activate-datasource) 00.14300 seconds
+Finished stage: (init-network/config-users-groups) 00.44100 seconds
+Finished stage: (init-network/config-ssh) 00.49900 seconds
+Finished stage: (init-network) 245.02400 seconds
+Finished stage: (modules-config) 00.86400 seconds
+Finished stage: (modules-final) 00.22000 seconds
+Total Time: 247.35000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00200 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.13000 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.13000 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.49800 seconds
+Finished stage: (azure-ds/_get_data) 00.52200 seconds
+Finished stage: (init-local/search-Azure) 00.52800 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00000 seconds
+Finished stage: (init-local) 00.80700 seconds
+Total Time: 2.62700 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00600 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.01000 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01600 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01900 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.02000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02900 seconds
+Finished stage: (azure-ds/_post_health_report) 00.04300 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.04500 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.06500 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.06500 seconds
+Finished stage: (azure-ds/_negotiate) 00.07600 seconds
+Finished stage: (azure-ds/setup) 00.07600 seconds
+Finished stage: (init-network/setup-datasource) 00.07600 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.03300 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.12600 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.12700 seconds
+Total Time: 0.83300 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01300 seconds
+Finished stage: (azure-ds/activate) 00.14000 seconds
+Finished stage: (init-network/activate-datasource) 00.14200 seconds
+Finished stage: (init-network/config-users-groups) 00.05300 seconds
+Finished stage: (init-network/config-ssh) 00.86700 seconds
+Finished stage: (init-network) 02.82300 seconds
+Finished stage: (modules-config) 00.39400 seconds
+Finished stage: (modules-final) 00.21700 seconds
+Finished stage: (init-network/setup-datasource) 00.00100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.09600 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.09600 seconds
+Total Time: 4.84200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.10900 seconds
+Finished stage: (init-network/activate-datasource) 00.11200 seconds
+Finished stage: (init-network) 00.33500 seconds
+Total Time: 0.56800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.20700s (azure-ds/obtain-dhcp-lease)
+     00.07900s (azure-ds/list_possible_azure_ds_devs)
+     00.05200s (init-network/check-cache)
+     00.02800s (azure-ds/get_boot_telemetry)
+     00.01500s (azure-ds/_get_metadata_from_imds)
+     00.00700s (azure-ds/write_files)
+     00.00300s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.09500s (azure-ds/obtain-dhcp-lease)
+     00.04500s (init-network/check-cache)
+     00.01900s (azure-ds/get_boot_telemetry)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_get_preprovisionedvmtype_cfg_value)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+
+2021-09-10 13:58:49 INFO      integration_testing.test_upgrade:test_upgrade.py:149
+=== `systemd-analyze` before:
+Startup finished in 2.485s (kernel) + 4min 31.803s (userspace) = 4min 34.288s
+graphical.target reached after 4min 31.132s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.541s (kernel) + 18.125s (userspace) = 20.666s
+graphical.target reached after 17.466s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+4min 5.484s cloud-init.service
+    13.049s snapd.seeded.service
+     3.592s snapd.service
+     2.879s snap.lxd.activate.service
+     2.857s snapd.apparmor.service
+     2.067s cloud-init-local.service
+     1.760s pollinate.service
+     1.653s systemd-networkd-wait-online.service
+     1.388s lvm2-monitor.service
+     1.307s cloud-config.service
+=== `systemd-analyze blame` after (first 10 lines):
+5.867s snap.lxd.activate.service
+5.635s snapd.service
+3.285s cloud-init.service
+1.953s systemd-networkd-wait-online.service
+1.933s lvm2-monitor.service
+1.824s networkd-dispatcher.service
+1.759s dev-sda1.device
+1.509s udisks2.service
+1.453s cloud-init-local.service
+1.428s systemd-udev-settle.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00400 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00700 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01100 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.25800 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.25800 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.52400 seconds
+Finished stage: (azure-ds/_get_data) 00.56000 seconds
+Finished stage: (init-local/search-Azure) 00.57000 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (init-local) 01.09000 seconds
+Total Time: 3.28300 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00100 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00900 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01700 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01800 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.02000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.03800 seconds
+Finished stage: (azure-ds/_post_health_report) 00.49100 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.49200 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.51200 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.51300 seconds
+Finished stage: (azure-ds/_negotiate) 00.52300 seconds
+Finished stage: (azure-ds/setup) 00.52300 seconds
+Finished stage: (init-network/setup-datasource) 00.52400 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.07900 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.11500 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.11500 seconds
+Total Time: 3.99100 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01800 seconds
+Finished stage: (azure-ds/activate) 00.14100 seconds
+Finished stage: (init-network/activate-datasource) 00.14300 seconds
+Finished stage: (init-network/config-users-groups) 00.44100 seconds
+Finished stage: (init-network/config-ssh) 00.49900 seconds
+Finished stage: (init-network) 245.02400 seconds
+Finished stage: (modules-config) 00.86400 seconds
+Finished stage: (modules-final) 00.22000 seconds
+Total Time: 247.35000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (azure-ds/_get_preprovisioning_cfgs) 00.00200 seconds
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
+Finished stage: (azure-ds/get_metadata_from_imds) 00.13000 seconds
+Finished stage: (azure-ds/get_imds_data_with_api_fallback) 00.13000 seconds
+Finished stage: (azure-ds/crawl_metadata) 00.49800 seconds
+Finished stage: (azure-ds/_get_data) 00.52200 seconds
+Finished stage: (init-local/search-Azure) 00.52800 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00000 seconds
+Finished stage: (init-local) 00.80700 seconds
+Total Time: 2.62700 seconds
+Finished stage: (azure-ds/parse_network_config) 00.00600 seconds
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.01000 seconds
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+Finished stage: (azure-ds/goalstate-retrieval) 00.01600 seconds
+Finished stage: (azure-ds/_get_raw_goal_state_xml_from_azure) 00.01900 seconds
+Finished stage: (azure-ds/_fetch_goal_state_from_azure) 00.02000 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.02900 seconds
+Finished stage: (azure-ds/_post_health_report) 00.04300 seconds
+Finished stage: (azure-ds/send_ready_signal) 00.04500 seconds
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.06500 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.06500 seconds
+Finished stage: (azure-ds/_negotiate) 00.07600 seconds
+Finished stage: (azure-ds/setup) 00.07600 seconds
+Finished stage: (init-network/setup-datasource) 00.07600 seconds
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.03300 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.12600 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.12700 seconds
+Total Time: 0.83300 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01300 seconds
+Finished stage: (azure-ds/activate) 00.14000 seconds
+Finished stage: (init-network/activate-datasource) 00.14200 seconds
+Finished stage: (init-network/config-users-groups) 00.05300 seconds
+Finished stage: (init-network/config-ssh) 00.86700 seconds
+Finished stage: (init-network) 02.82300 seconds
+Finished stage: (modules-config) 00.39400 seconds
+Finished stage: (modules-final) 00.21700 seconds
+Finished stage: (init-network/setup-datasource) 00.00100 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.09600 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.09600 seconds
+Total Time: 4.84200 seconds
+Finished stage: (azure-ds/push_log_to_kvp) 00.01200 seconds
+Finished stage: (azure-ds/activate) 00.10900 seconds
+Finished stage: (init-network/activate-datasource) 00.11200 seconds
+Finished stage: (init-network) 00.33500 seconds
+Total Time: 0.56800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.20700s (azure-ds/obtain-dhcp-lease)
+     00.07900s (azure-ds/list_possible_azure_ds_devs)
+     00.05200s (init-network/check-cache)
+     00.02800s (azure-ds/get_boot_telemetry)
+     00.01500s (azure-ds/_get_metadata_from_imds)
+     00.00700s (azure-ds/write_files)
+     00.00300s (azure-ds/_get_preprovisionedvm_cfg_value)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.09500s (azure-ds/obtain-dhcp-lease)
+     00.04500s (init-network/check-cache)
+     00.01900s (azure-ds/get_boot_telemetry)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00200s (azure-ds/write_files)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_get_preprovisionedvmtype_cfg_value)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 13:59:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Setting up environment for azure
+2021-09-10 13:59:30 INFO      integration_testing:conftest.py:156 Setting up environment for azure
+Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+2021-09-10 13:59:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily
+user_data=None
+2021-09-10 14:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:02:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:03:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:03:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:03:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad91be0>
+2021-09-10 14:04:03 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad91be0>
+2021-09-10 14:04:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 14:04:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 14:04:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 14:04:04 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-10 14:04:04 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 14:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 14:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 14:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 14:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:04:31 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:04:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 14:04:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 14:04:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 14:04:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 14:04:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo waagent -deprovision+user -force'
+Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+2021-09-10 14:05:36 INFO      integration_testing:instances.py:114 Created new image: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+Done with environment setup
+2021-09-10 14:06:16 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:06:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:07:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:07:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:07:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad5fcc0>
+2021-09-10 14:07:06 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad5fcc0>
+2021-09-10 14:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:07:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 14:07:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 14:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 14:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-10 14:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 14:07:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-10 14:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/edd2ccb1-d3ab-4d38-9a1d-4f8017e4d13b.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-10 14:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 14:07:08 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 14:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:07:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:07:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:07:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:07:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 14:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 14:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 14:08:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:08:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:09:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:09:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:09:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad773c8>
+2021-09-10 14:09:25 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8ad773c8>
+2021-09-10 14:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:09:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 14:09:26 INFO      integration_testing:clouds.py:183 image serial: 20210908
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 14:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 14:09:26 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 14:09:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:10:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:10:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:10:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 14:10:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 14:10:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-10 14:10:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/0ea1a7f8-1a96-4830-8bc9-6da90c671983.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-10 14:10:14 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 14:10:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:10:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 14:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 14:11:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:11:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:12:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:12:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:12:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:12:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8a510198>
+2021-09-10 14:12:15 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8a510198>
+2021-09-10 14:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:12:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 14:12:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 14:12:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-10 14:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b9ae4dce-4ae3-48cd-a36c-fd825dda62e2.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-10 14:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-10 14:12:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 14:12:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:13:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:13:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:13:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 14:13:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 14:13:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:13:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=/subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+user_data=None
+2021-09-10 14:14:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:14:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:15:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:15:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:15:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8adab710>
+2021-09-10 14:15:59 INFO      integration_testing:clouds.py:173 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7f1d8adab710>
+2021-09-10 14:15:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:16:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 14:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 14:16:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 14:16:00 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-10 14:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/79681e94-d99a-493c-9c43-2a7ec6edcce7.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-10 14:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-10 14:16:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 14:16:01 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 14:16:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 14:16:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 14:16:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 14:16:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 14:16:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSEDDeleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+
+------------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------------
+2021-09-10 14:17:30 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: /subscriptions/36c65514-b88a-44f1-a44a-795c5b6fb73c/resourceGroups/azure-integration-test-0910-085141-rg/providers/Microsoft.Compute/images/azure-integration-test-0910-085930-image
+
+
+================================================================================================= warnings summary ==================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_upgrade.py: 26 warnings
+tests/integration_tests/modules/test_user_events.py: 26 warnings
+tests/integration_tests/modules/test_version_change.py: 37 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/urllib3/util/retry.py:440: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
+    DeprecationWarning,
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+==================================================================================== 5 passed, 90 warnings in 1550.68s (0:25:50) ====================================================================================

--- a/21.3-1/integration_tests/ec2_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/ec2_bionic_integration_tests.txt
@@ -1,0 +1,3947 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:39:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 16:39:28 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 16:39:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 16:39:37 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-09 16:39:37 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+2021-09-09 16:39:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+2021-09-09 16:40:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:40:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:40:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:40:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:40:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0384c666e18d30a90'))
+2021-09-09 16:40:30 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0384c666e18d30a90'))
+2021-09-09 16:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:40:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:40:30 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 16:40:30 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 16:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 16:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 16:40:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 16:40:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:40:46 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 16:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 16:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 16:40:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 16:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:44:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:44:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:44:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-08c4b9461c8e92d12
+2021-09-09 16:45:03 INFO      integration_testing:instances.py:114 Created new image: ami-08c4b9461c8e92d12
+Done with environment setup
+2021-09-09 16:45:48 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 16:45:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 16:46:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:46:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:46:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:46:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:46:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:46:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:46:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:46:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-019cab6134dd3ba49'))
+2021-09-09 16:46:34 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-019cab6134dd3ba49'))
+2021-09-09 16:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:46:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:46:34 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-09 16:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:47:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:47:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 16:47:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 16:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:47:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:47:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:47:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0dabe4a3a704f86b7'))
+2021-09-09 16:48:09 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0dabe4a3a704f86b7'))
+2021-09-09 16:48:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:48:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:48:10 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 16:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 16:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 16:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 16:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 16:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 16:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 16:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 16:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 16:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-09 16:48:12 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 16:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 16:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 16:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 16:48:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:48:29 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 16:48:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 16:48:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-09 16:48:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 16:48:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:48:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:48:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:48:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:48:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:49:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:49:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:49:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 16:49:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:49:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 16:49:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-09 16:49:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 16:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 16:49:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 16:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.999s (kernel) + 22.082s (userspace) = 27.081s
+graphical.target reached after 20.843s in userspace
+=== `systemd-analyze` after:
+Startup finished in 5.813s (kernel) + 12.206s (userspace) = 18.019s
+graphical.target reached after 11.289s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         11.566s snapd.seeded.service
+          2.171s dev-xvda1.device
+          1.883s systemd-networkd-wait-online.service
+          1.876s apparmor.service
+          1.269s cloud-init-local.service
+          1.214s cloud-final.service
+          1.188s pollinate.service
+          1.156s cloud-init.service
+          1.030s cloud-config.service
+           837ms snapd.service
+=== `systemd-analyze blame` after (first 10 lines):
+          3.043s dev-xvda1.device
+          2.457s cloud-init-local.service
+          2.224s snapd.service
+          1.878s cloud-config.service
+          1.337s systemd-networkd-wait-online.service
+          1.196s cloud-init.service
+           912ms cloud-final.service
+           866ms networkd-dispatcher.service
+           853ms dev-loop2.device
+           780ms dev-loop0.device
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.48600 seconds
+Finished stage: (init-network) 00.59600 seconds
+Finished stage: (modules-config) 00.38100 seconds
+Finished stage: (modules-final) 00.16200 seconds
+Total Time: 1.62500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 01.24600 seconds
+Finished stage: (init-network) 00.61100 seconds
+Finished stage: (modules-config) 01.05000 seconds
+Finished stage: (modules-final) 00.17700 seconds
+Total Time: 3.08400 seconds
+Finished stage: (init-network) 00.18500 seconds
+Total Time: 0.18500 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.26900s (init-local/search-Ec2Local)
+     00.21200s (modules-config/config-grub-dpkg)
+     00.13700s (init-network/config-resizefs)
+     00.12600s (modules-config/config-apt-configure)
+     00.11900s (init-network/config-ssh)
+     00.08600s (init-network/config-growpart)
+     00.07500s (modules-final/config-keys-to-console)
+     00.06900s (init-network/config-users-groups)
+     00.03500s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     01.01800s (init-local/search-Ec2Local)
+     00.67100s (modules-config/config-grub-dpkg)
+     00.30400s (modules-config/config-apt-configure)
+     00.19600s (init-network/config-ssh)
+     00.11300s (init-network/config-growpart)
+     00.09400s (modules-final/config-keys-to-console)
+     00.04800s (init-network/config-resizefs)
+     00.03000s (modules-final/config-ssh-authkey-fingerprints)
+     00.02800s (init-network/config-users-groups)
+
+2021-09-09 16:49:47 INFO      integration_testing.test_upgrade:test_upgrade.py:149 
+=== `systemd-analyze` before:
+Startup finished in 4.999s (kernel) + 22.082s (userspace) = 27.081s
+graphical.target reached after 20.843s in userspace
+=== `systemd-analyze` after:
+Startup finished in 5.813s (kernel) + 12.206s (userspace) = 18.019s
+graphical.target reached after 11.289s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         11.566s snapd.seeded.service
+          2.171s dev-xvda1.device
+          1.883s systemd-networkd-wait-online.service
+          1.876s apparmor.service
+          1.269s cloud-init-local.service
+          1.214s cloud-final.service
+          1.188s pollinate.service
+          1.156s cloud-init.service
+          1.030s cloud-config.service
+           837ms snapd.service
+=== `systemd-analyze blame` after (first 10 lines):
+          3.043s dev-xvda1.device
+          2.457s cloud-init-local.service
+          2.224s snapd.service
+          1.878s cloud-config.service
+          1.337s systemd-networkd-wait-online.service
+          1.196s cloud-init.service
+           912ms cloud-final.service
+           866ms networkd-dispatcher.service
+           853ms dev-loop2.device
+           780ms dev-loop0.device
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.48600 seconds
+Finished stage: (init-network) 00.59600 seconds
+Finished stage: (modules-config) 00.38100 seconds
+Finished stage: (modules-final) 00.16200 seconds
+Total Time: 1.62500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 01.24600 seconds
+Finished stage: (init-network) 00.61100 seconds
+Finished stage: (modules-config) 01.05000 seconds
+Finished stage: (modules-final) 00.17700 seconds
+Total Time: 3.08400 seconds
+Finished stage: (init-network) 00.18500 seconds
+Total Time: 0.18500 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.26900s (init-local/search-Ec2Local)
+     00.21200s (modules-config/config-grub-dpkg)
+     00.13700s (init-network/config-resizefs)
+     00.12600s (modules-config/config-apt-configure)
+     00.11900s (init-network/config-ssh)
+     00.08600s (init-network/config-growpart)
+     00.07500s (modules-final/config-keys-to-console)
+     00.06900s (init-network/config-users-groups)
+     00.03500s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     01.01800s (init-local/search-Ec2Local)
+     00.67100s (modules-config/config-grub-dpkg)
+     00.30400s (modules-config/config-apt-configure)
+     00.19600s (init-network/config-ssh)
+     00.11300s (init-network/config-growpart)
+     00.09400s (modules-final/config-keys-to-console)
+     00.04800s (init-network/config-resizefs)
+     00.03000s (modules-final/config-ssh-authkey-fingerprints)
+     00.02800s (init-network/config-users-groups)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:50:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+2021-09-09 16:51:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:51:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:51:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:51:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:51:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:51:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-07ddc370960a0694c'))
+2021-09-09 16:51:43 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-07ddc370960a0694c'))
+2021-09-09 16:51:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:51:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-09 16:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:51:44 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 16:51:44 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 16:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 16:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 16:51:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 16:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:52:01 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-09 16:52:01 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 16:52:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:52:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:52:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:53:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:53:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:53:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 16:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 16:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:54:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 16:54:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 16:55:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:55:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:55:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:55:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ccf95dec3f919a2e'))
+2021-09-09 16:55:19 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ccf95dec3f919a2e'))
+2021-09-09 16:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:55:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:55:19 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:56:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 16:56:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 16:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:56:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:56:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:56:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ebb4b47b3a79db77'))
+2021-09-09 16:57:06 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ebb4b47b3a79db77'))
+2021-09-09 16:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:57:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:57:07 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:57:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 16:57:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 16:58:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:58:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:58:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:58:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0c39f42e8ce52f118'))
+2021-09-09 16:58:33 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0c39f42e8ce52f118'))
+2021-09-09 16:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:58:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 16:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 16:58:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 16:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 16:59:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 16:59:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 16:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:59:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:59:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 16:59:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 16:59:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 16:59:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ec7e9268172dbf44'))
+2021-09-09 17:00:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0ec7e9268172dbf44'))
+2021-09-09 17:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:00:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:00:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 17:00:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-09 17:00:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:00:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 17:00:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 17:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:01:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:01:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-09db4aae32b7821c5'))
+2021-09-09 17:01:42 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-09db4aae32b7821c5'))
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:01:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:01:42 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 17:01:42 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 17:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 17:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 17:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:01:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:02:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:02:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:02:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:02:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 17:02:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 17:02:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-09 17:02:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 17:04:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 17:05:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:05:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:05:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:05:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:05:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-027cfd9fd6fe50e84'))
+2021-09-09 17:05:18 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-027cfd9fd6fe50e84'))
+2021-09-09 17:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-09 17:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-09 17:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:05:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 17:05:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 17:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:06:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:06:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:06:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:06:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b60ee30c5bf91655'))
+2021-09-09 17:06:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b60ee30c5bf91655'))
+2021-09-09 17:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:06:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:06:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:07:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 17:07:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 17:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:07:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:07:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:07:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:08:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e238f176b76289f4'))
+2021-09-09 17:08:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e238f176b76289f4'))
+2021-09-09 17:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:08:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:08:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:08:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 17:08:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 17:09:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:09:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:09:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:09:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:09:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0a6c769d692cbf3d8'))
+2021-09-09 17:09:35 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0a6c769d692cbf3d8'))
+2021-09-09 17:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:09:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:09:35 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:09:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:10:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 17:10:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 17:10:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:10:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:10:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:10:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0284079523b17042e'))
+2021-09-09 17:10:57 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0284079523b17042e'))
+2021-09-09 17:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:10:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:10:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:10:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:11:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 17:11:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 17:12:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:12:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:12:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:12:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:12:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:12:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0cadef564675e96f9'))
+2021-09-09 17:12:10 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0cadef564675e96f9'))
+2021-09-09 17:12:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:12:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:12:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:12:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:12:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:12:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 17:12:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 17:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:13:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:13:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:13:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-08818760efae049a6'))
+2021-09-09 17:13:42 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-08818760efae049a6'))
+2021-09-09 17:13:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:13:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:13:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:13:43 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:13:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:14:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 17:14:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 17:15:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:15:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:15:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:15:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:15:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:15:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:15:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-07ca421c29444c346'))
+2021-09-09 17:15:19 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-07ca421c29444c346'))
+2021-09-09 17:15:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:15:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:15:20 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-09 17:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+PASSED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:15:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 17:15:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 17:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:16:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:16:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:16:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e576ca5ad00fc8d3'))
+2021-09-09 17:16:37 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e576ca5ad00fc8d3'))
+2021-09-09 17:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:16:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:16:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:17:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 17:17:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 17:17:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:17:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:17:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:17:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:17:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-024964564a701674c'))
+2021-09-09 17:17:49 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-024964564a701674c'))
+2021-09-09 17:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:17:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:17:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 17:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:18:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 17:18:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 17:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:19:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:19:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:19:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:19:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:19:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:19:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0de8d7b7e6c19728f'))
+2021-09-09 17:19:17 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0de8d7b7e6c19728f'))
+2021-09-09 17:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:19:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:19:18 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:19:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:19:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:19:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:20:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 17:20:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 17:20:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:20:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:20:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:20:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0f1035c452b4fd230'))
+2021-09-09 17:20:49 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0f1035c452b4fd230'))
+2021-09-09 17:20:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:20:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:20:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:20:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:20:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:20:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:20:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:21:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 17:21:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 17:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:22:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:22:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:22:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e90c76e612f827fb'))
+2021-09-09 17:22:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e90c76e612f827fb'))
+2021-09-09 17:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:22:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:22:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:22:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:22:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:22:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:22:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:22:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:23:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 17:23:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 17:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:24:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:24:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:24:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0d4eaf839a5cda3a4'))
+2021-09-09 17:24:17 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0d4eaf839a5cda3a4'))
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:24:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:24:17 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:24:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:24:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 17:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-09 17:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:25:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 17:25:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 17:25:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:25:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:25:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:25:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:25:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04aec9726cb4cd905'))
+2021-09-09 17:26:00 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04aec9726cb4cd905'))
+2021-09-09 17:26:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:26:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:26:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:26:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:26:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:26:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:26:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:26:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 17:26:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 17:27:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:27:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:27:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:27:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:27:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:27:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:27:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:27:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-045f32d3024bd711a'))
+2021-09-09 17:27:26 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-045f32d3024bd711a'))
+2021-09-09 17:27:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:27:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:27:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:27:26 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:27:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-09 17:27:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:28:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 17:28:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 17:28:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:28:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:28:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:28:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:28:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:28:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0f46116821cb747d5'))
+2021-09-09 17:28:52 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0f46116821cb747d5'))
+2021-09-09 17:28:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:28:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:28:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:28:53 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:28:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:29:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 17:29:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 17:30:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:30:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:30:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:30:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:30:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b4f219733166aaef'))
+2021-09-09 17:30:31 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b4f219733166aaef'))
+2021-09-09 17:30:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:30:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:30:32 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-09 17:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-09 17:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:31:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 17:31:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 17:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:31:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:31:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:31:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:31:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:31:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:31:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04e2e4f9e29ce6206'))
+2021-09-09 17:32:29 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04e2e4f9e29ce6206'))
+2021-09-09 17:32:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:32:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:32:30 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:32:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:32:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:33:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 17:33:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 17:33:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:33:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:33:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:33:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:33:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0d0d9f61c15f8f1df'))
+2021-09-09 17:33:56 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0d0d9f61c15f8f1df'))
+2021-09-09 17:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:33:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:33:56 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:34:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 17:34:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 17:35:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:35:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:35:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:35:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01ff2d0e6b5045fb0'))
+2021-09-09 17:35:22 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01ff2d0e6b5045fb0'))
+2021-09-09 17:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:35:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:35:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:36:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 17:36:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 17:36:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:36:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:36:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:36:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-026a9a503a60894dd'))
+2021-09-09 17:36:58 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-026a9a503a60894dd'))
+2021-09-09 17:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:36:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:36:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:37:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 17:37:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 17:38:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:38:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:38:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:38:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:38:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:38:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:38:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-08ee1ca2939dcd0d0'))
+2021-09-09 17:38:11 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-08ee1ca2939dcd0d0'))
+2021-09-09 17:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:38:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:38:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:38:12 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:38:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:38:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 17:38:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 17:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:39:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:39:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:39:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01007ca0f1a89f4fb'))
+2021-09-09 17:39:48 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01007ca0f1a89f4fb'))
+2021-09-09 17:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:39:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:39:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 17:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-09 17:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:40:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 17:40:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 17:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:41:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:41:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:41:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:41:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e4ea89d27f4a958d'))
+2021-09-09 17:41:22 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0e4ea89d27f4a958d'))
+2021-09-09 17:41:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:44:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:44:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:44:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:44:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 17:44:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 17:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:45:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:45:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:45:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:45:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01d062d5d6f7315fd'))
+2021-09-09 17:45:37 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01d062d5d6f7315fd'))
+2021-09-09 17:45:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:45:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:45:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:45:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:45:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:50:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:50:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:50:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:51:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 17:51:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 17:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:52:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:52:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:52:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0c870eb4e2083fe46'))
+2021-09-09 17:52:23 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0c870eb4e2083fe46'))
+2021-09-09 17:52:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:52:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:52:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:52:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:52:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:53:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 17:53:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 17:53:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:53:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:53:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:53:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:54:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b43b97b9de622454'))
+2021-09-09 17:54:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0b43b97b9de622454'))
+2021-09-09 17:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:54:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:54:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:54:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 17:54:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 17:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:55:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:55:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:55:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0931c9c032aa50472'))
+2021-09-09 17:55:21 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0931c9c032aa50472'))
+2021-09-09 17:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:55:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:55:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:56:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 17:56:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 17:56:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:56:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:56:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:56:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:56:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-045d9d266e44bcb2f'))
+2021-09-09 17:57:01 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-045d9d266e44bcb2f'))
+2021-09-09 17:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:57:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 17:57:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 17:58:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:58:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:58:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:58:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:58:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01242f3cbf7dd6995'))
+2021-09-09 17:58:37 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-01242f3cbf7dd6995'))
+2021-09-09 17:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:58:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 17:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 17:58:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 17:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 17:59:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 17:59:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 17:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:59:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:59:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 17:59:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 17:59:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 17:59:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-075ef4cc3681cc63f'))
+2021-09-09 18:00:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-075ef4cc3681cc63f'))
+2021-09-09 18:00:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:00:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:00:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:00:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:00:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:00:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:01:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:01:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:01:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:01:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-00c203924eff18c79'))
+2021-09-09 18:01:21 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-00c203924eff18c79'))
+2021-09-09 18:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:01:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:01:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-09 18:01:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 18:01:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 18:01:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 18:01:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 18:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 18:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-09 18:01:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 18:01:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 18:01:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 18:01:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 18:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 18:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 18:01:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 18:01:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 18:01:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 18:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:01:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 18:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:02:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:02:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:02:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:02:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:02:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:02:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:02:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-058a21aa6e6473232'))
+2021-09-09 18:02:42 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-058a21aa6e6473232'))
+2021-09-09 18:02:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:02:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:02:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:02:42 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:02:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 18:02:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 18:02:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 18:02:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 18:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 18:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 18:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-09 18:02:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 18:02:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 18:02:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:02:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 18:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 18:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 18:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-09 18:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 18:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 18:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 18:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:03:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:04:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:04:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:04:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:04:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0a3e331554266db0e'))
+2021-09-09 18:04:17 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0a3e331554266db0e'))
+2021-09-09 18:04:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:04:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:04:18 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 18:04:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 18:04:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 18:04:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 18:04:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 18:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 18:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 18:04:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 18:04:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 18:04:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 18:04:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 18:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 18:04:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 18:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:04:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 18:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 18:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 18:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:05:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:05:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 18:05:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:05:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:05:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:06:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-063a3a3078ee986b4'))
+2021-09-09 18:06:02 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-063a3a3078ee986b4'))
+2021-09-09 18:06:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:06:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:06:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:06:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:06:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 18:06:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 18:06:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 18:06:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 18:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 18:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 18:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 18:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 18:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 18:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 18:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 18:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-09 18:06:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 18:06:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 18:06:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:06:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 18:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 18:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 18:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 18:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:06:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 18:06:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 18:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:07:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:07:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:07:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:07:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-05a96b079b47bab5a'))
+2021-09-09 18:07:37 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-05a96b079b47bab5a'))
+2021-09-09 18:07:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:07:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:07:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:07:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:08:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:08:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:08:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:08:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:08:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:09:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-02271771236bc309b'))
+2021-09-09 18:09:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-02271771236bc309b'))
+2021-09-09 18:09:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:09:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:09:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:09:04 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4d77e153-58eb-4ba7-8974-229f19bfb1ea.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 18:09:04 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:09:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:09:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:11:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:11:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:11:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:11:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:11:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:12:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 18:12:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 18:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:13:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:13:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:13:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0af2a1884d5c1ebb2'))
+2021-09-09 18:13:28 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-0af2a1884d5c1ebb2'))
+2021-09-09 18:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:13:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:13:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:13:29 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/3bcab609-641d-4048-ac84-7cd3fb72f570.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 18:13:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:13:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:13:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:14:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:14:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:14:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:14:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:15:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 18:15:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 18:16:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:16:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:16:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:16:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:16:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04be12a818ab65a00'))
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-04be12a818ab65a00'))
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:16:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:16:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 18:16:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 18:17:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:17:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:17:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:17:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-02e5a4cf7cdbbd641'))
+2021-09-09 18:17:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-02e5a4cf7cdbbd641'))
+2021-09-09 18:17:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:17:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:17:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:17:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:17:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-09 18:17:54 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:18:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:18:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:18:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:18:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:18:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-002694811ee10ed8a'))
+2021-09-09 18:18:52 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-002694811ee10ed8a'))
+2021-09-09 18:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:18:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:18:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 18:18:53 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:18:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:18:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:18:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:19:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:19:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:19:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:20:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:20:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 18:20:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 18:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/124b5dec-2e80-4fc7-89e3-9b79e9d03430.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-09 18:20:06 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:20:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:20:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:20:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:21:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:21:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:21:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:21:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-09 18:21:50 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:21:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:21:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:22:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:22:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:22:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-089ced9d29767eb8c'))
+2021-09-09 18:22:54 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-089ced9d29767eb8c'))
+2021-09-09 18:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:22:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:22:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:22:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 18:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/d47a6563-c61d-4f3a-a9b3-23c409f38042.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 18:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-09 18:22:55 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:23:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:23:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:23:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:23:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:24:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:24:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:24:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:24:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:24:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:24:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-09 18:24:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:24:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:24:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=None
+2021-09-09 18:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:25:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:25:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:25:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-00485fb24ee56fe48'))
+2021-09-09 18:25:47 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-00485fb24ee56fe48'))
+2021-09-09 18:25:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:25:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:25:48 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:25:48 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 18:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4dd9edb6-758f-481f-8a94-20c380ffc9a3.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 18:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 18:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 18:25:49 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:25:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:25:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:26:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:26:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:26:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:27:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:27:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 18:27:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08c4b9461c8e92d12
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 18:27:33 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-09 18:28:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:28:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:28:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:28:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-09 18:28:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:28:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-05c7abb92974f8065'))
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f747dfeafd0>, instance=ec2.Instance(id='i-05c7abb92974f8065'))
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:28:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: ami-08c4b9461c8e92d12
+
+------------------------------ live log teardown -------------------------------
+2021-09-09 18:29:00 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-08c4b9461c8e92d12
+
+
+=================================== FAILURES ===================================
+____ TestPasswordListString.test_random_passwords_emitted_to_serial_console ____
+
+self = <test_set_password.TestPasswordListString object at 0x7f747d6d1b38>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f747d6a7550>
+
+    def test_random_passwords_emitted_to_serial_console(self, class_client):
+        """We should emit passwords to the serial console. (LP: #1918303)"""
+        try:
+            console_log = class_client.instance.console_log()
+        except NotImplementedError:
+            # Assume that an exception here means that we can't use the console
+            # log
+            pytest.skip("NotImplementedError when requesting console log")
+>       assert "dick:" in console_log
+E       assert 'dick:' in "No Console Output [ec2.Instance(id='i-01d062d5d6f7315fd')]"
+
+tests/integration_tests/modules/test_set_password.py:140: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 17:45:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console
+====== 1 failed, 120 passed, 28 skipped, 2 warnings in 6573.73s (1:49:33) ======

--- a/21.3-1/integration_tests/ec2_bionic_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/ec2_bionic_integration_tests_rerun.txt
@@ -1,0 +1,425 @@
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 18 items
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:36:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-10 04:36:15 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-10 04:36:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-10 04:36:21 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-10 04:36:21 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+2021-09-10 04:36:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-08853a6c93b952e8b
+user_data=None
+2021-09-10 04:36:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:37:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-10 04:37:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 04:37:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-0ef7a1c104f2c0e8e'))
+2021-09-10 04:39:40 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-0ef7a1c104f2c0e8e'))
+2021-09-10 04:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-10 04:39:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-10 04:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 04:39:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-10 04:39:45 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 04:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 04:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 04:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 04:40:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:40:21 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:40:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 04:40:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 04:40:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 04:40:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 04:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:43:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-10 04:43:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 04:43:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-079794d1571d5b7dc
+2021-09-10 04:44:41 INFO      integration_testing:instances.py:114 Created new image: ami-079794d1571d5b7dc
+Done with environment setup
+2021-09-10 04:45:26 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=ami-079794d1571d5b7dc
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 04:45:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-079794d1571d5b7dc
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 04:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:46:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-10 04:46:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 04:46:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-08e420e3b8c2d56d8'))
+2021-09-10 04:47:24 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-08e420e3b8c2d56d8'))
+2021-09-10 04:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:47:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 04:47:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:47:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:50:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ami-079794d1571d5b7dc
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 04:50:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-079794d1571d5b7dc
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 04:51:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 04:51:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-10 04:51:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 04:51:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-0461aa35941a77e3a'))
+2021-09-10 04:52:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f11533c2208>, instance=ec2.Instance(id='i-0461aa35941a77e3a'))
+2021-09-10 04:52:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:52:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-10 04:52:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 04:52:43 INFO      integration_testing:clouds.py:183 image serial: 20210907
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:52:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+--------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
+2021-09-10 04:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSEDDeleting snapshot image created for this testrun: ami-079794d1571d5b7dc
+
+------------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------------
+2021-09-10 04:56:10 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-079794d1571d5b7dc
+
+
+================================================================================================= warnings summary ==================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+==================================================================================== 18 passed, 2 warnings in 1195.55s (0:19:55) ====================================================================================

--- a/21.3-1/integration_tests/ec2_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/ec2_focal_integration_tests.txt
@@ -1,0 +1,3983 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:29:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 18:29:04 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 18:29:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-09 18:29:10 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-09 18:29:10 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+2021-09-09 18:29:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+2021-09-09 18:29:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:29:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:29:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:29:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:29:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:29:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e3491c8031af7582'))
+2021-09-09 18:30:01 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e3491c8031af7582'))
+2021-09-09 18:30:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:30:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:30:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:30:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 18:30:01 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 18:30:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 18:30:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 18:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 18:30:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:30:23 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:30:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 18:30:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 18:30:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 18:30:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 18:32:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:33:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:33:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:33:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:33:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-080eac9f29417ccbe
+2021-09-09 18:33:08 INFO      integration_testing:instances.py:114 Created new image: ami-080eac9f29417ccbe
+Done with environment setup
+2021-09-09 18:33:39 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 18:33:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 18:34:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:34:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:34:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:34:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c03fa96849c43e5f'))
+2021-09-09 18:34:39 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c03fa96849c43e5f'))
+2021-09-09 18:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:34:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:34:40 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:34:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-09 18:34:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:35:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:35:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 18:35:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-09 18:35:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:35:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:35:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:35:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:35:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c6de38d66715c92b'))
+2021-09-09 18:35:53 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c6de38d66715c92b'))
+2021-09-09 18:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:35:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:35:54 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 18:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 18:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 18:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 18:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-09 18:35:56 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 18:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 18:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 18:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 18:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:36:15 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-09 18:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-09 18:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-09 18:36:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:36:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:37:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:37:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:37:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-09 18:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-09 18:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-09 18:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-09 18:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-09 18:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 2.386s (kernel) + 19.174s (userspace) = 21.560s 
+graphical.target reached after 18.428s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.291s (kernel) + 17.730s (userspace) = 20.021s 
+graphical.target reached after 16.804s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.083s snapd.seeded.service                  
+2.651s snapd.apparmor.service                
+2.412s cloud-init-local.service              
+1.766s snapd.service                         
+1.452s lvm2-monitor.service                  
+1.302s cloud-config.service                  
+1.295s systemd-networkd-wait-online.service  
+1.237s cloud-init.service                    
+1.222s dev-xvda1.device                      
+ 993ms systemd-udev-settle.service           
+=== `systemd-analyze blame` after (first 10 lines):
+7.922s snap.lxd.activate.service             
+5.176s snapd.service                         
+2.402s cloud-config.service                  
+1.768s systemd-networkd-wait-online.service  
+1.724s cloud-init-local.service              
+1.686s cloud-init.service                    
+1.440s ec2-instance-connect.service          
+1.305s lvm2-monitor.service                  
+1.127s dev-xvda1.device                      
+ 965ms networkd-dispatcher.service           
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.85500 seconds
+Finished stage: (init-network) 00.76700 seconds
+Finished stage: (modules-config) 00.78500 seconds
+Finished stage: (modules-final) 00.19500 seconds
+Total Time: 2.60200 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.57500 seconds
+Finished stage: (init-network) 01.18800 seconds
+Finished stage: (modules-config) 00.55800 seconds
+Finished stage: (modules-final) 00.37500 seconds
+Total Time: 2.69600 seconds
+Finished stage: (init-network) 00.19800 seconds
+Total Time: 0.19800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.51400s (modules-config/config-grub-dpkg)
+     00.40200s (init-local/search-Ec2Local)
+     00.29100s (init-network/config-ssh)
+     00.19800s (modules-config/config-apt-configure)
+     00.11400s (init-network/config-growpart)
+     00.11100s (modules-final/config-keys-to-console)
+     00.09300s (init-network/config-users-groups)
+     00.06800s (init-network/config-resizefs)
+     00.03900s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.74600s (init-network/config-ssh)
+     00.31700s (init-local/search-Ec2Local)
+     00.31100s (modules-config/config-grub-dpkg)
+     00.20500s (modules-final/config-keys-to-console)
+     00.12800s (init-network/config-growpart)
+     00.08500s (modules-config/config-locale)
+     00.08300s (modules-config/config-apt-configure)
+     00.07900s (modules-final/config-ssh-authkey-fingerprints)
+     00.06600s (init-network/config-resizefs)
+
+2021-09-09 18:37:12 INFO      integration_testing.test_upgrade:test_upgrade.py:149 
+=== `systemd-analyze` before:
+Startup finished in 2.386s (kernel) + 19.174s (userspace) = 21.560s 
+graphical.target reached after 18.428s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.291s (kernel) + 17.730s (userspace) = 20.021s 
+graphical.target reached after 16.804s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.083s snapd.seeded.service                  
+2.651s snapd.apparmor.service                
+2.412s cloud-init-local.service              
+1.766s snapd.service                         
+1.452s lvm2-monitor.service                  
+1.302s cloud-config.service                  
+1.295s systemd-networkd-wait-online.service  
+1.237s cloud-init.service                    
+1.222s dev-xvda1.device                      
+ 993ms systemd-udev-settle.service           
+=== `systemd-analyze blame` after (first 10 lines):
+7.922s snap.lxd.activate.service             
+5.176s snapd.service                         
+2.402s cloud-config.service                  
+1.768s systemd-networkd-wait-online.service  
+1.724s cloud-init-local.service              
+1.686s cloud-init.service                    
+1.440s ec2-instance-connect.service          
+1.305s lvm2-monitor.service                  
+1.127s dev-xvda1.device                      
+ 965ms networkd-dispatcher.service           
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.85500 seconds
+Finished stage: (init-network) 00.76700 seconds
+Finished stage: (modules-config) 00.78500 seconds
+Finished stage: (modules-final) 00.19500 seconds
+Total Time: 2.60200 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.57500 seconds
+Finished stage: (init-network) 01.18800 seconds
+Finished stage: (modules-config) 00.55800 seconds
+Finished stage: (modules-final) 00.37500 seconds
+Total Time: 2.69600 seconds
+Finished stage: (init-network) 00.19800 seconds
+Total Time: 0.19800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.51400s (modules-config/config-grub-dpkg)
+     00.40200s (init-local/search-Ec2Local)
+     00.29100s (init-network/config-ssh)
+     00.19800s (modules-config/config-apt-configure)
+     00.11400s (init-network/config-growpart)
+     00.11100s (modules-final/config-keys-to-console)
+     00.09300s (init-network/config-users-groups)
+     00.06800s (init-network/config-resizefs)
+     00.03900s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.74600s (init-network/config-ssh)
+     00.31700s (init-local/search-Ec2Local)
+     00.31100s (modules-config/config-grub-dpkg)
+     00.20500s (modules-final/config-keys-to-console)
+     00.12800s (init-network/config-growpart)
+     00.08500s (modules-config/config-locale)
+     00.08300s (modules-config/config-apt-configure)
+     00.07900s (modules-final/config-ssh-authkey-fingerprints)
+     00.06600s (init-network/config-resizefs)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:37:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:37:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+2021-09-09 18:38:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:38:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:38:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:38:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:38:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:38:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:38:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:38:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-085c900bbdd0b2cf7'))
+2021-09-09 18:38:52 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-085c900bbdd0b2cf7'))
+2021-09-09 18:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:38:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-09 18:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:38:53 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-09 18:38:53 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-09 18:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-09 18:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-09 18:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-09 18:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:39:11 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-09 18:39:11 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:39:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:40:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:40:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:40:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:40:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:40:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:40:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:41:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 18:41:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-09 18:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:41:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:41:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:41:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:41:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0cb61208353afd0d7'))
+2021-09-09 18:41:58 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0cb61208353afd0d7'))
+2021-09-09 18:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:41:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:41:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:42:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 18:42:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-09 18:43:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:43:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:43:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:43:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0224539d20ee8d2ce'))
+2021-09-09 18:43:31 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0224539d20ee8d2ce'))
+2021-09-09 18:43:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:43:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:43:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:43:32 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:43:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:44:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 18:44:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-09 18:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:44:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:44:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:44:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0a0382a305795b635'))
+2021-09-09 18:45:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0a0382a305795b635'))
+2021-09-09 18:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:45:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:45:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:45:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 18:45:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-09 18:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:46:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:46:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:46:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-086d964539335d121'))
+2021-09-09 18:46:21 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-086d964539335d121'))
+2021-09-09 18:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:46:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:46:21 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 18:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-09 18:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:47:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 18:47:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 18:47:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:47:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:47:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-066598bd098dac222'))
+2021-09-09 18:47:52 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-066598bd098dac222'))
+2021-09-09 18:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:47:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:47:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-09 18:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-09 18:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 18:47:53 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 18:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:48:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:48:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:48:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 18:48:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 18:48:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-09 18:48:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:49:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 18:49:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-09 18:50:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:50:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:50:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:50:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-00f5f375f58462067'))
+2021-09-09 18:50:46 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-00f5f375f58462067'))
+2021-09-09 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:50:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-09 18:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:51:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 18:51:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-09 18:52:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:52:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:52:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:52:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:52:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:52:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:52:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:52:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03aea34d613fe5501'))
+2021-09-09 18:52:35 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03aea34d613fe5501'))
+2021-09-09 18:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:52:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:52:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:53:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 18:53:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-09 18:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:54:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:54:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:54:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c1bc73aad80b8c7e'))
+2021-09-09 18:54:36 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c1bc73aad80b8c7e'))
+2021-09-09 18:54:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:54:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:54:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:54:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:54:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:55:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 18:55:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-09 18:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:55:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:55:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:55:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-04510194d3514f2e4'))
+2021-09-09 18:55:53 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-04510194d3514f2e4'))
+2021-09-09 18:55:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:55:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:55:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:55:54 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:55:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:55:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:55:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:56:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 18:56:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-09 18:57:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:57:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:57:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:57:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0856317a5bcf9275b'))
+2021-09-09 18:57:25 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0856317a5bcf9275b'))
+2021-09-09 18:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:57:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:57:26 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:57:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:58:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 18:58:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 18:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:58:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:58:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 18:58:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 18:58:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 18:58:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b673b54d7586a2d2'))
+2021-09-09 18:58:57 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b673b54d7586a2d2'))
+2021-09-09 18:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:58:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 18:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 18:58:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 18:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 18:59:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 18:59:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-09 19:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:00:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:00:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:00:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:00:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:00:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c2aec33cf6be927c'))
+2021-09-09 19:00:34 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c2aec33cf6be927c'))
+2021-09-09 19:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:00:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:00:34 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:01:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 19:01:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-09 19:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:01:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:01:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:01:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:01:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:01:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-08a46993857b6ea5a'))
+2021-09-09 19:02:05 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-08a46993857b6ea5a'))
+2021-09-09 19:02:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:02:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:02:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-09 19:02:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-09 19:02:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:02:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+PASSED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:02:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 19:02:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-09 19:03:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:03:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:03:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:03:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e2a05a43515d9986'))
+2021-09-09 19:03:44 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e2a05a43515d9986'))
+2021-09-09 19:03:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:03:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:03:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:03:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:03:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:04:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 19:04:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-09 19:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:05:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:05:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:05:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-07eee98834933cea0'))
+2021-09-09 19:05:09 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-07eee98834933cea0'))
+2021-09-09 19:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:05:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:05:09 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 19:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:05:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 19:05:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-09 19:06:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:06:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:06:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:06:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-031be283919299f82'))
+2021-09-09 19:06:19 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-031be283919299f82'))
+2021-09-09 19:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:06:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:06:20 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:06:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:06:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:06:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:07:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 19:07:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-09 19:07:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:07:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:07:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:07:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:07:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:07:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-01b8022a9dc52336d'))
+2021-09-09 19:07:47 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-01b8022a9dc52336d'))
+2021-09-09 19:07:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:07:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:07:48 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:07:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:07:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:08:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 19:08:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-09 19:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:09:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:09:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:09:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:09:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0ab2ebe1a8cac10a1'))
+2021-09-09 19:09:16 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0ab2ebe1a8cac10a1'))
+2021-09-09 19:09:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:09:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:10:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 19:10:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-09 19:10:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:10:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:10:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:10:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0970b9404ddcd904b'))
+2021-09-09 19:11:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0970b9404ddcd904b'))
+2021-09-09 19:11:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:11:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:11:05 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:11:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:11:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-09 19:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:11:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 19:11:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-09 19:12:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:12:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:12:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:12:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:12:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0dd33becf08411685'))
+2021-09-09 19:12:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0dd33becf08411685'))
+2021-09-09 19:12:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:12:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:12:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:12:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:12:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:12:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:12:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:12:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:13:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 19:13:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-09 19:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:13:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:14:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:14:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:14:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03352b4ec649a6c2a'))
+2021-09-09 19:14:35 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03352b4ec649a6c2a'))
+2021-09-09 19:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:14:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:14:35 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-09 19:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:15:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 19:15:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-09 19:16:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:16:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:16:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:16:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c80f6081fdd554c4'))
+2021-09-09 19:16:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c80f6081fdd554c4'))
+2021-09-09 19:16:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:16:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:16:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:16:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 19:16:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-09 19:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:17:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:17:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:17:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:17:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0614dcc355383ed07'))
+2021-09-09 19:18:05 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0614dcc355383ed07'))
+2021-09-09 19:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:18:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:18:06 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-09 19:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-09 19:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:18:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 19:18:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-09 19:19:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:19:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:19:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:19:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:19:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:19:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0a9f5ee0b6d2f19c8'))
+2021-09-09 19:20:10 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0a9f5ee0b6d2f19c8'))
+2021-09-09 19:20:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:20:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:20:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:20:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:20:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:20:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 19:20:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-09 19:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:21:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:21:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:21:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:21:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c49b8b60569a27bf'))
+2021-09-09 19:21:37 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c49b8b60569a27bf'))
+2021-09-09 19:21:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:21:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:21:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:22:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 19:22:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-09 19:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:22:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:22:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:22:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-058e02e98c0c21215'))
+2021-09-09 19:23:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-058e02e98c0c21215'))
+2021-09-09 19:23:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:23:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:23:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 19:24:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 19:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:24:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:24:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:24:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e12418974cfd82a5'))
+2021-09-09 19:24:45 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e12418974cfd82a5'))
+2021-09-09 19:24:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:24:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:24:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:24:46 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:24:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:25:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 19:25:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-09 19:26:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:26:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:26:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:26:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:26:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:26:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e7513907fcfcd2c8'))
+2021-09-09 19:26:29 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0e7513907fcfcd2c8'))
+2021-09-09 19:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:26:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:26:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:27:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 19:27:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-09 19:27:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:27:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:27:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:27:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-08073609f91baa2c1'))
+2021-09-09 19:27:51 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-08073609f91baa2c1'))
+2021-09-09 19:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:27:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:27:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-09 19:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-09 19:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:28:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 19:28:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 19:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:29:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:29:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:29:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f5b6c7fe0634441a'))
+2021-09-09 19:29:27 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f5b6c7fe0634441a'))
+2021-09-09 19:29:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:34:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-09 19:50:39 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:50:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:50:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-09 19:50:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:50:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:50:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:51:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 19:51:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-09 19:51:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:51:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:51:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:51:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-036351347cdf5c63c'))
+2021-09-09 19:52:02 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-036351347cdf5c63c'))
+2021-09-09 19:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:57:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:57:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:57:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:57:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 19:57:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-09 19:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 19:58:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 19:58:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 19:58:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0eec3821fc077a76f'))
+2021-09-09 19:59:11 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0eec3821fc077a76f'))
+2021-09-09 19:59:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:59:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 19:59:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 19:59:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 19:59:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 19:59:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 19:59:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-09 20:00:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:00:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:00:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:00:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:00:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:00:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-041278492ac2fc790'))
+2021-09-09 20:00:41 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-041278492ac2fc790'))
+2021-09-09 20:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:00:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:00:42 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:01:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 20:01:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-09 20:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:02:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:02:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:02:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-04d732db2638350fd'))
+2021-09-09 20:02:23 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-04d732db2638350fd'))
+2021-09-09 20:02:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:02:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:02:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:02:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 20:02:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-09 20:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:03:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:03:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:03:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:03:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:03:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c099fe1c85cbe0d0'))
+2021-09-09 20:03:35 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0c099fe1c85cbe0d0'))
+2021-09-09 20:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:03:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:04:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 20:04:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-09 20:04:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:05:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:05:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:05:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:05:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-093739fd745742b7e'))
+2021-09-09 20:05:13 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-093739fd745742b7e'))
+2021-09-09 20:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:05:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:05:14 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 20:06:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-09 20:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:06:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:06:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:06:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f7645188632fca53'))
+2021-09-09 20:06:54 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f7645188632fca53'))
+2021-09-09 20:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:06:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:07:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:07:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:08:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:08:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b2384b4a52f213fe'))
+2021-09-09 20:08:20 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b2384b4a52f213fe'))
+2021-09-09 20:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:08:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:08:21 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-09 20:08:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 20:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 20:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-09 20:08:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-09 20:08:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 20:08:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 20:08:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:08:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 20:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 20:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 20:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-09 20:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 20:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 20:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 20:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:09:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:09:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:09:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:09:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:09:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:09:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:09:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03acc2377b202323a'))
+2021-09-09 20:10:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-03acc2377b202323a'))
+2021-09-09 20:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:10:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:10:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 20:10:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 20:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 20:10:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 20:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 20:10:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 20:10:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 20:10:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:10:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:10:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 20:10:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 20:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:10:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:10:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:11:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:11:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:11:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:11:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:11:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:11:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0be7c1f67c2868cb8'))
+2021-09-09 20:11:42 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0be7c1f67c2868cb8'))
+2021-09-09 20:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:11:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:11:42 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 20:11:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 20:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 20:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-09 20:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 20:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 20:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 20:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 20:11:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 20:11:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 20:11:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 20:11:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 20:11:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 20:11:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-09 20:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 20:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 20:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 20:11:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 20:11:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 20:11:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 20:11:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 20:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 20:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 20:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-09 20:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 20:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 20:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 20:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-09 20:11:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 20:11:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 20:11:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:11:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 20:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 20:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 20:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:12:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:12:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-09 20:13:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:13:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:13:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:13:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:13:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:13:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-01b085601583c61bb'))
+2021-09-09 20:13:20 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-01b085601583c61bb'))
+2021-09-09 20:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:13:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:13:20 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-09 20:13:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-09 20:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-09 20:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 20:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-09 20:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-09 20:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-09 20:13:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-09 20:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-09 20:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 20:13:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-09 20:13:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-09 20:13:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-09 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-09 20:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-09 20:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-09 20:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-09 20:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-09 20:13:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:13:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-09 20:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-09 20:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-09 20:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-09 20:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:14:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 20:14:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-09 20:15:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:15:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:15:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:15:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-059aa6edb763e5652'))
+2021-09-09 20:15:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-059aa6edb763e5652'))
+2021-09-09 20:15:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:15:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:15:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:15:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:15:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:15:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:15:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:16:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:16:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:16:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0718951fad733e0e9'))
+2021-09-09 20:16:28 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0718951fad733e0e9'))
+2021-09-09 20:16:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:16:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:16:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:16:29 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:16:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 20:16:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 20:16:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 20:16:30 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 20:16:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/9cd63b2e-ae6a-46a2-a545-aa2b8bf6127d.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 20:16:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 20:16:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:16:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:16:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:16:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:17:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:17:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:17:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:17:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:18:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 20:18:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-09 20:18:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:18:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:19:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:19:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-00624f64a152ecdb9'))
+2021-09-09 20:19:06 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-00624f64a152ecdb9'))
+2021-09-09 20:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:19:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:19:07 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 20:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-09 20:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-09 20:19:07 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-09 20:19:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/dbaf7485-8beb-4e7d-ba67-142eff4c789e.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-09 20:19:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 20:19:08 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:19:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:19:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:19:13 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-09 20:19:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:19:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:19:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:19:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:19:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:20:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:20:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 20:20:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 20:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:21:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:21:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:21:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:21:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:21:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0ebe3583c96e5cd81'))
+2021-09-09 20:21:32 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0ebe3583c96e5cd81'))
+2021-09-09 20:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:21:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:21:32 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 20:22:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-09 20:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:22:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:22:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:22:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-02ab866160bec3243'))
+2021-09-09 20:22:58 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-02ab866160bec3243'))
+2021-09-09 20:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:22:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:22:58 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:22:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:23:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:24:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:24:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:24:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0432e19910fd1a956'))
+2021-09-09 20:24:33 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0432e19910fd1a956'))
+2021-09-09 20:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:24:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:24:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 20:24:33 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:24:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:24:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:25:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:25:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:25:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:25:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:25:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-09 20:25:45 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 20:25:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b55e775f-e016-45de-aa9d-e6a43bf15a21.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-09 20:25:46 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:25:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:25:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:25:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:25:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:25:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:26:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:26:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:26:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:26:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:27:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:27:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:27:44 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-09 20:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:28:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:28:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-02eb1e4e7892dd66a'))
+2021-09-09 20:28:30 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-02eb1e4e7892dd66a'))
+2021-09-09 20:28:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:28:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:28:31 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:28:31 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 20:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/d57862af-8bdd-477a-9a60-332207c1f20f.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 20:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-09 20:28:31 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:28:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:28:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:29:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:29:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:29:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:29:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:29:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:29:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-09 20:30:30 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:30:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:30:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=None
+2021-09-09 20:31:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:31:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:31:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f248f5663fa0f2f5'))
+2021-09-09 20:31:15 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0f248f5663fa0f2f5'))
+2021-09-09 20:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:31:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:31:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:31:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-09 20:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/dc4ad920-0fb9-4f30-892c-076dc9bfab07.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-09 20:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-09 20:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-09 20:31:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-09 20:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:31:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:31:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:32:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:32:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:32:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-09 20:32:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-09 20:32:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-09 20:32:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:32:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 20:32:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-080eac9f29417ccbe
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-09 20:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:33:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-09 20:33:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-09 20:33:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-09 20:33:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b6850000266ab7b5'))
+2021-09-09 20:33:39 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f8c898aa898>, instance=ec2.Instance(id='i-0b6850000266ab7b5'))
+2021-09-09 20:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:33:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-09 20:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-09 20:33:39 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:33:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:33:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:33:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-09 20:33:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-09 20:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: ami-080eac9f29417ccbe
+
+------------------------------ live log teardown -------------------------------
+2021-09-09 20:34:26 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-080eac9f29417ccbe
+
+
+=================================== FAILURES ===================================
+_______ TestPasswordList.test_random_passwords_emitted_to_serial_console _______
+
+self = <test_set_password.TestPasswordList object at 0x7f8c87d14ba8>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f8c87d17d68>
+
+    def test_random_passwords_emitted_to_serial_console(self, class_client):
+        """We should emit passwords to the serial console. (LP: #1918303)"""
+        try:
+            console_log = class_client.instance.console_log()
+        except NotImplementedError:
+            # Assume that an exception here means that we can't use the console
+            # log
+            pytest.skip("NotImplementedError when requesting console log")
+>       assert "dick:" in console_log
+E       assert 'dick:' in "No Console Output [ec2.Instance(id='i-0f5b6c7fe0634441a')]"
+
+tests/integration_tests/modules/test_set_password.py:140: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 19:29:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+____________ TestPasswordList.test_explicit_password_set_correctly _____________
+
+self = <test_set_password.TestPasswordList object at 0x7f8c87fc4d30>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f8c87d17d68>
+
+    def test_explicit_password_set_correctly(self, class_client):
+        """Test that an explicitly-specified password is set correctly."""
+>       shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+
+tests/integration_tests/modules/test_set_password.py:145: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/modules/test_set_password.py:77: in _fetch_and_parse_etc_shadow
+    shadow_content = class_client.read_from_file("/etc/shadow")
+tests/integration_tests/instances.py:87: in read_from_file
+    result = self.execute('cat {}'.format(remote_path))
+tests/integration_tests/instances.py:72: in execute
+    return self.instance.execute(command, use_sudo=use_sudo)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:508: in exec_command
+    chan = self._transport.open_session(timeout=timeout)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:879: in open_session
+    timeout=timeout,
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1006: in open_channel
+    raise e
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:2055: in run
+    ptype, m = self.packetizer.read_message()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:459: in read_message
+    header = self.read_all(self.__block_size_in, check_rekey=True)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.packet.Packetizer object at 0x7f8c87fc1940>, n = 16
+check_rekey = True
+
+    def read_all(self, n, check_rekey=False):
+        """
+        Read as close to N bytes as possible, blocking as long as necessary.
+    
+        :param int n: number of bytes to read
+        :return: the data read, as a `str`
+    
+        :raises:
+            ``EOFError`` -- if the socket was closed before all the bytes could
+            be read
+        """
+        out = bytes()
+        # handle over-reading from reading the banner line
+        if len(self.__remainder) > 0:
+            out = self.__remainder[:n]
+            self.__remainder = self.__remainder[n:]
+            n -= len(out)
+        while n > 0:
+            got_timeout = False
+            if self.handshake_timed_out():
+                raise EOFError()
+            try:
+>               x = self.__socket.recv(n)
+E               TimeoutError: [Errno 110] Connection timed out
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:301: TimeoutError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 19:34:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+------------------------------ Captured log call -------------------------------
+2021-09-09 19:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-09 19:50:39 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+____ TestPasswordListString.test_random_passwords_emitted_to_serial_console ____
+
+self = <test_set_password.TestPasswordListString object at 0x7f8c87d087f0>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f8c895ebb00>
+
+    def test_random_passwords_emitted_to_serial_console(self, class_client):
+        """We should emit passwords to the serial console. (LP: #1918303)"""
+        try:
+            console_log = class_client.instance.console_log()
+        except NotImplementedError:
+            # Assume that an exception here means that we can't use the console
+            # log
+            pytest.skip("NotImplementedError when requesting console log")
+>       assert "dick:" in console_log
+E       assert 'dick:' in "No Console Output [ec2.Instance(id='i-036351347cdf5c63c')]"
+
+tests/integration_tests/modules/test_set_password.py:140: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-09 19:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console
+====== 3 failed, 118 passed, 28 skipped, 2 warnings in 7522.70s (2:05:22) ======

--- a/21.3-1/integration_tests/ec2_focal_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/ec2_focal_integration_tests_rerun.txt
@@ -1,0 +1,267 @@
+correctly tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 3 items
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------
+2021-09-10 21:57:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-10 21:57:38 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-10 21:57:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-10 21:57:44 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-10 21:57:44 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+2021-09-10 21:57:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0a5a9780e8617afe7
+user_data=None
+2021-09-10 21:58:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 21:58:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-10 21:58:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 21:58:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-06ff29092c2eb0c29'))
+2021-09-10 21:58:39 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-06ff29092c2eb0c29'))
+2021-09-10 21:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-10 21:58:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-10 21:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 21:58:40 INFO      integration_testing:clouds.py:183 image serial: 20210907
+Installing proposed image
+2021-09-10 21:58:40 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 21:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 21:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 21:58:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 21:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 21:58:59 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 21:58:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 21:58:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 21:58:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 21:59:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 22:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 22:01:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 22:01:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-10 22:01:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 22:01:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-0e325e0e90251ef87
+2021-09-10 22:01:57 INFO      integration_testing:instances.py:114 Created new image: ami-0e325e0e90251ef87
+Done with environment setup
+2021-09-10 22:02:28 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=ami-0e325e0e90251ef87
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 22:02:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0e325e0e90251ef87
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 22:02:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 22:03:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-10 22:03:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 22:03:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-0ea52fe8d9d33f465'))
+2021-09-10 22:03:23 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-0ea52fe8d9d33f465'))
+2021-09-10 22:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 22:03:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 22:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 22:03:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------------
+2021-09-10 22:20:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
+2021-09-10 22:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------------
+2021-09-10 22:20:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=ami-0e325e0e90251ef87
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 22:20:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-0e325e0e90251ef87
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-10 22:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 22:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 22:21:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-10 22:21:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 22:21:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-0ebef15149835aeed'))
+2021-09-10 22:21:32 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f507e3f2550>, instance=ec2.Instance(id='i-0ebef15149835aeed'))
+2021-09-10 22:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 22:21:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-10 22:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210907
+2021-09-10 22:21:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+PASSEDDeleting snapshot image created for this testrun: ami-0e325e0e90251ef87
+
+------------------------------------------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------------------------------------------
+2021-09-10 22:38:44 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-0e325e0e90251ef87
+
+
+===================================================================================================================================== warnings summary =====================================================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+======================================================================================================================== 3 passed, 2 warnings in 2466.69s (0:41:06) ========================================================================================================================

--- a/21.3-1/integration_tests/ec2_hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/ec2_hirsute_integration_tests.txt
@@ -1,0 +1,4051 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 00:57:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 00:57:22 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 00:57:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-10 00:57:31 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-10 00:57:31 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-01e80d9e7b6daabcf
+2021-09-10 00:57:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-01e80d9e7b6daabcf
+2021-09-10 00:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 00:58:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 00:58:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 00:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 00:58:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 00:58:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 00:58:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bf78c72adaf1761a'))
+2021-09-10 00:58:27 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bf78c72adaf1761a'))
+2021-09-10 00:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 00:58:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 00:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 00:58:28 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-10 00:58:28 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 00:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 00:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 00:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 00:58:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 00:58:50 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 00:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 00:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 00:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 00:58:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 01:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:01:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:01:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:01:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:01:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-095f9094107504d99
+2021-09-10 01:01:36 INFO      integration_testing:instances.py:114 Created new image: ami-095f9094107504d99
+Done with environment setup
+2021-09-10 01:02:21 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 01:02:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 01:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:02:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:02:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:02:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:02:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:02:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0901e783ba5e2810a'))
+2021-09-10 01:03:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0901e783ba5e2810a'))
+2021-09-10 01:03:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:03:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:03:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:03:04 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:03:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-10 01:03:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:03:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:03:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ami-01e80d9e7b6daabcf
+2021-09-10 01:03:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ami-01e80d9e7b6daabcf
+2021-09-10 01:04:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:04:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:04:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:04:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:04:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:04:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:04:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:04:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0b983fcd3b86415fe'))
+2021-09-10 01:04:44 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0b983fcd3b86415fe'))
+2021-09-10 01:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 01:04:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 01:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:04:44 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-10 01:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 01:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-10 01:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-10 01:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 01:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-10 01:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-10 01:04:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-10 01:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-10 01:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-10 01:04:48 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 01:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 01:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 01:04:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 01:05:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:05:05 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:05:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 01:05:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-10 01:05:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-10 01:05:05 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 01:05:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:05:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:05:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:06:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:06:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:06:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:06:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 01:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-10 01:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-10 01:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 01:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-10 01:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-10 01:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 01:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-10 01:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-10 01:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-10 01:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-10 01:06:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 2.181s (kernel) + 21.578s (userspace) = 23.759s 
+graphical.target reached after 19.617s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.078s (kernel) + 13.982s (userspace) = 16.060s 
+graphical.target reached after 12.917s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.820s snapd.seeded.service
+2.724s snapd.apparmor.service
+2.577s cloud-init.service
+2.247s cloud-init-local.service
+2.007s systemd-networkd-wait-online.service
+1.879s snapd.service
+1.390s cloud-config.service
+1.291s lvm2-monitor.service
+1.009s pollinate.service
+1.008s dev-xvda1.device
+=== `systemd-analyze blame` after (first 10 lines):
+6.957s snap.lxd.activate.service
+4.674s snapd.service
+2.305s cloud-config.service
+1.681s cloud-init.service
+1.385s ec2-instance-connect.service
+1.367s cloud-init-local.service
+1.293s lvm2-monitor.service
+1.135s dev-xvda1.device
+ 979ms networkd-dispatcher.service
+ 891ms systemd-udev-settle.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.89000 seconds
+Finished stage: (init-network) 02.15600 seconds
+Finished stage: (modules-config) 00.54900 seconds
+Finished stage: (modules-final) 00.19000 seconds
+Total Time: 3.78500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.52600 seconds
+Finished stage: (init-network) 01.19500 seconds
+Finished stage: (modules-config) 00.60700 seconds
+Finished stage: (modules-final) 00.27400 seconds
+Total Time: 2.60200 seconds
+Finished stage: (init-network) 00.17800 seconds
+Total Time: 0.17800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     01.58900s (init-network/config-ssh)
+     00.38900s (init-local/search-Ec2Local)
+     00.35200s (modules-config/config-grub-dpkg)
+     00.15000s (init-network/config-users-groups)
+     00.08600s (modules-final/config-keys-to-console)
+     00.08000s (modules-config/config-apt-configure)
+     00.06400s (init-network/config-resizefs)
+     00.04800s (init-network/config-growpart)
+     00.04600s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.80600s (init-network/config-ssh)
+     00.27200s (modules-config/config-grub-dpkg)
+     00.26700s (init-local/search-Ec2Local)
+     00.13400s (modules-final/config-keys-to-console)
+     00.13200s (modules-config/config-apt-configure)
+     00.09400s (modules-config/config-locale)
+     00.05900s (init-network/config-resizefs)
+     00.05700s (modules-final/config-ssh-authkey-fingerprints)
+     00.05100s (init-network/config-growpart)
+
+2021-09-10 01:06:23 INFO      integration_testing.test_upgrade:test_upgrade.py:149 
+=== `systemd-analyze` before:
+Startup finished in 2.181s (kernel) + 21.578s (userspace) = 23.759s 
+graphical.target reached after 19.617s in userspace
+=== `systemd-analyze` after:
+Startup finished in 2.078s (kernel) + 13.982s (userspace) = 16.060s 
+graphical.target reached after 12.917s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.820s snapd.seeded.service
+2.724s snapd.apparmor.service
+2.577s cloud-init.service
+2.247s cloud-init-local.service
+2.007s systemd-networkd-wait-online.service
+1.879s snapd.service
+1.390s cloud-config.service
+1.291s lvm2-monitor.service
+1.009s pollinate.service
+1.008s dev-xvda1.device
+=== `systemd-analyze blame` after (first 10 lines):
+6.957s snap.lxd.activate.service
+4.674s snapd.service
+2.305s cloud-config.service
+1.681s cloud-init.service
+1.385s ec2-instance-connect.service
+1.367s cloud-init-local.service
+1.293s lvm2-monitor.service
+1.135s dev-xvda1.device
+ 979ms networkd-dispatcher.service
+ 891ms systemd-udev-settle.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.89000 seconds
+Finished stage: (init-network) 02.15600 seconds
+Finished stage: (modules-config) 00.54900 seconds
+Finished stage: (modules-final) 00.19000 seconds
+Total Time: 3.78500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.52600 seconds
+Finished stage: (init-network) 01.19500 seconds
+Finished stage: (modules-config) 00.60700 seconds
+Finished stage: (modules-final) 00.27400 seconds
+Total Time: 2.60200 seconds
+Finished stage: (init-network) 00.17800 seconds
+Total Time: 0.17800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     01.58900s (init-network/config-ssh)
+     00.38900s (init-local/search-Ec2Local)
+     00.35200s (modules-config/config-grub-dpkg)
+     00.15000s (init-network/config-users-groups)
+     00.08600s (modules-final/config-keys-to-console)
+     00.08000s (modules-config/config-apt-configure)
+     00.06400s (init-network/config-resizefs)
+     00.04800s (init-network/config-growpart)
+     00.04600s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.80600s (init-network/config-ssh)
+     00.27200s (modules-config/config-grub-dpkg)
+     00.26700s (init-local/search-Ec2Local)
+     00.13400s (modules-final/config-keys-to-console)
+     00.13200s (modules-config/config-apt-configure)
+     00.09400s (modules-config/config-locale)
+     00.05900s (init-network/config-resizefs)
+     00.05700s (modules-final/config-ssh-authkey-fingerprints)
+     00.05100s (init-network/config-growpart)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:07:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-01e80d9e7b6daabcf
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:07:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-01e80d9e7b6daabcf
+2021-09-10 01:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:07:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:07:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:07:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bd5bf38ef9d36a04'))
+2021-09-10 01:08:05 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bd5bf38ef9d36a04'))
+2021-09-10 01:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 01:08:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-10 01:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:08:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-10 01:08:05 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-10 01:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-10 01:08:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-10 01:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-10 01:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:08:22 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+Restarting instance and waiting for boot
+2021-09-10 01:08:22 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 01:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:08:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:09:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:09:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:09:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:09:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 01:09:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:09:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:10:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:10:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:11:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:11:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:11:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07ae318b9990d60a6'))
+2021-09-10 01:11:30 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07ae318b9990d60a6'))
+2021-09-10 01:11:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:11:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:11:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:11:30 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:11:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:12:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:12:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:12:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:12:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:12:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:12:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-086a1cea75a5fe2aa'))
+2021-09-10 01:13:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-086a1cea75a5fe2aa'))
+2021-09-10 01:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:13:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:13:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:13:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:13:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:14:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:14:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:14:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:14:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:14:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03f230f8381771cc8'))
+2021-09-10 01:14:32 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03f230f8381771cc8'))
+2021-09-10 01:14:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:14:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:14:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:14:33 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:14:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:15:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:15:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:15:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:15:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:15:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:15:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:15:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:15:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03e06692064ee52be'))
+2021-09-10 01:15:49 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03e06692064ee52be'))
+2021-09-10 01:15:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:15:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:15:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:15:50 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:15:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 01:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-10 01:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:16:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 01:16:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 01:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:17:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:17:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:17:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0547627ce4e38e1ae'))
+2021-09-10 01:17:16 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0547627ce4e38e1ae'))
+2021-09-10 01:17:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:17:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:17:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-10 01:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-10 01:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 01:17:17 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 01:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:17:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:17:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:17:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:17:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:17:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:18:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:18:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:18:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:18:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 01:18:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 01:18:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-10 01:18:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:19:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:19:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:19:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:19:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:19:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:19:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:19:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0cf3848dd36439683'))
+2021-09-10 01:19:48 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0cf3848dd36439683'))
+2021-09-10 01:19:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-10 01:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-10 01:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:19:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:20:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:20:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:20:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:20:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:20:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:20:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05db6d6248e80fba7'))
+2021-09-10 01:20:59 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05db6d6248e80fba7'))
+2021-09-10 01:20:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:21:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:21:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:21:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:21:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:22:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:22:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:22:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:22:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bbf139a562896474'))
+2021-09-10 01:22:28 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bbf139a562896474'))
+2021-09-10 01:22:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:22:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:22:29 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:23:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:23:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:23:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:23:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:23:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-049f19fb09fd6be23'))
+2021-09-10 01:23:55 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-049f19fb09fd6be23'))
+2021-09-10 01:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:23:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:23:56 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:23:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:24:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:24:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:25:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:25:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:25:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:25:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0d897df1a0513bd45'))
+2021-09-10 01:25:12 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0d897df1a0513bd45'))
+2021-09-10 01:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:25:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:25:13 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:25:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:25:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:25:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:26:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:26:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:26:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:26:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:26:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:26:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0955c898ebdadede2'))
+2021-09-10 01:26:26 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0955c898ebdadede2'))
+2021-09-10 01:26:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:26:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:26:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:26:26 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:26:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:26:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:26:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:27:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:27:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:27:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:27:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-043d0217f84523194'))
+2021-09-10 01:27:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-043d0217f84523194'))
+2021-09-10 01:27:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:27:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:27:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:27:39 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:27:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:28:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:28:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:28:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:28:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:29:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05bb11589b7d25465'))
+2021-09-10 01:29:07 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05bb11589b7d25465'))
+2021-09-10 01:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:29:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:29:08 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 01:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-10 01:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+PASSED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:29:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:29:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:30:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:30:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:30:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:30:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:30:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0116d52e69176f925'))
+2021-09-10 01:30:21 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0116d52e69176f925'))
+2021-09-10 01:30:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:30:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:30:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:30:21 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:30:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:31:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:31:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:31:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:31:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:31:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0b8fbf04888a27d6f'))
+2021-09-10 01:32:00 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0b8fbf04888a27d6f'))
+2021-09-10 01:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:32:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:32:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 01:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:32:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:32:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:33:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:33:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:33:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:33:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00a936ed3484af90e'))
+2021-09-10 01:33:26 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00a936ed3484af90e'))
+2021-09-10 01:33:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:33:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:33:27 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:33:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:33:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:33:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:34:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:34:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:35:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:35:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:35:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:35:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0168dc7ca426f91b3'))
+2021-09-10 01:35:02 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0168dc7ca426f91b3'))
+2021-09-10 01:35:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:35:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:35:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:35:03 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:35:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:35:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:35:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:35:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:35:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:36:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:36:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:36:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:36:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:36:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:36:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:36:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00a32a2c5638f68ff'))
+2021-09-10 01:36:17 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00a32a2c5638f68ff'))
+2021-09-10 01:36:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:36:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:36:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:36:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:36:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:36:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:36:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:36:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:37:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:37:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:37:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:37:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:37:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03685f8bf69e948bd'))
+2021-09-10 01:37:51 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03685f8bf69e948bd'))
+2021-09-10 01:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:37:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:37:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:37:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:37:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-10 01:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:38:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:38:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:39:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:39:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:39:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:39:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0a5e42b04ab935c42'))
+2021-09-10 01:39:58 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0a5e42b04ab935c42'))
+2021-09-10 01:39:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:39:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:39:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:39:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:39:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:39:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:40:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:40:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:41:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:41:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:41:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:41:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:41:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:41:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:41:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0eabb122764d0fe69'))
+2021-09-10 01:41:41 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0eabb122764d0fe69'))
+2021-09-10 01:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:41:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:41:42 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-10 01:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:42:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:42:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:43:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:43:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:43:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:43:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:43:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0838730cc38523f61'))
+2021-09-10 01:43:18 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0838730cc38523f61'))
+2021-09-10 01:43:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:43:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:43:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:43:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:43:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:44:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:44:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:44:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:44:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:44:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-09e9e17fe5e91d8ec'))
+2021-09-10 01:45:00 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-09e9e17fe5e91d8ec'))
+2021-09-10 01:45:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:45:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:45:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-10 01:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-10 01:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:45:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:45:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:46:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:46:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:46:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:46:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:46:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0628f37ba8480cdee'))
+2021-09-10 01:46:48 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0628f37ba8480cdee'))
+2021-09-10 01:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:46:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:46:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:46:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:46:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:47:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:47:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:48:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:48:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:48:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:48:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bd0e0f70778947fe'))
+2021-09-10 01:48:13 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0bd0e0f70778947fe'))
+2021-09-10 01:48:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:48:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:48:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:48:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:48:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:48:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:48:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:49:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:49:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:49:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:49:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-01470b3f9a5eef917'))
+2021-09-10 01:49:23 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-01470b3f9a5eef917'))
+2021-09-10 01:49:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:49:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:49:24 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:50:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:50:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:50:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:50:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:50:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:50:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05a2457f14d446a28'))
+2021-09-10 01:50:47 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05a2457f14d446a28'))
+2021-09-10 01:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:50:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:50:48 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:51:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:51:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:52:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:52:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:52:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:52:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-027a0823073b20d23'))
+2021-09-10 01:52:18 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-027a0823073b20d23'))
+2021-09-10 01:52:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:52:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:52:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:52:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:53:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:53:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:53:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:53:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:53:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0005c04763bd6c454'))
+2021-09-10 01:53:42 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0005c04763bd6c454'))
+2021-09-10 01:53:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:53:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:53:43 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-10 01:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-10 01:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:54:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:54:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ami-095f9094107504d99
+2021-09-10 01:55:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 01:55:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 01:55:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 01:55:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05f6230db3406bb02'))
+2021-09-10 01:55:09 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-05f6230db3406bb02'))
+2021-09-10 01:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:55:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 01:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 01:55:09 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:55:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:55:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:55:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:55:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:55:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 01:55:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 01:55:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:00:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:16:41 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:16:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:16:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:16:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:16:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:17:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:17:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:18:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:18:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:18:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:18:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:18:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0e2f9732b891cbeb2'))
+2021-09-10 02:18:12 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0e2f9732b891cbeb2'))
+2021-09-10 02:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:18:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:18:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:18:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:18:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:18:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:18:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:18:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:23:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:39:41 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+FAILED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:39:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:39:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:39:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:39:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:39:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:40:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:40:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:40:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:40:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:40:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:40:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07a870a1bbd67a0d3'))
+2021-09-10 02:41:11 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07a870a1bbd67a0d3'))
+2021-09-10 02:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:41:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:41:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:41:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:41:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:42:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:42:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:42:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:42:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:42:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:42:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0206b86837b65e098'))
+2021-09-10 02:42:40 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0206b86837b65e098'))
+2021-09-10 02:42:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:42:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:42:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:42:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:42:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:43:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:43:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:43:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:43:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:44:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:44:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:44:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03e92dcf78dae534e'))
+2021-09-10 02:45:12 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03e92dcf78dae534e'))
+2021-09-10 02:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:45:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:45:13 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:45:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:45:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:46:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:46:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:46:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:46:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:46:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:46:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:46:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0de70525fa9ef49d9'))
+2021-09-10 02:49:04 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0de70525fa9ef49d9'))
+2021-09-10 02:49:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:49:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:49:08 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:49:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:49:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:50:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:50:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:50:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:50:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:51:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0182afe2e8cf33c47'))
+2021-09-10 02:53:39 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0182afe2e8cf33c47'))
+2021-09-10 02:53:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:53:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:53:43 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:54:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:54:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:55:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:55:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:55:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:55:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-080d862c7848f39b9'))
+2021-09-10 02:55:17 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-080d862c7848f39b9'))
+2021-09-10 02:55:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:55:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 02:56:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:56:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 02:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 02:56:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:56:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 02:56:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-08c7ee7f2d34e1b98'))
+2021-09-10 02:59:22 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-08c7ee7f2d34e1b98'))
+2021-09-10 02:59:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:59:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 02:59:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 02:59:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 02:59:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-10 02:59:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-10 02:59:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-10 02:59:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-10 02:59:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-10 02:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-10 02:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-10 02:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-10 02:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-10 02:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 02:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-10 02:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-10 02:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-10 02:59:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-10 02:59:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-10 02:59:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-10 02:59:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-10 02:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-10 02:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-10 02:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-10 02:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-10 02:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 02:59:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-10 02:59:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-10 02:59:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-10 02:59:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-10 02:59:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-10 02:59:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-10 02:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-10 02:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-10 02:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-10 02:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-10 02:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 02:59:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-10 02:59:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-10 02:59:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-10 02:59:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-10 02:59:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-10 02:59:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 02:59:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 02:59:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-10 02:59:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-10 02:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-10 02:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-10 02:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-10 02:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 02:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-10 02:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-10 02:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:00:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:00:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:01:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:01:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:01:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00c93e7ad1a2dadfe'))
+2021-09-10 03:04:56 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-00c93e7ad1a2dadfe'))
+2021-09-10 03:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:05:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:05:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-10 03:05:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-10 03:05:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-10 03:05:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-10 03:05:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-10 03:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-10 03:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-10 03:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-10 03:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-10 03:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-10 03:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-10 03:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-10 03:05:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-10 03:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-10 03:05:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-10 03:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-10 03:05:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-10 03:05:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-10 03:05:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:05:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-10 03:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-10 03:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-10 03:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:06:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:06:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:06:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:06:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:06:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:06:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:06:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:06:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:07:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0adb3f367ccdb7389'))
+2021-09-10 03:08:43 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0adb3f367ccdb7389'))
+2021-09-10 03:08:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:08:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:08:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:08:47 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:08:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-10 03:08:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-10 03:08:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-10 03:08:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-10 03:08:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:08:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-10 03:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-10 03:08:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-10 03:08:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-10 03:08:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-10 03:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-10 03:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-10 03:08:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-10 03:08:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-10 03:08:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:08:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-10 03:08:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-10 03:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-10 03:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-10 03:09:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-10 03:09:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:09:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-10 03:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-10 03:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-10 03:09:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-10 03:09:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-10 03:09:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-10 03:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-10 03:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-10 03:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-10 03:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-10 03:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-10 03:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-10 03:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-10 03:09:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-10 03:09:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-10 03:09:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:09:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-10 03:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-10 03:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-10 03:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-10 03:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-10 03:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-10 03:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-10 03:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:09:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:09:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:10:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:10:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:10:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:11:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0ff5fc8e63290d560'))
+2021-09-10 03:13:28 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0ff5fc8e63290d560'))
+2021-09-10 03:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:13:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:13:32 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-10 03:13:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-10 03:13:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-10 03:13:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-10 03:13:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-10 03:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-10 03:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-10 03:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-10 03:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-10 03:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-10 03:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-10 03:13:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-10 03:13:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-10 03:13:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-10 03:13:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-10 03:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-10 03:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-10 03:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-10 03:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:13:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-10 03:13:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-10 03:13:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-10 03:13:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-10 03:13:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-10 03:13:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-10 03:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-10 03:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-10 03:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-10 03:13:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-10 03:13:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:13:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-10 03:13:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-10 03:13:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-10 03:13:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-10 03:13:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-10 03:13:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:13:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:13:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-10 03:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-10 03:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-10 03:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-10 03:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-10 03:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-10 03:13:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-10 03:13:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-10 03:13:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:14:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:14:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:15:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:15:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:15:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:15:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:15:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:15:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:15:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:15:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-074363d286afb092a'))
+2021-09-10 03:18:03 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-074363d286afb092a'))
+2021-09-10 03:18:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:18:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:18:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:18:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:18:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:18:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:18:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:19:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:19:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:19:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:19:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:20:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0feb277e4e2bea77e'))
+2021-09-10 03:20:13 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0feb277e4e2bea77e'))
+2021-09-10 03:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:20:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:20:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 03:20:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/204df7d5-c0b9-4a25-a048-8d6a31201ccf.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-10 03:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 03:20:15 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:20:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:20:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:20:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:20:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:20:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:21:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:21:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:21:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:21:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:22:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:22:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:22:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:22:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:23:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0ac0c4d6db4e739c9'))
+2021-09-10 03:25:12 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0ac0c4d6db4e739c9'))
+2021-09-10 03:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:25:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:25:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 03:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-10 03:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-10 03:25:13 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-10 03:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/9b8e2681-1fa5-4346-a7d0-9bf7199bb45d.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-10 03:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 03:25:13 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:25:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:25:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:25:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:25:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:25:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:26:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:26:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:26:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:26:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:26:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:26:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:27:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:27:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:27:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:28:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:28:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:28:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0e1c894244d0ca99e'))
+2021-09-10 03:30:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0e1c894244d0ca99e'))
+2021-09-10 03:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:30:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:30:14 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:30:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:31:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:31:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:31:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-10 03:31:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-10 03:31:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:31:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:31:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:31:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:32:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07d6da0e860851e08'))
+2021-09-10 03:34:19 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-07d6da0e860851e08'))
+2021-09-10 03:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:34:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:34:23 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:34:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-10 03:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-10 03:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-10 03:34:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-10 03:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Restarting instance and waiting for boot
+2021-09-10 03:34:28 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:34:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:34:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:34:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:34:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:34:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:35:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:35:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:35:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:35:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:37:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:37:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:37:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:37:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:37:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0cf1023d798cbfaa7'))
+2021-09-10 03:38:51 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0cf1023d798cbfaa7'))
+2021-09-10 03:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:38:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:38:55 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 03:38:55 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:39:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:39:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:39:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:40:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:40:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-10 03:40:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-10 03:40:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/57899b37-2a00-42b8-b76e-d48d198f5bdd.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-10 03:40:20 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:40:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:40:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:40:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:41:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:41:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:41:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:41:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:43:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:43:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-10 03:44:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:44:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:44:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:44:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:44:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:44:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:45:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03253aa94cd9a8b43'))
+2021-09-10 03:45:14 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-03253aa94cd9a8b43'))
+2021-09-10 03:45:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:45:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:45:15 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:45:15 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-10 03:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/5873d904-4527-4928-858b-b8d48012ebbb.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-10 03:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-10 03:45:15 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:45:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:45:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:45:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:46:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-10 03:46:37 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:46:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:46:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ami-095f9094107504d99
+2021-09-10 03:47:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:47:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:47:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:47:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:47:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:47:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0f3f95523189afe37'))
+2021-09-10 03:49:43 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-0f3f95523189afe37'))
+2021-09-10 03:49:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:49:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:49:47 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:49:47 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-10 03:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/bd8ec94a-f598-4746-8803-14c2b0653751.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-10 03:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-10 03:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-10 03:49:48 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-10 03:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:49:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:50:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:51:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:51:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:51:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-10 03:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'cat /proc/sys/kernel/random/boot_id'
+2021-09-10 03:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:55:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:55:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ami-095f9094107504d99
+2021-09-10 03:55:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-10 03:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:55:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-10 03:55:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-10 03:55:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-10 03:56:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-066929fe9e5ea95dc'))
+2021-09-10 03:58:38 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f47fe85a4a8>, instance=ec2.Instance(id='i-066929fe9e5ea95dc'))
+2021-09-10 03:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:58:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-10 03:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-10 03:58:42 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-10 03:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-10 03:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: ami-095f9094107504d99
+
+------------------------------ live log teardown -------------------------------
+2021-09-10 03:59:28 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-095f9094107504d99
+
+
+=================================== FAILURES ===================================
+____________ TestPasswordList.test_explicit_password_set_correctly _____________
+
+self = <test_set_password.TestPasswordList object at 0x7f47fce707f0>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f47fde1ea90>
+
+    def test_explicit_password_set_correctly(self, class_client):
+        """Test that an explicitly-specified password is set correctly."""
+>       shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+
+tests/integration_tests/modules/test_set_password.py:145: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/modules/test_set_password.py:77: in _fetch_and_parse_etc_shadow
+    shadow_content = class_client.read_from_file("/etc/shadow")
+tests/integration_tests/instances.py:87: in read_from_file
+    result = self.execute('cat {}'.format(remote_path))
+tests/integration_tests/instances.py:72: in execute
+    return self.instance.execute(command, use_sudo=use_sudo)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:508: in exec_command
+    chan = self._transport.open_session(timeout=timeout)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:879: in open_session
+    timeout=timeout,
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1006: in open_channel
+    raise e
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:2055: in run
+    ptype, m = self.packetizer.read_message()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:459: in read_message
+    header = self.read_all(self.__block_size_in, check_rekey=True)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.packet.Packetizer object at 0x7f47fde66e80>, n = 16
+check_rekey = True
+
+    def read_all(self, n, check_rekey=False):
+        """
+        Read as close to N bytes as possible, blocking as long as necessary.
+    
+        :param int n: number of bytes to read
+        :return: the data read, as a `str`
+    
+        :raises:
+            ``EOFError`` -- if the socket was closed before all the bytes could
+            be read
+        """
+        out = bytes()
+        # handle over-reading from reading the banner line
+        if len(self.__remainder) > 0:
+            out = self.__remainder[:n]
+            self.__remainder = self.__remainder[n:]
+            n -= len(out)
+        while n > 0:
+            got_timeout = False
+            if self.handshake_timed_out():
+                raise EOFError()
+            try:
+>               x = self.__socket.recv(n)
+E               TimeoutError: [Errno 110] Connection timed out
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:301: TimeoutError
+------------------------------ Captured log setup ------------------------------
+2021-09-10 02:00:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+------------------------------ Captured log call -------------------------------
+2021-09-10 02:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:16:41 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+_________ TestPasswordListString.test_explicit_password_set_correctly __________
+
+self = <test_set_password.TestPasswordListString object at 0x7f47fdb83198>
+class_client = <tests.integration_tests.instances.IntegrationEc2Instance object at 0x7f47fc7e2eb8>
+
+    def test_explicit_password_set_correctly(self, class_client):
+        """Test that an explicitly-specified password is set correctly."""
+>       shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+
+tests/integration_tests/modules/test_set_password.py:145: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/modules/test_set_password.py:77: in _fetch_and_parse_etc_shadow
+    shadow_content = class_client.read_from_file("/etc/shadow")
+tests/integration_tests/instances.py:87: in read_from_file
+    result = self.execute('cat {}'.format(remote_path))
+tests/integration_tests/instances.py:72: in execute
+    return self.instance.execute(command, use_sudo=use_sudo)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:508: in exec_command
+    chan = self._transport.open_session(timeout=timeout)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:879: in open_session
+    timeout=timeout,
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1006: in open_channel
+    raise e
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:2055: in run
+    ptype, m = self.packetizer.read_message()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:459: in read_message
+    header = self.read_all(self.__block_size_in, check_rekey=True)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.packet.Packetizer object at 0x7f47fc7e5f98>, n = 16
+check_rekey = True
+
+    def read_all(self, n, check_rekey=False):
+        """
+        Read as close to N bytes as possible, blocking as long as necessary.
+    
+        :param int n: number of bytes to read
+        :return: the data read, as a `str`
+    
+        :raises:
+            ``EOFError`` -- if the socket was closed before all the bytes could
+            be read
+        """
+        out = bytes()
+        # handle over-reading from reading the banner line
+        if len(self.__remainder) > 0:
+            out = self.__remainder[:n]
+            self.__remainder = self.__remainder[n:]
+            n -= len(out)
+        while n > 0:
+            got_timeout = False
+            if self.handshake_timed_out():
+                raise EOFError()
+            try:
+>               x = self.__socket.recv(n)
+E               TimeoutError: [Errno 110] Connection timed out
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:301: TimeoutError
+------------------------------ Captured log setup ------------------------------
+2021-09-10 02:23:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+------------------------------ Captured log call -------------------------------
+2021-09-10 02:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-10 02:39:41 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly
+FAILED tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly
+===== 2 failed, 120 passed, 27 skipped, 2 warnings in 10927.67s (3:02:07) ======

--- a/21.3-1/integration_tests/ec2_hirsute_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/ec2_hirsute_integration_tests_rerun.txt
@@ -1,0 +1,265 @@
+=================================================================================================================================== test session starts ====================================================================================================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 2 items
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------------
+2021-09-11 04:05:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-11 04:05:42 INFO      botocore.credentials:credentials.py:1217 Found credentials in shared credentials file: ~/.aws/credentials
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-11 04:05:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-11 04:05:50 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=ec2
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for ec2
+2021-09-11 04:05:50 INFO      integration_testing:conftest.py:156 Setting up environment for ec2
+Launching instance with launch_kwargs:
+image_id=ami-01e80d9e7b6daabcf
+user_data=None
+2021-09-11 04:05:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-01e80d9e7b6daabcf
+user_data=None
+2021-09-11 04:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:06:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:06:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:06:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:06:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-11 04:06:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-11 04:06:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-0743e928bb86f3ad2'))
+2021-09-11 04:06:41 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-0743e928bb86f3ad2'))
+2021-09-11 04:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-11 04:06:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-11 04:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-11 04:06:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+Installing proposed image
+2021-09-11 04:06:41 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-11 04:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-11 04:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-11 04:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-11 04:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:07:05 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-11 04:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-11 04:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-11 04:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-11 04:09:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:09:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-11 04:09:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-11 04:09:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Created new image: ami-02823131ce7dd85ec
+2021-09-11 04:09:44 INFO      integration_testing:instances.py:114 Created new image: ami-02823131ce7dd85ec
+Done with environment setup
+2021-09-11 04:10:29 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=ami-02823131ce7dd85ec
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-11 04:10:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-02823131ce7dd85ec
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-11 04:11:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:11:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-11 04:11:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-11 04:11:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-09e9086bcd3c24d2c'))
+2021-09-11 04:11:22 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-09e9086bcd3c24d2c'))
+2021-09-11 04:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:11:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-11 04:11:23 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
+2021-09-11 04:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------------
+2021-09-11 04:11:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=ami-02823131ce7dd85ec
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-11 04:11:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ami-02823131ce7dd85ec
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-11 04:12:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-11 04:12:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-11 04:12:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-11 04:12:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-0936aa4ad9b218648'))
+2021-09-11 04:12:48 INFO      integration_testing:clouds.py:173 Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f01aee6d9b0>, instance=ec2.Instance(id='i-0936aa4ad9b218648'))
+2021-09-11 04:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:12:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-11 04:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210908
+2021-09-11 04:12:48 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
+2021-09-11 04:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSEDDeleting snapshot image created for this testrun: ami-02823131ce7dd85ec
+
+------------------------------------------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------------------------------------------
+2021-09-11 04:13:34 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ami-02823131ce7dd85ec
+
+
+===================================================================================================================================== warnings summary =====================================================================================================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+======================================================================================================================== 2 passed, 2 warnings in 472.57s (0:07:52) =========================================================================================================================

--- a/21.3-1/integration_tests/gce_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/gce_bionic_integration_tests.txt
@@ -1,0 +1,3784 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:04:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 06:04:03 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 06:04:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 06:04:07 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for gce
+2021-09-05 06:04:07 INFO      integration_testing:conftest.py:156 Setting up environment for gce
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+2021-09-05 06:04:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+2021-09-05 06:04:11 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:04:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:05:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:05:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:05:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8076375704840299319)
+2021-09-05 06:05:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8076375704840299319)
+2021-09-05 06:05:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:05:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:05:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 06:05:17 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 06:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 06:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 06:05:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 06:05:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:05:34 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:05:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 06:05:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:07:00 INFO      integration_testing:instances.py:114 Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+Done with environment setup
+2021-09-05 06:07:01 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:07:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:07:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:07:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:07:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:07:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7722471683845120106)
+2021-09-05 06:07:49 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7722471683845120106)
+2021-09-05 06:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:07:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:07:50 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:07:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 06:07:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:08:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:08:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+2021-09-05 06:08:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+2021-09-05 06:08:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:08:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:08:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:08:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:08:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3224165543537401894)
+2021-09-05 06:09:10 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3224165543537401894)
+2021-09-05 06:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:09:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:09:11 INFO      integration_testing:clouds.py:183 image serial: 20210831
+2021-09-05 06:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 06:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 06:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 06:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 06:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 06:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 06:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 06:09:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 06:09:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 06:09:15 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 06:09:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 06:09:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 06:09:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 06:09:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:09:32 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:09:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 06:09:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 06:09:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 06:09:33 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 06:10:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:11:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:11:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:11:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 06:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 06:11:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 06:11:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 06:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 06:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 06:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 06:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 06:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 06:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 06:11:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 06:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.188s (kernel) + 31.389s (userspace) = 35.577s
+graphical.target reached after 29.426s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.204s (kernel) + 18.038s (userspace) = 22.243s
+graphical.target reached after 14.120s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         14.884s snapd.seeded.service
+          5.825s accounts-daemon.service
+          4.125s apport.service
+          4.097s grub-common.service
+          2.921s google-oslogin-cache.service
+          2.915s systemd-user-sessions.service
+          2.893s rsyslog.service
+          2.716s networkd-dispatcher.service
+          2.705s lxd-containers.service
+          2.277s dev-sda1.device
+=== `systemd-analyze blame` after (first 10 lines):
+          3.098s snapd.service
+          2.450s dev-sda1.device
+          2.415s keyboard-setup.service
+          2.097s lxd-containers.service
+          2.031s cloud-final.service
+          1.981s systemd-networkd-wait-online.service
+          1.767s cloud-init.service
+          1.753s cloud-config.service
+          1.672s networkd-dispatcher.service
+          1.528s accounts-daemon.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.20700 seconds
+Finished stage: (init-network) 00.98200 seconds
+Finished stage: (modules-config) 00.43900 seconds
+Finished stage: (modules-final) 00.09700 seconds
+Total Time: 1.72500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.21100 seconds
+Finished stage: (init-network) 01.13100 seconds
+Finished stage: (modules-config) 00.94900 seconds
+Finished stage: (modules-final) 01.29000 seconds
+Total Time: 3.58100 seconds
+Finished stage: (init-network) 00.18900 seconds
+Total Time: 0.18900 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.31300s (init-network/config-ssh)
+     00.21500s (modules-config/config-grub-dpkg)
+     00.14000s (init-network/config-growpart)
+     00.10800s (init-network/config-resizefs)
+     00.09700s (modules-config/config-apt-configure)
+     00.08200s (init-network/config-users-groups)
+     00.07800s (modules-config/config-ntp)
+     00.05000s (init-network/search-GCE)
+     00.03700s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     01.16900s (modules-final/config-ssh-authkey-fingerprints)
+     00.40500s (modules-config/config-ntp)
+     00.31800s (init-network/config-ssh)
+     00.25200s (modules-config/config-grub-dpkg)
+     00.23400s (modules-config/config-apt-configure)
+     00.06900s (init-network/config-growpart)
+     00.05300s (init-network/search-GCE)
+     00.04900s (modules-final/config-keys-to-console)
+     00.03000s (init-network/config-resizefs)
+
+2021-09-05 06:11:10 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 4.188s (kernel) + 31.389s (userspace) = 35.577s
+graphical.target reached after 29.426s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.204s (kernel) + 18.038s (userspace) = 22.243s
+graphical.target reached after 14.120s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         14.884s snapd.seeded.service
+          5.825s accounts-daemon.service
+          4.125s apport.service
+          4.097s grub-common.service
+          2.921s google-oslogin-cache.service
+          2.915s systemd-user-sessions.service
+          2.893s rsyslog.service
+          2.716s networkd-dispatcher.service
+          2.705s lxd-containers.service
+          2.277s dev-sda1.device
+=== `systemd-analyze blame` after (first 10 lines):
+          3.098s snapd.service
+          2.450s dev-sda1.device
+          2.415s keyboard-setup.service
+          2.097s lxd-containers.service
+          2.031s cloud-final.service
+          1.981s systemd-networkd-wait-online.service
+          1.767s cloud-init.service
+          1.753s cloud-config.service
+          1.672s networkd-dispatcher.service
+          1.528s accounts-daemon.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.20700 seconds
+Finished stage: (init-network) 00.98200 seconds
+Finished stage: (modules-config) 00.43900 seconds
+Finished stage: (modules-final) 00.09700 seconds
+Total Time: 1.72500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.21100 seconds
+Finished stage: (init-network) 01.13100 seconds
+Finished stage: (modules-config) 00.94900 seconds
+Finished stage: (modules-final) 01.29000 seconds
+Total Time: 3.58100 seconds
+Finished stage: (init-network) 00.18900 seconds
+Total Time: 0.18900 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.31300s (init-network/config-ssh)
+     00.21500s (modules-config/config-grub-dpkg)
+     00.14000s (init-network/config-growpart)
+     00.10800s (init-network/config-resizefs)
+     00.09700s (modules-config/config-apt-configure)
+     00.08200s (init-network/config-users-groups)
+     00.07800s (modules-config/config-ntp)
+     00.05000s (init-network/search-GCE)
+     00.03700s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     01.16900s (modules-final/config-ssh-authkey-fingerprints)
+     00.40500s (modules-config/config-ntp)
+     00.31800s (init-network/config-ssh)
+     00.25200s (modules-config/config-grub-dpkg)
+     00.23400s (modules-config/config-apt-configure)
+     00.06900s (init-network/config-growpart)
+     00.05300s (init-network/search-GCE)
+     00.04900s (modules-final/config-keys-to-console)
+     00.03000s (init-network/config-resizefs)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:11:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:11:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20210831
+2021-09-05 06:11:33 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:11:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:12:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:12:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:12:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5904423254492832125)
+2021-09-05 06:12:30 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5904423254492832125)
+2021-09-05 06:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:12:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 06:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:12:31 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 06:12:31 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 06:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 06:12:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 06:12:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 06:12:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:12:48 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-05 06:12:48 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 06:13:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:14:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:14:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:14:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 06:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:15:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:15:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:15:28 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:16:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:16:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:16:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4562517403541036701)
+2021-09-05 06:16:10 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4562517403541036701)
+2021-09-05 06:16:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:16:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:16:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:16:11 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:16:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:16:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:16:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:16:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:17:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:17:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:17:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:17:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2318484552879300178)
+2021-09-05 06:17:29 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2318484552879300178)
+2021-09-05 06:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:17:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:17:30 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:17:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:17:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:17:54 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:18:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:18:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:18:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:18:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3688505534628618239)
+2021-09-05 06:18:44 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3688505534628618239)
+2021-09-05 06:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:18:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:18:45 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:19:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:19:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:19:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:19:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:19:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:19:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:19:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:19:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:19:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:19:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2709159609961668537)
+2021-09-05 06:19:52 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2709159609961668537)
+2021-09-05 06:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:19:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:19:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:19:53 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:19:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 06:19:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 06:19:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:20:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:20:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:20:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:20:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:20:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:20:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:21:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:21:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=116238989523541873)
+2021-09-05 06:21:05 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=116238989523541873)
+2021-09-05 06:21:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:21:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:21:06 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 06:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 06:21:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 06:21:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 06:21:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:22:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:22:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:22:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 06:22:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 06:22:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:22:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:23:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:23:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:23:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:23:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:23:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=128667637035687083)
+2021-09-05 06:23:55 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=128667637035687083)
+2021-09-05 06:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:23:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:23:56 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-05 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 06:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 06:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:23:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:24:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:24:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:24:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:24:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:24:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:24:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:25:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8112692883143384160)
+2021-09-05 06:25:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8112692883143384160)
+2021-09-05 06:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:25:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:25:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:25:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:25:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:25:40 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:26:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:26:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:26:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6271459838075198520)
+2021-09-05 06:26:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6271459838075198520)
+2021-09-05 06:26:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:26:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:26:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:26:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:26:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:26:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:26:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:26:39 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:26:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:27:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:27:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:27:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:27:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5513294829252632050)
+2021-09-05 06:27:29 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5513294829252632050)
+2021-09-05 06:27:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:27:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:27:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:27:30 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:27:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:27:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:27:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:27:52 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:28:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:28:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:28:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:28:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:28:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:28:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6136609302478708105)
+2021-09-05 06:28:42 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6136609302478708105)
+2021-09-05 06:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:28:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:28:43 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 06:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 06:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 06:28:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:28:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:28:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:29:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:29:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:29:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:29:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:29:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:29:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:29:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3278846752162700609)
+2021-09-05 06:29:50 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3278846752162700609)
+2021-09-05 06:29:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:29:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:29:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:29:51 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:29:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:30:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:30:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:30:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:30:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:30:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:30:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:30:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:30:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:30:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2128469070785928477)
+2021-09-05 06:31:02 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2128469070785928477)
+2021-09-05 06:31:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:31:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:31:03 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:31:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:31:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:31:24 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:31:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:32:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:32:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:32:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:32:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4345916597871434453)
+2021-09-05 06:32:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4345916597871434453)
+2021-09-05 06:32:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:32:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:32:16 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 06:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 06:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 06:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 06:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 06:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:32:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:32:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:32:39 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:32:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:33:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:33:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:33:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:33:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:33:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:33:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6832502353570683498)
+2021-09-05 06:33:30 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6832502353570683498)
+2021-09-05 06:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:33:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:33:31 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:33:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:33:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:33:52 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:34:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:34:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:34:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1323961034127039010)
+2021-09-05 06:34:41 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1323961034127039010)
+2021-09-05 06:34:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:34:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:34:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:34:42 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:34:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 06:34:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:35:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:35:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:35:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:35:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:35:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:35:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=186070411817638905)
+2021-09-05 06:35:55 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=186070411817638905)
+2021-09-05 06:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:35:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:35:56 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:35:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:35:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:35:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:36:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:36:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:36:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:36:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:37:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:37:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:37:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2371080632191802288)
+2021-09-05 06:37:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2371080632191802288)
+2021-09-05 06:37:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:37:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:37:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:37:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:37:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:37:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:37:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:38:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:38:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:38:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1110612394873838408)
+2021-09-05 06:38:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1110612394873838408)
+2021-09-05 06:38:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:38:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:38:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:38:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:38:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:38:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:38:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:38:38 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:39:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:39:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:39:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5392579683862305540)
+2021-09-05 06:39:34 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5392579683862305540)
+2021-09-05 06:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:39:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:39:35 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:39:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:39:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 06:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 06:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:39:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:39:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:40:00 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:40:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:40:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:40:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:40:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:40:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:40:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:40:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8984589025395988690)
+2021-09-05 06:41:00 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8984589025395988690)
+2021-09-05 06:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:41:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:41:01 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:41:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:41:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:41:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:41:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:41:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:41:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:42:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:42:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:42:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:42:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4193172876332488800)
+2021-09-05 06:42:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4193172876332488800)
+2021-09-05 06:42:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:42:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:42:10 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 06:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:42:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:42:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:42:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:42:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:43:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:43:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:43:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5311070434468943932)
+2021-09-05 06:43:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5311070434468943932)
+2021-09-05 06:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:43:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:43:16 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:43:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:43:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:43:37 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:43:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:44:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:44:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:44:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5238711458280888825)
+2021-09-05 06:44:36 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5238711458280888825)
+2021-09-05 06:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:44:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:44:36 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 06:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 06:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:44:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:44:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:44:59 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:45:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:45:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:45:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7791680421780642182)
+2021-09-05 06:47:27 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7791680421780642182)
+2021-09-05 06:47:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:47:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:47:28 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:47:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:47:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:47:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:47:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:48:03 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:48:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:48:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:48:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=203949720720758521)
+2021-09-05 06:48:40 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=203949720720758521)
+2021-09-05 06:48:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:48:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:48:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:48:41 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:48:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:48:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:48:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:49:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:49:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:49:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:49:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:49:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5938236140444833459)
+2021-09-05 06:49:50 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5938236140444833459)
+2021-09-05 06:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:49:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:49:51 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:50:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:50:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:50:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:50:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:50:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:50:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:50:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:50:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4782503549677983309)
+2021-09-05 06:50:58 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4782503549677983309)
+2021-09-05 06:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:50:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:50:59 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:50:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:51:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:51:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:51:19 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:51:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:52:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:52:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:52:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8070627415100610058)
+2021-09-05 06:52:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8070627415100610058)
+2021-09-05 06:52:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:52:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:52:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:52:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:52:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:53:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:53:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:53:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7955803122299426758)
+2021-09-05 06:53:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7955803122299426758)
+2021-09-05 06:53:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:53:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:53:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:53:15 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:53:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 06:53:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 06:53:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:53:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:53:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:53:37 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:54:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:54:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:54:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1535081062094985089)
+2021-09-05 06:54:25 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1535081062094985089)
+2021-09-05 06:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:54:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:54:26 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:54:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:55:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:55:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:55:18 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:55:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:56:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:56:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:56:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:56:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2504193020293404476)
+2021-09-05 06:56:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2504193020293404476)
+2021-09-05 06:56:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:56:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:56:10 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:56:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:57:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:57:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:57:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:57:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:57:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:57:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:57:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7153214712683549905)
+2021-09-05 06:58:11 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7153214712683549905)
+2021-09-05 06:58:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:58:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:58:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:58:12 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:58:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:58:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:58:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:58:45 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 06:59:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 06:59:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 06:59:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=691085937930261623)
+2021-09-05 06:59:23 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=691085937930261623)
+2021-09-05 06:59:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:59:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 06:59:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 06:59:24 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 06:59:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 06:59:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:59:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 06:59:46 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 06:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:00:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:00:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:00:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:00:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5806097451494003760)
+2021-09-05 07:00:36 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5806097451494003760)
+2021-09-05 07:00:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:00:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:00:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:00:37 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:00:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:00:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:00:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:00:57 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:01:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:01:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:01:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:01:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8748854191962314185)
+2021-09-05 07:01:45 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8748854191962314185)
+2021-09-05 07:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:01:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:01:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:01:46 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:01:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:02:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:02:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:02:08 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:02:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:02:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:02:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:02:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=61869316351055234)
+2021-09-05 07:02:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=61869316351055234)
+2021-09-05 07:02:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:02:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:02:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:02:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:02:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:03:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:03:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:03:19 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:03:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:04:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:04:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:04:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:04:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:04:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3985540615211963738)
+2021-09-05 07:04:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3985540615211963738)
+2021-09-05 07:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:04:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:04:10 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:04:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:04:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:04:34 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:04:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:05:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:05:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:05:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2671452515817083631)
+2021-09-05 07:05:23 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2671452515817083631)
+2021-09-05 07:05:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:05:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:05:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:05:24 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:05:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 07:05:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 07:05:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 07:05:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 07:05:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 07:05:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 07:05:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 07:05:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 07:05:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 07:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 07:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 07:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 07:05:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 07:05:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 07:05:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 07:05:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 07:05:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 07:05:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 07:05:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 07:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 07:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 07:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 07:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 07:05:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 07:05:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 07:05:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 07:05:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 07:05:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 07:05:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 07:05:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 07:05:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:05:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 07:05:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 07:05:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 07:05:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 07:05:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 07:05:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:05:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:05:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 07:05:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 07:05:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 07:05:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 07:05:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 07:05:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:05:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 07:05:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 07:05:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:05:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:05:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:06:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:06:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:06:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=195044273536225975)
+2021-09-05 07:06:51 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=195044273536225975)
+2021-09-05 07:06:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:06:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:06:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:06:52 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:06:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 07:06:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 07:06:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 07:06:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 07:06:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:06:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 07:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 07:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 07:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 07:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 07:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 07:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 07:06:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 07:06:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 07:06:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 07:06:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 07:06:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:06:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:06:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:06:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 07:06:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 07:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 07:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 07:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 07:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 07:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 07:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 07:07:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 07:07:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 07:07:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:07:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 07:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 07:07:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 07:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 07:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 07:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 07:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 07:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 07:07:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 07:07:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 07:07:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:07:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:07:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 07:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 07:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 07:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 07:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 07:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 07:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 07:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:07:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:07:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:07:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:07:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:08:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:08:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:08:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3841671112150340162)
+2021-09-05 07:08:17 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3841671112150340162)
+2021-09-05 07:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:08:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:08:18 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 07:08:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 07:08:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 07:08:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 07:08:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 07:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 07:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 07:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 07:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 07:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 07:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 07:08:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 07:08:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 07:08:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 07:08:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 07:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 07:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 07:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 07:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 07:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 07:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 07:08:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 07:08:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 07:08:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 07:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 07:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 07:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 07:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 07:08:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 07:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 07:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 07:08:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 07:08:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 07:08:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:08:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:08:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 07:08:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 07:08:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 07:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 07:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 07:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 07:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 07:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:08:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:08:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:09:06 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:09:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:09:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2390857182768387052)
+2021-09-05 07:09:42 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2390857182768387052)
+2021-09-05 07:09:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:09:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:09:43 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 07:09:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 07:09:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 07:09:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 07:09:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 07:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 07:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 07:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 07:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 07:09:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 07:09:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 07:09:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 07:09:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 07:09:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 07:09:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 07:09:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 07:09:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 07:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 07:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 07:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 07:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 07:09:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 07:09:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 07:09:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 07:09:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 07:09:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 07:09:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 07:09:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 07:09:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:09:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 07:09:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 07:09:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 07:09:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 07:09:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 07:09:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:09:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 07:09:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 07:09:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 07:09:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 07:09:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 07:09:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 07:09:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 07:09:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 07:09:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 07:09:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:10:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:10:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:10:19 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:11:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:11:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:11:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:11:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:11:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4639421687783871414)
+2021-09-05 07:11:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4639421687783871414)
+2021-09-05 07:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:11:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:11:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:11:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:11:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:11:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:11:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:12:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:12:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:12:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:12:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:12:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1275174891453797232)
+2021-09-05 07:12:19 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1275174891453797232)
+2021-09-05 07:12:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:12:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:12:20 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 07:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 07:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 07:12:21 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 07:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/3a934fba-b88f-4706-a8ad-796f44da85a8.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 07:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 07:12:22 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:12:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:13:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:13:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:13:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:14:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:14:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:14:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 07:14:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:14:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:14:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:14:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:15:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6489734791932006569)
+2021-09-05 07:15:05 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6489734791932006569)
+2021-09-05 07:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:15:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:15:06 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 07:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 07:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 07:15:07 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 07:15:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/c22707cd-3a03-4daa-a4d0-68b1abf6bf66.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 07:15:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 07:15:08 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:15:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:16:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:16:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:16:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:16:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:17:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:17:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 07:17:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:17:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:17:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:17:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:17:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:17:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:17:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:17:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:17:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6279913888491884547)
+2021-09-05 07:17:51 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6279913888491884547)
+2021-09-05 07:17:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:17:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:17:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:17:52 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:17:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:17:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:18:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:18:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:18:14 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:18:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:18:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:18:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:18:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=200620970742501851)
+2021-09-05 07:19:03 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=200620970742501851)
+2021-09-05 07:19:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:19:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:19:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:19:04 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:19:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:19:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:19:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:19:38 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:19:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:20:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:20:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:20:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4806883703900459410)
+2021-09-05 07:20:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4806883703900459410)
+2021-09-05 07:20:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:20:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:20:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:20:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:20:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 07:20:17 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:20:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:21:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:21:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:21:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:21:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 07:21:19 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 07:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/925d2ebd-1220-43a1-b7ea-789210174568.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 07:21:20 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:22:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:22:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:22:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 07:23:44 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:23:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:23:47 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:24:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:24:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:24:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:24:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=150085109932478062)
+2021-09-05 07:24:37 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=150085109932478062)
+2021-09-05 07:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:24:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:24:38 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:24:38 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 07:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/756cfee5-e3d3-40bb-80eb-20dadfa5dc85.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 07:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 07:24:39 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:25:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:25:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:25:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 07:26:31 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:26:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:26:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:26:34 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:26:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:27:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:27:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:27:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:27:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6963177901782585287)
+2021-09-05 07:27:22 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6963177901782585287)
+2021-09-05 07:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:27:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:27:23 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:27:23 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 07:27:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/5299c261-78e8-488a-a47e-c080a4c0f39b.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 07:27:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 07:27:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 07:27:24 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 07:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:28:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:28:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:28:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 07:28:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 07:29:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:29:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:29:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+2021-09-05 07:29:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 07:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:29:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:30:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 07:30:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 07:30:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 07:30:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1991450444288347941)
+2021-09-05 07:30:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1991450444288347941)
+2021-09-05 07:30:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:30:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 07:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 07:30:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:30:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:30:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:30:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:30:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 07:30:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 07:30:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 07:30:27 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-010401-image
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 118 passed, 31 skipped, 2 warnings in 5187.12s (1:26:27) ===========

--- a/21.3-1/integration_tests/gce_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/gce_focal_integration_tests.txt
@@ -1,0 +1,4066 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:42:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 13:42:20 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 13:42:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 13:42:24 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for gce
+2021-09-05 13:42:24 INFO      integration_testing:conftest.py:156 Setting up environment for gce
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:42:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:42:28 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 13:42:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:42:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:43:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:43:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:43:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:43:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:43:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=297960627775305646)
+2021-09-05 13:43:53 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=297960627775305646)
+2021-09-05 13:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:43:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 13:43:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 13:43:54 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 13:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 13:43:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 13:44:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 13:44:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:44:15 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:44:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 13:44:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 13:45:43 INFO      integration_testing:instances.py:114 Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+Done with environment setup
+2021-09-05 13:45:44 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 13:45:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 13:45:47 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 13:46:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:46:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:46:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:46:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:46:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:46:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3482422395197289703)
+2021-09-05 13:46:34 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3482422395197289703)
+2021-09-05 13:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:46:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 13:46:35 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 13:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:46:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:46:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:46:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:46:57 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 13:47:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:47:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:47:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:47:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5730152070239581344)
+2021-09-05 13:47:43 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5730152070239581344)
+2021-09-05 13:47:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:47:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 13:47:44 INFO      integration_testing:clouds.py:183 image serial: 20210831
+2021-09-05 13:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 13:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 13:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 13:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 13:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 13:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 13:47:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 13:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 13:47:48 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 13:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 13:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 13:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 13:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:48:06 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 13:48:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 13:48:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 13:48:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:48:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:49:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:49:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 13:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 13:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 13:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 13:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 13:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 13:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 13:49:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 13:49:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 13:49:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 1.198s (kernel) + 29.372s (userspace) = 30.570s 
+graphical.target reached after 27.811s in userspace
+=== `systemd-analyze` after:
+Startup finished in 1.360s (kernel) + 20.238s (userspace) = 21.599s 
+graphical.target reached after 15.545s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+12.108s accounts-daemon.service                       
+11.452s networkd-dispatcher.service                   
+ 9.562s snapd.seeded.service                          
+ 5.172s grub-initrd-fallback.service                  
+ 4.273s google-shutdown-scripts.service               
+ 3.471s grub-common.service                           
+ 2.856s setvtrgb.service                              
+ 2.535s snapd.apparmor.service                        
+ 2.374s snapd.service                                 
+ 2.350s plymouth-quit-wait.service                    
+=== `systemd-analyze blame` after (first 10 lines):
+4.832s snap.lxd.activate.service                     
+4.509s snapd.service                                 
+3.664s accounts-daemon.service                       
+3.524s cloud-final.service                           
+2.492s networkd-dispatcher.service                   
+2.317s systemd-logind.service                        
+2.079s cloud-init-local.service                      
+1.972s cloud-init.service                            
+1.933s apport.service                                
+1.858s systemd-networkd-wait-online.service          
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.39400 seconds
+Finished stage: (init-network) 01.38500 seconds
+Finished stage: (modules-config) 00.41700 seconds
+Finished stage: (modules-final) 00.08400 seconds
+Total Time: 2.28000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.25000 seconds
+Finished stage: (init-network) 01.50100 seconds
+Finished stage: (modules-config) 00.51500 seconds
+Finished stage: (modules-final) 02.99500 seconds
+Total Time: 5.26100 seconds
+Finished stage: (init-network) 00.19600 seconds
+Total Time: 0.19600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.42500s (init-network/config-growpart)
+     00.39000s (init-network/config-ssh)
+     00.22100s (modules-config/config-grub-dpkg)
+     00.16300s (init-network/config-resizefs)
+     00.08400s (modules-config/config-apt-configure)
+     00.07000s (init-network/config-users-groups)
+     00.05600s (modules-config/config-ntp)
+     00.03900s (init-network/search-GCE)
+     00.03600s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     02.26000s (modules-final/config-ssh-authkey-fingerprints)
+     00.68200s (modules-final/config-keys-to-console)
+     00.46900s (init-network/config-ssh)
+     00.24400s (modules-config/config-grub-dpkg)
+     00.14000s (modules-config/config-apt-configure)
+     00.07300s (init-network/config-resizefs)
+     00.06000s (init-network/config-growpart)
+     00.05800s (modules-config/config-ntp)
+     00.04200s (init-network/search-GCE)
+
+2021-09-05 13:49:14 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 1.198s (kernel) + 29.372s (userspace) = 30.570s 
+graphical.target reached after 27.811s in userspace
+=== `systemd-analyze` after:
+Startup finished in 1.360s (kernel) + 20.238s (userspace) = 21.599s 
+graphical.target reached after 15.545s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+12.108s accounts-daemon.service                       
+11.452s networkd-dispatcher.service                   
+ 9.562s snapd.seeded.service                          
+ 5.172s grub-initrd-fallback.service                  
+ 4.273s google-shutdown-scripts.service               
+ 3.471s grub-common.service                           
+ 2.856s setvtrgb.service                              
+ 2.535s snapd.apparmor.service                        
+ 2.374s snapd.service                                 
+ 2.350s plymouth-quit-wait.service                    
+=== `systemd-analyze blame` after (first 10 lines):
+4.832s snap.lxd.activate.service                     
+4.509s snapd.service                                 
+3.664s accounts-daemon.service                       
+3.524s cloud-final.service                           
+2.492s networkd-dispatcher.service                   
+2.317s systemd-logind.service                        
+2.079s cloud-init-local.service                      
+1.972s cloud-init.service                            
+1.933s apport.service                                
+1.858s systemd-networkd-wait-online.service          
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.39400 seconds
+Finished stage: (init-network) 01.38500 seconds
+Finished stage: (modules-config) 00.41700 seconds
+Finished stage: (modules-final) 00.08400 seconds
+Total Time: 2.28000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.25000 seconds
+Finished stage: (init-network) 01.50100 seconds
+Finished stage: (modules-config) 00.51500 seconds
+Finished stage: (modules-final) 02.99500 seconds
+Total Time: 5.26100 seconds
+Finished stage: (init-network) 00.19600 seconds
+Total Time: 0.19600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.42500s (init-network/config-growpart)
+     00.39000s (init-network/config-ssh)
+     00.22100s (modules-config/config-grub-dpkg)
+     00.16300s (init-network/config-resizefs)
+     00.08400s (modules-config/config-apt-configure)
+     00.07000s (init-network/config-users-groups)
+     00.05600s (modules-config/config-ntp)
+     00.03900s (init-network/search-GCE)
+     00.03600s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     02.26000s (modules-final/config-ssh-authkey-fingerprints)
+     00.68200s (modules-final/config-keys-to-console)
+     00.46900s (init-network/config-ssh)
+     00.24400s (modules-config/config-grub-dpkg)
+     00.14000s (modules-config/config-apt-configure)
+     00.07300s (init-network/config-resizefs)
+     00.06000s (init-network/config-growpart)
+     00.05800s (modules-config/config-ntp)
+     00.04200s (init-network/search-GCE)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:49:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:49:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:49:33 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 13:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:50:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:50:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8199820692789228549)
+2021-09-05 13:50:57 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8199820692789228549)
+2021-09-05 13:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:50:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 13:50:58 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 13:50:58 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 13:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 13:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 13:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 13:51:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:51:16 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-05 13:51:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:52:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:08:44 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+FAILED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:09:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:09:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:09:49 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:10:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:10:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:10:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1668441755140845936)
+2021-09-05 14:10:22 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1668441755140845936)
+2021-09-05 14:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:10:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:10:23 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:10:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:10:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:10:42 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:10:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:11:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:11:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:11:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:11:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:11:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3003582573039939855)
+2021-09-05 14:11:29 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3003582573039939855)
+2021-09-05 14:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:11:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:11:29 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:11:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:11:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:11:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:11:49 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:11:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:12:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:12:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:12:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7951044341485104844)
+2021-09-05 14:12:31 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7951044341485104844)
+2021-09-05 14:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:12:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:12:32 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:12:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:12:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:12:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:12:54 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:13:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:13:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:13:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:13:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=420965523310341772)
+2021-09-05 14:13:32 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=420965523310341772)
+2021-09-05 14:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:13:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:13:33 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:13:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 14:13:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 14:13:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:13:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:13:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:13:58 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:14:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:14:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:14:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:14:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:14:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:14:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:14:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8825096888032783948)
+2021-09-05 14:14:37 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8825096888032783948)
+2021-09-05 14:14:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:14:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:14:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:14:38 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 14:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 14:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 14:14:38 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 14:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:15:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:15:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:15:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:15:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:15:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:15:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 14:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 14:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:16:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:16:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:16:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:16:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:16:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:16:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:16:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2568507222088314843)
+2021-09-05 14:17:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2568507222088314843)
+2021-09-05 14:17:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:17:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:17:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:17:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-05 14:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 14:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 14:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:17:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:17:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:17:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:17:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:18:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:18:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:18:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:18:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7771785334401626005)
+2021-09-05 14:18:11 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7771785334401626005)
+2021-09-05 14:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:18:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:18:12 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:18:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:18:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:18:39 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:19:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:19:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:19:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6211271691102416723)
+2021-09-05 14:19:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6211271691102416723)
+2021-09-05 14:19:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:19:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:19:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:19:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:19:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:19:42 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:20:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=767387779995365140)
+2021-09-05 14:20:25 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=767387779995365140)
+2021-09-05 14:20:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:20:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:20:26 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:20:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:20:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:20:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:20:56 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:20:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:21:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:21:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:21:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:21:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:21:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:21:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8630379619341135061)
+2021-09-05 14:21:26 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8630379619341135061)
+2021-09-05 14:21:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:21:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:21:27 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 14:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 14:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 14:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:21:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:21:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:21:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:21:49 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:21:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:22:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:22:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:22:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8798665319990783124)
+2021-09-05 14:22:31 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8798665319990783124)
+2021-09-05 14:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:22:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:22:32 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:22:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:22:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:22:53 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:23:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:23:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:23:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:23:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:23:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=943657691704290389)
+2021-09-05 14:23:31 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=943657691704290389)
+2021-09-05 14:23:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:23:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:23:32 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:23:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:23:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:23:53 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:24:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:24:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:24:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:24:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:24:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:24:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8737220710400355353)
+2021-09-05 14:24:34 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8737220710400355353)
+2021-09-05 14:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:24:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:24:35 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 14:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 14:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 14:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 14:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 14:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:24:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:24:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:24:57 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:25:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:25:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:25:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:25:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8744870893263089112)
+2021-09-05 14:25:39 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8744870893263089112)
+2021-09-05 14:25:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:25:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:25:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:25:40 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:25:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:25:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:25:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:26:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:26:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:26:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:26:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5680380898291838360)
+2021-09-05 14:26:43 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5680380898291838360)
+2021-09-05 14:26:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:26:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:26:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:26:44 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:26:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 14:26:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:27:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:27:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:27:08 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:27:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:27:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:27:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:27:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:27:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6642637465915583830)
+2021-09-05 14:27:50 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6642637465915583830)
+2021-09-05 14:27:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:27:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:27:51 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:27:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:27:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:27:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:27:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:28:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:28:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:28:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:28:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:28:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:28:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2149546244833897749)
+2021-09-05 14:28:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2149546244833897749)
+2021-09-05 14:28:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:28:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:28:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:28:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:28:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:29:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:29:18 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:29:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:29:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:29:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:29:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:29:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:29:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:29:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:29:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6475954775909821140)
+2021-09-05 14:29:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6475954775909821140)
+2021-09-05 14:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:29:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:29:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:29:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:30:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:30:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:30:24 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:30:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:30:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:30:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:31:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2970661008765971090)
+2021-09-05 14:31:13 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2970661008765971090)
+2021-09-05 14:31:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:31:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:31:14 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:31:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:31:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 14:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 14:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:31:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:31:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:31:54 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:32:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:32:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:32:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8915435821387573795)
+2021-09-05 14:32:39 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8915435821387573795)
+2021-09-05 14:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:32:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:32:39 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:32:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:32:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:32:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:32:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:32:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:33:02 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:33:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:33:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:33:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:33:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4155765678279322612)
+2021-09-05 14:33:46 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4155765678279322612)
+2021-09-05 14:33:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:33:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:33:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:33:47 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:33:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 14:33:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:34:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:34:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:34:08 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:34:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:34:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:34:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:34:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:34:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:34:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6018127226549660593)
+2021-09-05 14:34:53 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6018127226549660593)
+2021-09-05 14:34:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:34:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:34:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:34:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:34:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:35:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:35:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:35:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:35:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:35:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:35:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6301320031264926540)
+2021-09-05 14:36:12 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6301320031264926540)
+2021-09-05 14:36:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:36:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:36:13 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 14:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 14:36:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:36:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:36:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:36:34 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:36:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:37:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:37:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:37:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7368235163661724447)
+2021-09-05 14:38:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7368235163661724447)
+2021-09-05 14:38:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:38:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:38:10 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:38:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:38:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:38:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:38:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:38:30 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:38:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:38:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:39:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:39:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1746151878327625868)
+2021-09-05 14:39:10 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1746151878327625868)
+2021-09-05 14:39:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:39:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:39:11 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:39:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:39:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:39:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:39:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:39:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:40:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:40:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:40:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:40:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8593226593157605454)
+2021-09-05 14:40:12 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8593226593157605454)
+2021-09-05 14:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:40:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:40:12 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:40:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:40:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:40:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:40:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:40:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:40:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:41:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:41:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5241848472329087026)
+2021-09-05 14:41:11 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5241848472329087026)
+2021-09-05 14:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:41:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:41:11 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:41:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:41:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:41:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:42:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:42:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:42:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:42:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:42:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2205334253646473718)
+2021-09-05 14:42:12 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2205334253646473718)
+2021-09-05 14:42:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:42:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:42:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:42:13 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:42:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:42:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:42:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:42:45 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:42:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:43:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:43:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:43:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=804322570300647865)
+2021-09-05 14:43:12 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=804322570300647865)
+2021-09-05 14:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:43:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:43:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:43:13 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:43:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 14:43:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 14:43:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:43:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:43:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:43:34 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:43:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:44:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:44:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:44:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6902513318382627195)
+2021-09-05 14:44:18 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6902513318382627195)
+2021-09-05 14:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:44:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:44:19 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:44:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:44:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:45:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:45:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:45:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:45:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:45:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:45:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4737111504910379289)
+2021-09-05 14:45:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4737111504910379289)
+2021-09-05 14:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:45:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:45:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:45:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:45:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:46:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:46:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:46:53 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:47:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:47:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:47:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:47:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8815656854858852021)
+2021-09-05 14:47:54 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8815656854858852021)
+2021-09-05 14:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:47:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:47:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:48:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:48:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:48:14 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:48:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:48:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:48:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:48:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:48:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:48:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:48:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:48:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2196446007805961795)
+2021-09-05 14:48:53 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2196446007805961795)
+2021-09-05 14:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:48:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:48:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:49:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:49:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:49:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:49:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:49:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:49:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7000811594936051231)
+2021-09-05 14:50:01 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7000811594936051231)
+2021-09-05 14:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:50:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:50:02 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+FAILED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:50:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:50:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:50:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:50:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:50:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:50:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:50:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:50:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:50:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8936481874102544323)
+2021-09-05 14:51:02 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8936481874102544323)
+2021-09-05 14:51:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:51:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:51:03 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:51:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:51:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:51:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:51:24 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:51:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:51:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:51:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:51:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:51:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:51:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:51:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:51:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1081004831660402565)
+2021-09-05 14:52:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1081004831660402565)
+2021-09-05 14:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:52:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:52:09 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:52:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:52:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:52:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:53:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:53:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:53:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6905824523419477828)
+2021-09-05 14:53:11 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6905824523419477828)
+2021-09-05 14:53:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:53:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:53:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:53:12 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:53:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:53:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:53:45 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:54:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:54:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:54:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6243850585705637635)
+2021-09-05 14:54:17 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6243850585705637635)
+2021-09-05 14:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:54:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:54:18 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 14:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 14:54:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 14:54:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 14:54:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 14:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 14:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 14:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 14:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 14:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 14:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 14:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 14:54:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 14:54:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 14:54:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 14:54:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 14:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 14:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 14:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 14:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 14:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 14:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 14:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 14:54:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 14:54:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 14:54:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 14:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 14:54:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 14:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 14:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 14:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 14:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 14:54:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 14:54:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 14:54:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 14:54:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:54:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:54:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 14:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 14:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 14:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 14:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 14:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 14:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 14:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:54:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:54:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:54:53 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:55:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:55:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:55:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5156575027698164948)
+2021-09-05 14:55:35 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5156575027698164948)
+2021-09-05 14:55:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:55:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:55:36 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 14:55:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 14:55:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 14:55:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 14:55:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 14:55:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 14:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 14:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 14:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 14:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 14:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 14:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 14:55:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 14:55:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 14:55:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 14:55:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 14:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 14:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 14:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 14:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 14:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 14:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 14:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 14:55:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 14:55:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 14:55:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 14:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 14:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 14:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 14:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 14:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 14:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 14:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 14:55:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 14:55:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 14:55:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:55:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:55:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 14:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 14:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 14:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 14:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 14:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 14:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 14:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:56:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:56:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:56:13 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:56:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:56:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:56:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:56:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3580323176822432868)
+2021-09-05 14:56:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3580323176822432868)
+2021-09-05 14:56:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:56:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:56:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 14:56:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:56:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 14:56:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:56:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 14:56:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:56:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 14:56:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:56:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:56:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 14:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 14:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 14:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 14:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 14:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 14:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 14:57:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 14:57:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 14:57:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 14:57:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 14:57:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 14:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 14:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 14:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:57:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 14:57:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 14:57:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 14:57:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 14:57:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 14:57:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 14:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 14:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 14:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 14:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 14:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 14:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 14:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 14:57:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 14:57:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 14:57:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:57:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 14:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 14:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 14:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 14:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 14:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 14:57:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 14:57:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:57:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:57:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:57:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:57:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:57:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:57:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:58:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:58:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:58:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:58:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4674271593589466165)
+2021-09-05 14:58:17 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4674271593589466165)
+2021-09-05 14:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:58:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:58:18 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 14:58:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 14:58:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 14:58:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 14:58:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 14:58:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 14:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 14:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 14:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 14:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 14:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 14:58:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 14:58:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 14:58:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 14:58:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 14:58:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 14:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 14:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 14:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 14:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 14:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 14:58:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 14:58:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 14:58:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 14:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 14:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 14:58:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 14:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 14:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 14:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 14:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 14:58:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 14:58:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 14:58:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:58:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:58:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 14:58:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 14:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 14:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 14:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 14:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 14:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 14:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 14:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:58:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:58:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:58:53 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:59:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:59:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:59:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:59:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=668578518297830852)
+2021-09-05 14:59:33 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=668578518297830852)
+2021-09-05 14:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:59:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 14:59:34 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 14:59:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 14:59:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:59:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:59:57 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:00:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:00:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:00:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:00:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4771708948243375492)
+2021-09-05 15:00:42 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4771708948243375492)
+2021-09-05 15:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:00:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:00:43 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 15:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 15:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 15:00:44 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 15:00:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/cdfc535b-ede5-40d8-a56e-5f61b26d8aca.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 15:00:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 15:00:45 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:01:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:01:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:01:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:01:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:01:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:01:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:02:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:02:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:02:31 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 15:02:33 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:02:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:03:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:03:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:03:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4328930822554477289)
+2021-09-05 15:03:13 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4328930822554477289)
+2021-09-05 15:03:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:03:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:03:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:03:14 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:03:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 15:03:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 15:03:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 15:03:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 15:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/f81edf7c-a586-475b-a1a7-e41fadac435d.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 15:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 15:03:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:03:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:04:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:04:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:04:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:04:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:04:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:04:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:05:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:05:14 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:05:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:05:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:05:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:05:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:05:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3347904431803425395)
+2021-09-05 15:05:48 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3347904431803425395)
+2021-09-05 15:05:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:05:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:05:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:05:49 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:05:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:06:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:06:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:06:13 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:06:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:06:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:06:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7366498210167742989)
+2021-09-05 15:06:57 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7366498210167742989)
+2021-09-05 15:06:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:06:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:06:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:06:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:06:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:07:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:07:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:07:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:07:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:07:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:07:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:07:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:07:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:07:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:07:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5213699793542013901)
+2021-09-05 15:07:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5213699793542013901)
+2021-09-05 15:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:07:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:07:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 15:07:57 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:08:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:08:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:08:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:08:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:08:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:08:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:08:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 15:08:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 15:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/7c11f87b-9988-4d52-b2fa-fe8c40346be6.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 15:08:53 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:09:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:10:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:10:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:10:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:10:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 15:11:04 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:11:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:11:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:11:07 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:11:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:11:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:11:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6853300535133036775)
+2021-09-05 15:11:49 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6853300535133036775)
+2021-09-05 15:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:11:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:11:50 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:11:50 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 15:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/27659f48-347c-4209-9dd8-d227019ac594.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 15:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 15:11:51 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:12:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:12:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:12:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:12:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:12:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:12:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:13:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:13:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:13:34 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 15:13:37 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:13:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:14:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:14:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:14:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:14:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:14:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:14:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:14:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6626584931157500017)
+2021-09-05 15:14:19 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6626584931157500017)
+2021-09-05 15:14:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:14:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:14:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:14:20 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:14:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 15:14:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/950a1c8b-375f-4ce0-aa70-64979502773c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 15:14:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 15:14:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 15:14:21 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 15:14:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:15:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:15:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:15:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:15:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:15:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:15:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:15:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 15:15:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:16:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:16:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 15:16:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 15:16:20 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 15:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 15:16:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 15:16:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 15:16:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2570139021897982425)
+2021-09-05 15:16:48 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2570139021897982425)
+2021-09-05 15:16:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:16:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 15:16:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 15:16:49 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:16:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:16:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:16:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 15:16:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 15:16:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 15:17:10 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+
+
+=================================== FAILURES ===================================
+___________________ test_subsequent_boot_of_upgraded_package ___________________
+
+session_cloud = <tests.integration_tests.clouds.GceCloud object at 0x7fc784fab9e8>
+
+    @pytest.mark.ci
+    @pytest.mark.ubuntu
+    def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
+        source = get_validated_source(session_cloud)
+        if not source.installs_new_version():
+            if os.environ.get('TRAVIS'):
+                # If this isn't running on CI, we should know
+                pytest.fail(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
+            else:
+                pytest.skip(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
+            return  # type checking doesn't understand that skip raises
+    
+        launch_kwargs = {'image_id': session_cloud.released_image_id}
+    
+        with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
+            instance.install_new_cloud_init(
+                source, take_snapshot=False, clean=False
+            )
+>           instance.restart()
+
+tests/integration_tests/test_upgrade.py:166: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/integration_tests/instances.py:67: in restart
+    self.instance.restart()
+../pycloudlib/pycloudlib/gce/instance.py:102: in restart
+    self.start()
+../pycloudlib/pycloudlib/gce/instance.py:132: in start
+    self.wait()
+../pycloudlib/pycloudlib/instance.py:101: in wait
+    self._wait_for_execute()
+../pycloudlib/pycloudlib/instance.py:381: in _wait_for_execute
+    result = self.execute(test_instance_command)
+../pycloudlib/pycloudlib/instance.py:181: in execute
+    return self._run_command(command, stdin, **kwargs)
+../pycloudlib/pycloudlib/instance.py:147: in _run_command
+    return self._ssh(list(command), stdin=stdin)
+../pycloudlib/pycloudlib/instance.py:284: in _ssh
+    fp_in, fp_out, fp_err = client.exec_command(cmd)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/client.py:508: in exec_command
+    chan = self._transport.open_session(timeout=timeout)
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:879: in open_session
+    timeout=timeout,
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:1006: in open_channel
+    raise e
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py:2055: in run
+    ptype, m = self.packetizer.read_message()
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:459: in read_message
+    header = self.read_all(self.__block_size_in, check_rekey=True)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <paramiko.packet.Packetizer object at 0x7fc7821be4a8>, n = 16
+check_rekey = True
+
+    def read_all(self, n, check_rekey=False):
+        """
+        Read as close to N bytes as possible, blocking as long as necessary.
+    
+        :param int n: number of bytes to read
+        :return: the data read, as a `str`
+    
+        :raises:
+            ``EOFError`` -- if the socket was closed before all the bytes could
+            be read
+        """
+        out = bytes()
+        # handle over-reading from reading the banner line
+        if len(self.__remainder) > 0:
+            out = self.__remainder[:n]
+            self.__remainder = self.__remainder[n:]
+            n -= len(out)
+        while n > 0:
+            got_timeout = False
+            if self.handshake_timed_out():
+                raise EOFError()
+            try:
+>               x = self.__socket.recv(n)
+E               TimeoutError: [Errno 110] Connection timed out
+
+../envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py:301: TimeoutError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 13:49:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+------------------------------ Captured log call -------------------------------
+2021-09-05 13:49:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-05 13:49:33 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 13:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:50:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 13:50:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:50:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:50:57 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8199820692789228549)
+2021-09-05 13:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-05 13:50:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 13:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-05 13:50:58 INFO      integration_testing:clouds.py:183 image serial: 20210831
+2021-09-05 13:50:58 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 13:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 13:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 13:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 13:51:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-05 13:51:16 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 13:51:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:52:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:08:44 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection timed out (110)
+_______ TestSshAuthkeyFingerprints.test_ssh_authkey_fingerprints_enable ________
+
+self = <test_ssh_auth_key_fingerprints.TestSshAuthkeyFingerprints object at 0x7fc783addcc0>
+client = <tests.integration_tests.instances.IntegrationGceInstance object at 0x7fc781fee668>
+
+    @pytest.mark.user_data(USER_DATA_SSH_AUTHKEY_ENABLE)
+    def test_ssh_authkey_fingerprints_enable(self, client):
+        syslog_output = client.read_from_file("/var/log/syslog")
+    
+>       assert re.search(r'256 SHA256:.*(ECDSA)', syslog_output) is not None
+E       AssertionError: assert None is not None
+E        +  where None = <function search at 0x7fc78ddaad08>('256 SHA256:.*(ECDSA)', 'Sep  5 14:49:50 i37-gce-integration-test-0905-084205 systemd-sysctl[177]: Not setting net/ipv4/conf/all/promote_secon...timate of 30s plus 5s per snap)\nSep  5 14:49:54 i37-gce-integration-test-0905-084205 systemd[1]: Started Snap Daemon.')
+E        +    where <function search at 0x7fc78ddaad08> = re.search
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py:45: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 14:49:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 14:49:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-084205-image
+2021-09-05 14:49:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 14:49:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 14:49:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 14:49:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 14:49:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 14:50:01 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7000811594936051231)
+2021-09-05 14:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-05 14:50:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 14:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-05 14:50:02 INFO      integration_testing:clouds.py:183 image serial: 20210831
+------------------------------ Captured log call -------------------------------
+2021-09-05 14:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package
+FAILED tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable
+====== 2 failed, 116 passed, 31 skipped, 2 warnings in 5705.58s (1:35:05) ======

--- a/21.3-1/integration_tests/gce_focal_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/gce_focal_integration_tests_rerun.txt
@@ -1,0 +1,196 @@
+========================================== test session starts ===========================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 2 items
+
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+--------------------------------------------- live log setup ---------------------------------------------
+2021-09-06 19:38:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-06 19:38:15 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-06 19:38:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-06 19:38:20 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+--------------------------------------------- live log call ----------------------------------------------
+2021-09-06 19:38:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-06 19:38:23 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 19:38:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:38:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-06 19:39:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 19:39:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3229523515239289026)
+2021-09-06 19:39:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3229523515239289026)
+2021-09-06 19:39:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-06 19:39:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-06 19:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 19:39:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-06 19:39:08 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 19:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 19:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 19:39:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 19:39:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-06 19:39:27 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-06 19:39:27 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 19:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:40:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:40:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:40:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-06 19:40:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 19:40:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 19:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+--------------------------------------------- live log setup ---------------------------------------------
+2021-09-06 19:41:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Setting up environment for gce
+2021-09-06 19:41:05 INFO      integration_testing:conftest.py:156 Setting up environment for gce
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-06 19:41:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20210831
+2021-09-06 19:41:08 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 19:41:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:41:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-06 19:41:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 19:41:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1849808066453426237)
+2021-09-06 19:41:54 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1849808066453426237)
+2021-09-06 19:41:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-06 19:41:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-06 19:41:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 19:41:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-06 19:41:54 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 19:41:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 19:41:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 19:42:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 19:42:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-06 19:42:15 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-06 19:42:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 19:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+2021-09-06 19:43:12 INFO      integration_testing:instances.py:114 Created new image: projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+Done with environment setup
+2021-09-06 19:43:13 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+2021-09-06 19:43:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+2021-09-06 19:43:16 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 19:43:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:43:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:43:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:43:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 19:43:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-06 19:43:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 19:43:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6243051884997497278)
+2021-09-06 19:43:55 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6243051884997497278)
+2021-09-06 19:43:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-06 19:43:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-06 19:43:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 19:43:56 INFO      integration_testing:clouds.py:183 image serial: 20210831
+--------------------------------------------- live log call ----------------------------------------------
+2021-09-06 19:43:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSEDDeleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+
+------------------------------------------- live log teardown --------------------------------------------
+2021-09-06 19:44:14 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i1-gce-integration-test-0906-143813-image
+
+
+============================================ warnings summary ============================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=============================== 2 passed, 2 warnings in 362.03s (0:06:02) ================================

--- a/21.3-1/integration_tests/gce_hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/gce_hirsute_integration_tests.txt
@@ -1,0 +1,4058 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:36:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 22:36:23 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 22:36:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 22:36:28 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for gce
+2021-09-05 22:36:28 INFO      integration_testing:conftest.py:156 Setting up environment for gce
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+2021-09-05 22:36:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+2021-09-05 22:36:31 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:36:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:36:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:37:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:37:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:37:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8190446230880974979)
+2021-09-05 22:37:17 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8190446230880974979)
+2021-09-05 22:37:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:37:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:37:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:37:18 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 22:37:18 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 22:37:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 22:37:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 22:37:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 22:37:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:37:35 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:37:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 22:37:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:38:26 INFO      integration_testing:instances.py:114 Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+Done with environment setup
+2021-09-05 22:38:27 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:38:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:38:30 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:38:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:38:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:38:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:39:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8218075064006408204)
+2021-09-05 22:39:08 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8218075064006408204)
+2021-09-05 22:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:39:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:39:09 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:39:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 22:39:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:39:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:39:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+2021-09-05 22:39:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+2021-09-05 22:39:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:39:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:40:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:40:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:40:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4279326252388121072)
+2021-09-05 22:40:14 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4279326252388121072)
+2021-09-05 22:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:40:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:40:15 INFO      integration_testing:clouds.py:183 image serial: 20210831
+2021-09-05 22:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 22:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 22:40:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 22:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 22:40:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 22:40:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 22:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 22:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 22:40:18 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 22:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 22:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 22:40:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 22:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:40:36 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 22:40:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 22:40:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 22:40:37 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:41:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:41:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:41:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:41:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:41:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 22:41:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 22:41:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 22:41:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 22:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 22:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 22:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 22:41:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 22:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 22:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 1.185s (kernel) + 28.117s (userspace) = 29.302s 
+graphical.target reached after 26.536s in userspace
+=== `systemd-analyze` after:
+Startup finished in 1.199s (kernel) + 22.712s (userspace) = 23.911s 
+graphical.target reached after 16.105s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+11.172s accounts-daemon.service
+ 9.564s snapd.seeded.service
+ 8.065s networkd-dispatcher.service
+ 5.466s grub-initrd-fallback.service
+ 4.235s google-shutdown-scripts.service
+ 2.854s google-oslogin-cache.service
+ 2.840s grub-common.service
+ 2.805s setvtrgb.service
+ 2.803s pollinate.service
+ 2.768s secureboot-db.service
+=== `systemd-analyze blame` after (first 10 lines):
+6.063s snap.lxd.activate.service
+5.466s cloud-final.service
+5.447s snapd.service
+3.113s accounts-daemon.service
+2.148s networkd-dispatcher.service
+1.988s cloud-init-local.service
+1.795s cloud-init.service
+1.710s apport.service
+1.658s systemd-logind.service
+1.637s systemd-networkd-wait-online.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.41800 seconds
+Finished stage: (init-network) 01.33300 seconds
+Finished stage: (modules-config) 00.57000 seconds
+Finished stage: (modules-final) 00.09200 seconds
+Total Time: 2.41300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.27100 seconds
+Finished stage: (init-network) 01.44100 seconds
+Finished stage: (modules-config) 00.56000 seconds
+Finished stage: (modules-final) 05.07600 seconds
+Total Time: 7.34800 seconds
+Finished stage: (init-network) 00.17800 seconds
+Total Time: 0.17800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.60200s (init-network/config-growpart)
+     00.22100s (modules-config/config-apt-configure)
+     00.21900s (modules-config/config-grub-dpkg)
+     00.17700s (init-network/config-ssh)
+     00.13600s (init-network/config-resizefs)
+     00.08200s (init-network/config-users-groups)
+     00.07200s (modules-config/config-ntp)
+     00.04400s (init-network/search-GCE)
+     00.03800s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     04.65700s (modules-final/config-ssh-authkey-fingerprints)
+     00.45900s (init-network/config-ssh)
+     00.37100s (modules-final/config-keys-to-console)
+     00.30100s (modules-config/config-grub-dpkg)
+     00.09300s (modules-config/config-apt-configure)
+     00.06800s (modules-config/config-ntp)
+     00.05900s (init-network/config-resizefs)
+     00.05800s (init-network/config-growpart)
+     00.05300s (modules-config/config-locale)
+
+2021-09-05 22:41:41 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 1.185s (kernel) + 28.117s (userspace) = 29.302s 
+graphical.target reached after 26.536s in userspace
+=== `systemd-analyze` after:
+Startup finished in 1.199s (kernel) + 22.712s (userspace) = 23.911s 
+graphical.target reached after 16.105s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+11.172s accounts-daemon.service
+ 9.564s snapd.seeded.service
+ 8.065s networkd-dispatcher.service
+ 5.466s grub-initrd-fallback.service
+ 4.235s google-shutdown-scripts.service
+ 2.854s google-oslogin-cache.service
+ 2.840s grub-common.service
+ 2.805s setvtrgb.service
+ 2.803s pollinate.service
+ 2.768s secureboot-db.service
+=== `systemd-analyze blame` after (first 10 lines):
+6.063s snap.lxd.activate.service
+5.466s cloud-final.service
+5.447s snapd.service
+3.113s accounts-daemon.service
+2.148s networkd-dispatcher.service
+1.988s cloud-init-local.service
+1.795s cloud-init.service
+1.710s apport.service
+1.658s systemd-logind.service
+1.637s systemd-networkd-wait-online.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.41800 seconds
+Finished stage: (init-network) 01.33300 seconds
+Finished stage: (modules-config) 00.57000 seconds
+Finished stage: (modules-final) 00.09200 seconds
+Total Time: 2.41300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.27100 seconds
+Finished stage: (init-network) 01.44100 seconds
+Finished stage: (modules-config) 00.56000 seconds
+Finished stage: (modules-final) 05.07600 seconds
+Total Time: 7.34800 seconds
+Finished stage: (init-network) 00.17800 seconds
+Total Time: 0.17800 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.60200s (init-network/config-growpart)
+     00.22100s (modules-config/config-apt-configure)
+     00.21900s (modules-config/config-grub-dpkg)
+     00.17700s (init-network/config-ssh)
+     00.13600s (init-network/config-resizefs)
+     00.08200s (init-network/config-users-groups)
+     00.07200s (modules-config/config-ntp)
+     00.04400s (init-network/search-GCE)
+     00.03800s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     04.65700s (modules-final/config-ssh-authkey-fingerprints)
+     00.45900s (init-network/config-ssh)
+     00.37100s (modules-final/config-keys-to-console)
+     00.30100s (modules-config/config-grub-dpkg)
+     00.09300s (modules-config/config-apt-configure)
+     00.06800s (modules-config/config-ntp)
+     00.05900s (init-network/config-resizefs)
+     00.05800s (init-network/config-growpart)
+     00.05300s (modules-config/config-locale)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:42:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:42:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+2021-09-05 22:42:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:42:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1819 Exception: Error reading SSH protocol banner[Errno 104] Connection reset by peer
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 Traceback (most recent call last):
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817   File "/home/james/envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py", line 2211, in _check_banner
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817     buf = self.packetizer.readline(timeout)
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817   File "/home/james/envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py", line 380, in readline
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817     buf += self._read_timeout(timeout)
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817   File "/home/james/envs/cloud-init/lib/python3.5/site-packages/paramiko/packet.py", line 607, in _read_timeout
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817     x = self.__socket.recv(128)
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 ConnectionResetError: [Errno 104] Connection reset by peer
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 During handling of the above exception, another exception occurred:
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 Traceback (most recent call last):
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817   File "/home/james/envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py", line 2039, in run
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817     self._check_banner()
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817   File "/home/james/envs/cloud-init/lib/python3.5/site-packages/paramiko/transport.py", line 2216, in _check_banner
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817     "Error reading SSH protocol banner" + str(e)
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 paramiko.ssh_exception.SSHException: Error reading SSH protocol banner[Errno 104] Connection reset by peer
+2021-09-05 22:42:38 ERROR     paramiko.transport:transport.py:1817 
+2021-09-05 22:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:42:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:42:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:42:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6259354683204761941)
+2021-09-05 22:42:48 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6259354683204761941)
+2021-09-05 22:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:42:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-05 22:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:42:49 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-05 22:42:49 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 22:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 22:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 22:42:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 22:43:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:43:07 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+Restarting instance and waiting for boot
+2021-09-05 22:43:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:43:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:43:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:43:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:43:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:44:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:44:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:44:24 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:44:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:44:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:44:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:44:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5793603451759425193)
+2021-09-05 22:45:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5793603451759425193)
+2021-09-05 22:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:45:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:45:10 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:45:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:45:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:45:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:45:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:46:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:46:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=394631893407561320)
+2021-09-05 22:46:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=394631893407561320)
+2021-09-05 22:46:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:46:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:46:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:46:16 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:46:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:46:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:46:50 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:47:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:47:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:47:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7624981668597134882)
+2021-09-05 22:47:16 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7624981668597134882)
+2021-09-05 22:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:47:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:47:17 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:47:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:47:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:47:43 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:47:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:48:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:48:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:48:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8093790568864872419)
+2021-09-05 22:48:22 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8093790568864872419)
+2021-09-05 22:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:48:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:48:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:48:23 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:48:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:48:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 22:48:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:48:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:48:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:48:42 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:48:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:49:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:49:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:49:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=312949299134134183)
+2021-09-05 22:49:24 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=312949299134134183)
+2021-09-05 22:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:49:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:49:24 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:49:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 22:49:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 22:49:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 22:49:25 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:50:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:50:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:50:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:50:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:50:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:50:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:50:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 22:50:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:51:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:51:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:51:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:51:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:51:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:51:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:51:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2929447438896396081)
+2021-09-05 22:51:57 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2929447438896396081)
+2021-09-05 22:51:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:51:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:51:58 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:51:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:51:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:51:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:51:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:51:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 22:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-05 22:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:51:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 22:51:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:52:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 22:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:52:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:52:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:52:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:52:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:52:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:52:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:52:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:52:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:52:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:52:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:52:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:52:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=537781160518415563)
+2021-09-05 22:53:01 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=537781160518415563)
+2021-09-05 22:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:53:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:53:02 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:53:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:53:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:53:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:53:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:53:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:53:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:53:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:54:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6477692558332458122)
+2021-09-05 22:54:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6477692558332458122)
+2021-09-05 22:54:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:54:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:54:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:54:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:54:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:54:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:54:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:54:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:54:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:54:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:54:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:55:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:55:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:55:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:55:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4453134318907749450)
+2021-09-05 22:55:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4453134318907749450)
+2021-09-05 22:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:55:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:55:16 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:55:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:55:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:55:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:55:38 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:56:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:56:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:56:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1652543753306043399)
+2021-09-05 22:56:19 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1652543753306043399)
+2021-09-05 22:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:56:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:56:20 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 22:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 22:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 22:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:56:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:56:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:56:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:56:42 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:56:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:57:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:57:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:57:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:57:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2468078555856696775)
+2021-09-05 22:57:24 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2468078555856696775)
+2021-09-05 22:57:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:57:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:57:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:57:24 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:57:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:57:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:57:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:57:55 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:57:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:58:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:58:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:58:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:58:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8427022667451266441)
+2021-09-05 22:58:30 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8427022667451266441)
+2021-09-05 22:58:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:58:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:58:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:58:31 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:58:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:58:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:58:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:58:52 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 22:59:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:59:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 22:59:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:59:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8059346507403949381)
+2021-09-05 22:59:35 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8059346507403949381)
+2021-09-05 22:59:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:59:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 22:59:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 22:59:36 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 22:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 22:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 22:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 22:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:59:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:59:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 22:59:58 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:00:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:00:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:00:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:00:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:00:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:00:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:00:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2167973638808597764)
+2021-09-05 23:00:41 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2167973638808597764)
+2021-09-05 23:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:00:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:00:41 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:01:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:01:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:01:04 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:01:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:01:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:01:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6787480376070173377)
+2021-09-05 23:01:44 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6787480376070173377)
+2021-09-05 23:01:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:01:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:01:45 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 23:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:02:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:02:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:02:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:02:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:02:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:02:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:02:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:02:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:02:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:02:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:02:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3937823266560340638)
+2021-09-05 23:02:50 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3937823266560340638)
+2021-09-05 23:02:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:02:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:02:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:02:51 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:02:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:02:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:02:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+FAILED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:02:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+FAILED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:03:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:03:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:03:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:03:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:03:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:03:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:03:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:03:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:03:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1310190247989539394)
+2021-09-05 23:03:55 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1310190247989539394)
+2021-09-05 23:03:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:03:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:03:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:03:56 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:03:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:03:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:03:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:04:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:04:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:04:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:04:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:04:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:04:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:04:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:04:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2932831100031529472)
+2021-09-05 23:04:58 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2932831100031529472)
+2021-09-05 23:04:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:04:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:04:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:04:59 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:04:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:04:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:04:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:04:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:04:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:05:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:05:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:05:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:05:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:05:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:05:19 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:05:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:05:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:05:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:05:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:05:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:05:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:05:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2527080780754645954)
+2021-09-05 23:06:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2527080780754645954)
+2021-09-05 23:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:06:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:06:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:06:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:06:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 23:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 23:06:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:06:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:06:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:06:34 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:06:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:07:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:07:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:07:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:07:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:07:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:07:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=9010316180146680727)
+2021-09-05 23:07:28 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=9010316180146680727)
+2021-09-05 23:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:07:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:07:29 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:07:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:07:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:07:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:07:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:07:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:07:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:07:52 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:08:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:08:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:08:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1525139887841932073)
+2021-09-05 23:08:32 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1525139887841932073)
+2021-09-05 23:08:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:08:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:08:33 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 23:08:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:08:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:08:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:09:09 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:09:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:09:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:09:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=9040687160912048359)
+2021-09-05 23:09:43 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=9040687160912048359)
+2021-09-05 23:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:09:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:09:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:09:44 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:09:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:10:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:10:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:10:03 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:10:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:10:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:10:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:10:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:10:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:10:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2902317401797882023)
+2021-09-05 23:10:57 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2902317401797882023)
+2021-09-05 23:10:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:10:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:10:58 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 23:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 23:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:11:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:11:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:11:17 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:11:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:11:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:11:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:11:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:11:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:11:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:11:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:11:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5276941327254745212)
+2021-09-05 23:13:03 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5276941327254745212)
+2021-09-05 23:13:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:13:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:13:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:13:04 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:13:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:13:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:13:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:13:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:13:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:13:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:13:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:13:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:13:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:13:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:14:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=544610450576830971)
+2021-09-05 23:14:03 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=544610450576830971)
+2021-09-05 23:14:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:14:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:14:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:14:04 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:14:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:14:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:14:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:14:30 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:14:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:14:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:14:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:14:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:15:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=1451109121403711932)
+2021-09-05 23:15:06 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=1451109121403711932)
+2021-09-05 23:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:15:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:15:07 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:15:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:15:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:15:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:15:28 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:15:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:15:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:15:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:15:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:15:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:15:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:16:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6624754819822842209)
+2021-09-05 23:16:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6624754819822842209)
+2021-09-05 23:16:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:16:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:16:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:16:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:16:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:16:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:16:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:16:28 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:16:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:16:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:16:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:16:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:16:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:17:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3790526740373762341)
+2021-09-05 23:17:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3790526740373762341)
+2021-09-05 23:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:17:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:17:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:17:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:17:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:17:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:17:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:18:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:18:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:18:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5052239311321755365)
+2021-09-05 23:18:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5052239311321755365)
+2021-09-05 23:18:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:18:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:18:16 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 23:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 23:18:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:18:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:18:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:18:38 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:19:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:19:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:19:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4340272877700443812)
+2021-09-05 23:19:23 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4340272877700443812)
+2021-09-05 23:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:19:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:19:23 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:19:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:20:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:20:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:20:29 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:20:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:20:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:20:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:20:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:20:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2328388167643229760)
+2021-09-05 23:20:59 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2328388167643229760)
+2021-09-05 23:20:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:20:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:20:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:21:00 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:21:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:21:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:21:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:21:52 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:22:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:22:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:22:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:22:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:22:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5187631133056626658)
+2021-09-05 23:22:49 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5187631133056626658)
+2021-09-05 23:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:22:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:22:50 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:23:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:23:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:23:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:23:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:23:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:23:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=147651366714142641)
+2021-09-05 23:23:56 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=147651366714142641)
+2021-09-05 23:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:23:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:23:57 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:24:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:24:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:24:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:24:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2559812331380469579)
+2021-09-05 23:24:59 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2559812331380469579)
+2021-09-05 23:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:25:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:25:00 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+FAILED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:25:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:25:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:25:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:25:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:25:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:25:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:25:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:25:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:25:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:26:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3163657825227960074)
+2021-09-05 23:26:11 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3163657825227960074)
+2021-09-05 23:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:26:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:26:12 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:26:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:26:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:26:32 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:26:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:26:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:26:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:27:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:27:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:27:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8051413243246734537)
+2021-09-05 23:27:12 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8051413243246734537)
+2021-09-05 23:27:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:27:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:27:13 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:27:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:27:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:27:33 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:27:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:27:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:27:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:27:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:28:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:28:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:28:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:28:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=909627407392631949)
+2021-09-05 23:28:15 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=909627407392631949)
+2021-09-05 23:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:28:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:28:15 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:28:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:28:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:28:37 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:28:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:29:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:29:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:29:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:29:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:29:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8714412101891320908)
+2021-09-05 23:29:21 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8714412101891320908)
+2021-09-05 23:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:29:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:29:22 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 23:29:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 23:29:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 23:29:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 23:29:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 23:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 23:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 23:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 23:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 23:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 23:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 23:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 23:29:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 23:29:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 23:29:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 23:29:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 23:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 23:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 23:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 23:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 23:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 23:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 23:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 23:29:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 23:29:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 23:29:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 23:29:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 23:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 23:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 23:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 23:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:29:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 23:29:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 23:29:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 23:29:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 23:29:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 23:29:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:29:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 23:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 23:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 23:29:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 23:29:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 23:29:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 23:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 23:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:29:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:29:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:29:59 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:30:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:30:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:30:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:30:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:30:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:30:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5700863507132115994)
+2021-09-05 23:30:43 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5700863507132115994)
+2021-09-05 23:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:30:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:30:43 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 23:30:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 23:30:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 23:30:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 23:30:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 23:30:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 23:30:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 23:30:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 23:30:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 23:30:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:30:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 23:30:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 23:30:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 23:30:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 23:30:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 23:30:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 23:30:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 23:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 23:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 23:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 23:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 23:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:30:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 23:30:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 23:30:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 23:30:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 23:30:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 23:30:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 23:30:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 23:30:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 23:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 23:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 23:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 23:30:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 23:30:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 23:30:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 23:30:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 23:30:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:30:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:30:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 23:30:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 23:30:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 23:30:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 23:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 23:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 23:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 23:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:31:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:31:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:31:31 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:31:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:31:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:31:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:31:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:31:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:31:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=9165796865300032938)
+2021-09-05 23:32:04 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=9165796865300032938)
+2021-09-05 23:32:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:32:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:32:05 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 23:32:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 23:32:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 23:32:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 23:32:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 23:32:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 23:32:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 23:32:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 23:32:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:32:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 23:32:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 23:32:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 23:32:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 23:32:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 23:32:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 23:32:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 23:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 23:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 23:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 23:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 23:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 23:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 23:32:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 23:32:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 23:32:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 23:32:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 23:32:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 23:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 23:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 23:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 23:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 23:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 23:32:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 23:32:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 23:32:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:32:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 23:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 23:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 23:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 23:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 23:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 23:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 23:32:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:32:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:32:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:32:43 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:32:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:33:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:33:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=4631745412994755958)
+2021-09-05 23:33:27 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=4631745412994755958)
+2021-09-05 23:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:33:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:33:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:33:28 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:33:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 23:33:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 23:33:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 23:33:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 23:33:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 23:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 23:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 23:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 23:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 23:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 23:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 23:33:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 23:33:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 23:33:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 23:33:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 23:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 23:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 23:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 23:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:33:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 23:33:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 23:33:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 23:33:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 23:33:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 23:33:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 23:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 23:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 23:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 23:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 23:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 23:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 23:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 23:33:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 23:33:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 23:33:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:33:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 23:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 23:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 23:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 23:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 23:33:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 23:33:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 23:33:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 23:33:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:34:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:34:03 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:34:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:34:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:34:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:34:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:34:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3458673811620687111)
+2021-09-05 23:34:41 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3458673811620687111)
+2021-09-05 23:34:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:34:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:34:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:34:41 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:34:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:35:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:35:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:35:07 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:35:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:35:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:35:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=883329545977522887)
+2021-09-05 23:35:50 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=883329545977522887)
+2021-09-05 23:35:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:35:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:35:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:35:51 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:35:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 23:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 23:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 23:35:53 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 23:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/67dbc8e4-58aa-4922-825c-ff1555f76e70.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 23:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 23:35:53 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:36:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:36:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:36:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:36:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:36:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:36:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:36:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:37:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:37:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:37:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 23:37:37 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:38:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:38:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:38:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6793303866392242768)
+2021-09-05 23:38:22 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6793303866392242768)
+2021-09-05 23:38:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:38:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:38:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:38:23 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:38:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 23:38:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 23:38:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 23:38:24 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 23:38:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/a1afac5c-f964-4f81-8f5f-59314f4a4e78.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 23:38:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 23:38:25 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:39:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:39:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:39:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:39:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:39:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:40:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:40:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 23:40:09 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:40:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:40:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:40:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5705952433492519864)
+2021-09-05 23:40:54 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5705952433492519864)
+2021-09-05 23:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:40:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:40:55 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:40:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:40:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:41:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:41:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:41:18 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:41:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:41:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:41:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:41:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5699859202044390259)
+2021-09-05 23:42:04 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5699859202044390259)
+2021-09-05 23:42:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:42:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:42:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:42:05 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:42:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:42:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-05 23:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-05 23:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 23:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Restarting instance and waiting for boot
+2021-09-05 23:42:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:42:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:42:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:42:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:42:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:42:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:43:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:43:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:43:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:43:46 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:43:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:44:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:44:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:44:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=7630002682934651084)
+2021-09-05 23:44:17 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=7630002682934651084)
+2021-09-05 23:44:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:44:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:44:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:44:18 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:44:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 23:44:18 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:45:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:45:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:45:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:45:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 23:45:11 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 23:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/1038993d-1989-4474-b6a2-c35a7950b23d.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 23:45:11 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:46:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:46:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:46:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:46:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:46:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:46:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 23:47:24 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:47:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:47:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:47:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:47:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:47:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:47:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:48:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=22467359391934947)
+2021-09-05 23:48:07 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=22467359391934947)
+2021-09-05 23:48:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:48:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:48:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:48:08 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:48:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 23:48:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/bd62728b-5730-460c-8b9e-a71de4609e49.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 23:48:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 23:48:09 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:48:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:48:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:49:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:49:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:49:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:49:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:49:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:49:54 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 23:49:57 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:50:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:50:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:50:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:50:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=2596478248143087949)
+2021-09-05 23:50:39 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2596478248143087949)
+2021-09-05 23:50:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:50:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:50:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:50:39 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:50:40 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 23:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/87ca2fe6-45f0-4a14-bdf3-ab057a36f944.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 23:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 23:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 23:50:41 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 23:51:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:51:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:51:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:51:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:51:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:51:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:51:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:52:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:52:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:52:24 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 23:52:27 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:52:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:52:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:52:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:52:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:53:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6490417378199398102)
+2021-09-05 23:53:09 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6490417378199398102)
+2021-09-05 23:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:53:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-05 23:53:09 INFO      integration_testing:clouds.py:183 image serial: 20210831
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:53:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:53:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:53:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 23:53:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-05 23:53:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 23:53:30 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+
+
+=================================== FAILURES ===================================
+____________ TestKeysToConsoleBlacklist.test_included_keys[ED25519] ____________
+
+self = <test_keys_to_console.TestKeysToConsoleBlacklist object at 0x7f4ae3646828>
+class_client = <tests.integration_tests.instances.IntegrationGceInstance object at 0x7f4ae3646dd8>
+key_type = 'ED25519'
+
+    @pytest.mark.parametrize("key_type", ["ED25519", "RSA"])
+    def test_included_keys(self, class_client, key_type):
+        syslog = class_client.read_from_file("/var/log/syslog")
+>       assert "({})".format(key_type) in syslog
+E       AssertionError: assert '(ED25519)' in 'Sep  5 23:02:39 i19-gce-integration-test-0905-173608 systemd[1]: Mounted Huge Pages File System.\nSep  5 23:02:39 i19...23:02:43 i19-gce-integration-test-0905-173608 chronyd[543]: Selected source 169.254.169.254 (metadata.google.internal)'
+E        +  where '(ED25519)' = <built-in method format of str object at 0x7f4ae5ef4c70>('ED25519')
+E        +    where <built-in method format of str object at 0x7f4ae5ef4c70> = '({})'.format
+
+tests/integration_tests/modules/test_keys_to_console.py:36: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 23:02:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+------------------------------ Captured log call -------------------------------
+2021-09-05 23:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+______________ TestKeysToConsoleBlacklist.test_included_keys[RSA] ______________
+
+self = <test_keys_to_console.TestKeysToConsoleBlacklist object at 0x7f4ae3cc86a0>
+class_client = <tests.integration_tests.instances.IntegrationGceInstance object at 0x7f4ae3646dd8>
+key_type = 'RSA'
+
+    @pytest.mark.parametrize("key_type", ["ED25519", "RSA"])
+    def test_included_keys(self, class_client, key_type):
+        syslog = class_client.read_from_file("/var/log/syslog")
+>       assert "({})".format(key_type) in syslog
+E       AssertionError: assert '(RSA)' in 'Sep  5 23:02:39 i19-gce-integration-test-0905-173608 systemd[1]: Mounted Huge Pages File System.\nSep  5 23:02:39 i19...23:02:43 i19-gce-integration-test-0905-173608 chronyd[543]: Selected source 169.254.169.254 (metadata.google.internal)'
+E        +  where '(RSA)' = <built-in method format of str object at 0x7f4ae5ef4c70>('RSA')
+E        +    where <built-in method format of str object at 0x7f4ae5ef4c70> = '({})'.format
+
+tests/integration_tests/modules/test_keys_to_console.py:36: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 23:02:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+------------------------------ Captured log call -------------------------------
+2021-09-05 23:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+_______ TestSshAuthkeyFingerprints.test_ssh_authkey_fingerprints_enable ________
+
+self = <test_ssh_auth_key_fingerprints.TestSshAuthkeyFingerprints object at 0x7f4ae414c3c8>
+client = <tests.integration_tests.instances.IntegrationGceInstance object at 0x7f4ae401f2e8>
+
+    @pytest.mark.user_data(USER_DATA_SSH_AUTHKEY_ENABLE)
+    def test_ssh_authkey_fingerprints_enable(self, client):
+        syslog_output = client.read_from_file("/var/log/syslog")
+    
+>       assert re.search(r'256 SHA256:.*(ECDSA)', syslog_output) is not None
+E       AssertionError: assert None is not None
+E        +  where None = <function search at 0x7f4aeec1cd08>('256 SHA256:.*(ECDSA)', 'Sep  5 23:24:49 i37-gce-integration-test-0905-173608 systemd[1]: modprobe@configfs.service: Succeeded.\nSep  5 23:24:...23:24:53 i37-gce-integration-test-0905-173608 systemd[655]: Listening on REST API socket for snapd user session agent.')
+E        +    where <function search at 0x7f4aeec1cd08> = re.search
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py:45: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 23:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-05 23:24:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0905-173608-image
+2021-09-05 23:24:22 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-05 23:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 23:24:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-05 23:24:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 23:24:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 23:24:59 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=2559812331380469579)
+2021-09-05 23:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-05 23:25:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-05 23:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-05 23:25:00 INFO      integration_testing:clouds.py:183 image serial: 20210831
+------------------------------ Captured log call -------------------------------
+2021-09-05 23:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519]
+FAILED tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA]
+FAILED tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable
+====== 3 failed, 116 passed, 30 skipped, 2 warnings in 4643.06s (1:17:23) ======

--- a/21.3-1/integration_tests/gce_hirsute_integration_tests_rerun.txt
+++ b/21.3-1/integration_tests/gce_hirsute_integration_tests_rerun.txt
@@ -1,0 +1,308 @@
+================================================ test session starts ================================================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 13 items
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:04:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-06 20:04:08 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-06 20:04:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=True
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-06 20:04:13 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=True
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=gce
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for gce
+2021-09-06 20:04:13 INFO      integration_testing:conftest.py:156 Setting up environment for gce
+Launching instance with launch_kwargs:
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+user_data=None
+2021-09-06 20:04:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2104-hirsute-v20210831
+user_data=None
+2021-09-06 20:04:16 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 20:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:04:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 20:04:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 20:04:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=8675940911590132433)
+2021-09-06 20:05:00 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=8675940911590132433)
+2021-09-06 20:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 20:05:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 20:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 20:05:00 INFO      integration_testing:clouds.py:183 image serial: 20210831
+Installing proposed image
+2021-09-06 20:05:00 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 20:05:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 20:05:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 20:05:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 20:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:05:18 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 20:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+2021-09-06 20:06:08 INFO      integration_testing:instances.py:114 Created new image: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+Done with environment setup
+2021-09-06 20:06:09 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-06 20:06:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-06 20:06:12 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 20:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:06:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:06:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:06:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:06:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 20:06:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 20:06:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=5343593507382348381)
+2021-09-06 20:06:53 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=5343593507382348381)
+2021-09-06 20:06:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:06:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 20:06:54 INFO      integration_testing:clouds.py:183 image serial: 20210831
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:06:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:06:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:06:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:06:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-06 20:06:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-06 20:07:00 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 20:07:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:07:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 20:07:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 20:07:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3671001215025269263)
+2021-09-06 20:07:40 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3671001215025269263)
+2021-09-06 20:07:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:07:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:07:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 20:07:41 INFO      integration_testing:clouds.py:183 image serial: 20210831
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:07:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:07:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:07:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:07:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-06 20:07:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-06 20:07:45 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 20:07:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 20:08:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 20:08:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=3769271724615125985)
+2021-09-06 20:08:25 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=3769271724615125985)
+2021-09-06 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:08:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 20:08:26 INFO      integration_testing:clouds.py:183 image serial: 20210831
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------------------------- live log setup ---------------------------------------------------
+2021-09-06 20:08:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-06 20:08:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-06 20:08:30 WARNING   google.auth._default:_default.py:352 No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
+2021-09-06 20:08:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 20:08:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 20:08:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 20:09:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: GceInstance(instance_id=6247808728781540307)
+2021-09-06 20:09:13 INFO      integration_testing:clouds.py:173 Launched instance: GceInstance(instance_id=6247808728781540307)
+2021-09-06 20:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:09:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 20:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210831
+2021-09-06 20:09:13 INFO      integration_testing:clouds.py:183 image serial: 20210831
+--------------------------------------------------- live log call ---------------------------------------------------
+2021-09-06 20:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSEDDeleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+
+------------------------------------------------- live log teardown -------------------------------------------------
+2021-09-06 20:09:14 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: projects/ubuntu-server-277015/global/images/i0-gce-integration-test-0906-150406-image
+
+
+================================================= warnings summary ==================================================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA]
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+==================================== 13 passed, 2 warnings in 309.20s (0:05:09) =====================================

--- a/21.3-1/integration_tests/lxd_container_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_container_bionic_integration_tests.txt
@@ -1,0 +1,2887 @@
+Started by timer
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed
+[WS-CLEANUP] Deleting project workspace...
+[WS-CLEANUP] Deferred wipeout is used...
+[WS-CLEANUP] Done
+[cloud-init-integration-lxd_container-bionic-proposed] $ /bin/bash /tmp/jenkins3462330109591534778.sh
++ trap cleanup EXIT
++ [[ proposed == proposed ]]
++ proposed=1
++ (( proposed ))
++ repourl=http://archive.ubuntu.com/ubuntu
++ suite=bionic-proposed
+++ rmadison --suite bionic-proposed cloud-init
++ pversion=' cloud-init | 21.3-1-g6803368d-0ubuntu1~18.04.2 | bionic-proposed | source, all'
++ [[ -z  cloud-init | 21.3-1-g6803368d-0ubuntu1~18.04.2 | bionic-proposed | source, all ]]
++ container=cii-lxd_container-bionic-proposed-44-debretrieval
+++ echo cii-lxd_container-bionic-proposed-44-debretrieval
+++ tr -d _
++ container=cii-lxdcontainer-bionic-proposed-44-debretrieval
++ lxd_remote=ubuntu-minimal
+++ distro-info --devel
++ [[ impish == bionic ]]
++ lxc launch --quiet ubuntu-minimal:bionic cii-lxdcontainer-bionic-proposed-44-debretrieval --ephemeral
++ sleep 1
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval -- cloud-init status --wait
+..................
+status: done
++ (( !proposed ))
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval -- sh -c 'echo deb '\''http://archive.ubuntu.com/ubuntu bionic-proposed main'\'' > /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval -- sh -c 'echo deb-src '\''http://archive.ubuntu.com/ubuntu bionic-proposed main'\'' >> /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval -- apt-get -q update
+Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [1866 kB]
+Get:4 http://security.ubuntu.com/ubuntu bionic-security/main Translation-en [340 kB]
+Get:5 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [433 kB]
+Get:6 http://security.ubuntu.com/ubuntu bionic-security/restricted Translation-en [58.1 kB]
+Get:7 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1138 kB]
+Get:8 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [259 kB]
+Get:9 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [20.9 kB]
+Get:10 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [4732 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1019 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic/main Translation-en [516 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [9184 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic/restricted Translation-en [3584 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2212 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main Translation-en [432 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [457 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/restricted Translation-en [61.8 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1749 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [375 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [27.3 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6808 B]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [10.0 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [10.3 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4588 B]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-proposed/main Sources [81.4 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [110 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [28.2 kB]
+Fetched 25.7 MB in 4s (5845 kB/s)
+Reading package lists...
+++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval -- id --user ubuntu
++ ubuntu_uid=1000
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval --user 1000 -- mkdir /tmp/cloud-init-src
++ lxc exec cii-lxdcontainer-bionic-proposed-44-debretrieval --user 1000 --cwd /tmp/cloud-init-src -- apt-get -q --download-only source cloud-init/bionic-proposed
+Reading package lists...
+Selected version '21.3-1-g6803368d-0ubuntu1~18.04.2' (bionic-proposed) for cloud-init
+NOTICE: 'cloud-init' packaging is maintained in the 'Git' version control system at:
+git://git.launchpad.net/cloud-init -b ubuntu/devel
+Please use:
+git clone git://git.launchpad.net/cloud-init -b ubuntu/devel
+to retrieve the latest (possibly unreleased) updates to the package.
+Need to get 1427 kB of source archives.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2 (dsc) [2278 B]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2 (tar) [1348 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2 (diff) [76.1 kB]
+Fetched 1427 kB in 1s (1993 kB/s)
+Download complete and in download only mode
++ lxc file pull --recursive cii-lxdcontainer-bionic-proposed-44-debretrieval/tmp/cloud-init-src .
++ lxc stop cii-lxdcontainer-bionic-proposed-44-debretrieval
++ pushd cloud-init-src
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed
++ dpkg-source -x cloud-init_21.3-1-g6803368d-0ubuntu1~18.04.2.dsc
+gpgv: Signature made Fri 03 Sep 2021 08:05:46 PM UTC
+gpgv:                using RSA key E25451E0221B5773DEBFF178ECDACB160995AD89
+gpgv: Can't check signature: No public key
+dpkg-source: warning: failed to verify signature on ./cloud-init_21.3-1-g6803368d-0ubuntu1~18.04.2.dsc
+dpkg-source: info: extracting cloud-init in cloud-init-21.3-1-g6803368d
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d.orig.tar.gz
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d-0ubuntu1~18.04.2.debian.tar.xz
+dpkg-source: info: applying openstack-no-network-config.patch
+dpkg-source: info: applying ec2-dont-apply-full-imds-network-config.patch
+dpkg-source: info: applying renderer-do-not-prefer-netplan.patch
+dpkg-source: info: applying cpick-28e56d99-Azure-Retry-dhcp-on-timeouts-when-polling
+dpkg-source: info: applying cpick-e69a8874-Set-Azure-to-only-update-metadata-on-BOOT_NEW_INSTANCE
+++ realpath cloud-init-21.3-1-g6803368d/
++ ln -s /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d ../cloud-init
++ popd
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed
++ CLOUD_INIT_PLATFORM=lxd_container
++ CLOUD_INIT_OS_IMAGE=bionic
++ (( proposed ))
++ CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED
++ CLOUD_INIT_COLLECT_LOGS=ON_ERROR
++ CLOUD_INIT_LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud_init_test_logs
++ export CLOUD_INIT_PLATFORM
++ export CLOUD_INIT_CLOUD_INIT_SOURCE
++ export CLOUD_INIT_OS_IMAGE
++ export CLOUD_INIT_COLLECT_LOGS
++ export CLOUD_INIT_LOCAL_LOG_PATH
++ cd cloud-init
++ tox -e integration-tests-jenkins -- -vv --showlocals tests/integration_tests
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/setup.py
+integration-tests-jenkins create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins
+integration-tests-jenkins installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/integration-requirements.txt
+integration-tests-jenkins inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip
+integration-tests-jenkins installed: adal==1.2.7,appdirs==1.4.4,applicationinsights==0.11.10,argcomplete==1.12.3,attrs==21.2.0,autopage==0.4.0,azure-cli-core==2.28.1,azure-cli-telemetry==1.0.6,azure-common==1.1.27,azure-core==1.18.0,azure-mgmt-compute==14.0.0,azure-mgmt-core==1.2.2,azure-mgmt-network==13.0.0,azure-mgmt-resource==13.0.0,bcrypt==3.2.0,boto3==1.18.40,botocore==1.21.40,cachetools==4.2.2,certifi==2021.5.30,cffi==1.14.6,chardet==4.0.0,cliff==3.9.0,cloud-init @ file:///var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip,cmd2==2.1.2,colorama==0.4.4,configobj==5.0.6,configparser==4.0.2,cryptography==3.3.2,debtcollector==2.3.0,decorator==5.1.0,dogpile.cache==1.1.4,google-api-core==2.0.1,google-api-python-client==2.20.0,google-auth==2.0.2,google-auth-httplib2==0.1.0,googleapis-common-protos==1.53.0,httplib2==0.19.1,humanfriendly==9.2,idna==2.10,importlib-metadata==4.8.1,importlib-resources==5.2.2,iniconfig==1.1.1,iso8601==0.1.16,isodate==0.6.0,Jinja2==3.0.1,jmespath==0.10.0,jsonpatch==1.32,jsonpointer==2.1,jsonschema==3.2.0,keystoneauth1==4.3.1,knack==0.8.2,MarkupSafe==2.0.1,msal==1.14.0,msgpack==1.0.2,msrest==0.6.21,msrestazure==0.6.4,munch==2.5.0,netaddr==0.8.0,netifaces==0.11.0,oauthlib==3.1.1,oci==2.45.0,openstacksdk==0.59.0,os-service-types==1.7.0,osc-lib==2.4.2,oslo.config==8.7.1,oslo.i18n==5.1.0,oslo.serialization==4.2.0,oslo.utils==4.10.0,packaging==21.0,paramiko==2.7.2,pbr==5.6.0,pkg_resources==0.0.0,pkginfo==1.7.1,pluggy==1.0.0,portalocker==1.7.1,prettytable==2.2.0,protobuf==3.17.3,psutil==5.8.0,py==1.10.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycloudlib @ git+https://github.com/canonical/pycloudlib.git@245ca0b97e71926fdb651147e42d6256b17f6778,pycparser==2.20,Pygments==2.10.0,PyJWT==2.1.0,PyNaCl==1.4.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pyperclip==1.8.2,pyrsistent==0.18.0,PySocks==1.7.1,pytest==6.2.5,python-cinderclient==8.1.0,python-dateutil==2.8.2,python-keystoneclient==4.2.0,python-novaclient==17.6.0,python-openstackclient==5.6.0,python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requestsexceptions==1.4.0,rfc3986==1.5.0,rsa==4.7.2,s3transfer==0.5.0,simplejson==3.17.5,six==1.16.0,stevedore==3.4.0,tabulate==0.8.9,toml==0.10.2,typing-extensions==3.10.0.2,uritemplate==3.0.1,urllib3==1.26.6,wcwidth==0.2.5,wrapt==1.12.1,zipp==3.5.0
+integration-tests-jenkins runtests: PYTHONHASHSEED='2655923125'
+integration-tests-jenkins runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python -m pytest --log-cli-level=INFO -vv --showlocals tests/integration_tests
+============================= test session starts ==============================
+platform linux -- Python 3.6.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python
+cachedir: .pytest_cache
+rootdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d, configfile: tox.ini
+collecting ... collected 149 items / 1 deselected / 148 selected
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:28:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:28:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:28:14 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=ON_ERROR
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud_init_test_logs
+OPENSTACK_NETWORK=None
+ORACLE_AVAILABILITY_DOMAIN=None
+OS_IMAGE=bionic
+PLATFORM=lxd_container
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-12 19:28:14 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_container
+2021-09-12 19:28:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:3abe6b79b7cea5cadcf739ff43cad8a56edca2b02d44fcad94ec357859112b1a
+user_data=None
+2021-09-12 19:28:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:28:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:28:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:28:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:28:25 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:28:28 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=glad-camel)
+2021-09-12 19:28:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:28:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-12 19:28:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:28:28 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 19:28:28 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 19:28:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 19:28:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 19:28:41 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:28:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 19:28:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 19:28:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 19:28:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 19:28:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 19:28:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 19:29:34 INFO      integration_testing:instances.py:113 Created new image: local:glad-camel-snapshot
+2021-09-12 19:29:34 INFO      integration_testing:conftest.py:162 Done with environment setup
+2021-09-12 19:29:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:29:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:29:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:29:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:29:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:29:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:29:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:29:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=crack-lamprey)
+2021-09-12 19:29:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:29:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:29:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:29:56 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:29:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-12 19:29:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED                                                                   [  0%]
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:30:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:30:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:30:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:3abe6b79b7cea5cadcf739ff43cad8a56edca2b02d44fcad94ec357859112b1a
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-12 19:30:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:30:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:30:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:30:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humble-drum)
+2021-09-12 19:30:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:30:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-12 19:30:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:30:14 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 19:30:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 19:30:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-12 19:30:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-12 19:30:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:30:16 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 19:30:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 19:30:29 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 19:30:29 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:30:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 19:30:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 19:30:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname something-else'
+2021-09-12 19:30:30 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:30:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:30:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:30:36 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:30:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-12 19:30:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init init'
+2021-09-12 19:30:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 19:30:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-12 19:30:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-12 19:30:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:30:40 INFO      integration_testing.test_upgrade:test_upgrade.py:136 
+=== `systemd-analyze` before:
+Startup finished in 6.052s (userspace) = 1month 1d 26min 35.575s
+graphical.target reached after 4.494s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.463s (userspace) = 1month 1d 26min 58.504s
+graphical.target reached after 2.966s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+          1.547s snapd.seeded.service
+           940ms cloud-config.service
+           915ms cloud-init-local.service
+           903ms cloud-init.service
+           614ms cloud-final.service
+           543ms apparmor.service
+           212ms systemd-udev-trigger.service
+           159ms snapd.service
+           157ms networkd-dispatcher.service
+            81ms ebtables.service
+=== `systemd-analyze blame` after (first 10 lines):
+           908ms cloud-init-local.service
+           836ms cloud-config.service
+           794ms cloud-init.service
+           655ms cloud-final.service
+           650ms systemd-networkd-wait-online.service
+           214ms systemd-udev-trigger.service
+           162ms snapd.service
+           151ms networkd-dispatcher.service
+           124ms apparmor.service
+            95ms lxd-containers.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.34700 seconds
+Finished stage: (init-network) 00.37900 seconds
+Finished stage: (modules-config) 00.37400 seconds
+Finished stage: (modules-final) 00.08000 seconds
+Total Time: 1.18000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.32000 seconds
+Finished stage: (init-network) 00.26600 seconds
+Finished stage: (modules-config) 00.26900 seconds
+Finished stage: (modules-final) 00.08400 seconds
+Total Time: 0.93900 seconds
+Finished stage: (init-network) 00.16200 seconds
+Total Time: 0.16200 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.26000s (modules-config/config-grub-dpkg)
+     00.16300s (init-network/config-ssh)
+     00.07900s (modules-config/config-apt-configure)
+     00.03200s (init-local/search-NoCloud)
+     00.03100s (modules-final/config-keys-to-console)
+     00.02800s (init-network/config-users-groups)
+     00.00700s (modules-final/config-final-message)
+     00.00600s (init-network/config-resizefs)
+     00.00500s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.14200s (modules-config/config-grub-dpkg)
+     00.08400s (modules-config/config-apt-configure)
+     00.07500s (init-network/config-ssh)
+     00.03300s (modules-final/config-keys-to-console)
+     00.02700s (init-local/search-NoCloud)
+     00.01100s (init-network/config-users-groups)
+     00.00700s (modules-config/config-locale)
+     00.00700s (init-network/config-resizefs)
+     00.00600s (modules-final/config-final-message)
+
+PASSED                                                                   [  1%]
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:30:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:30:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:3abe6b79b7cea5cadcf739ff43cad8a56edca2b02d44fcad94ec357859112b1a
+user_data=None
+2021-09-12 19:30:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:30:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:30:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:30:53 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:30:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=trusty-gull)
+2021-09-12 19:30:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:30:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-12 19:30:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:30:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 19:30:55 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 19:30:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 19:31:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 19:31:08 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:31:08 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:31:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:31:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:31:13 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:31:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:31:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:31:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:31:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:31:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:31:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:31:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wanted-chamois)
+2021-09-12 19:31:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:31:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:31:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:31:25 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:31:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-12 19:31:25 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-12 19:31:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/2c73ae7f-cd46-4342-a09b-8ead35e1d8ab.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-12 19:31:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-12 19:31:26 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:31:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:31:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:31:32 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:31:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-12 19:31:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:31:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:31:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:c7:cd:8f\n', 'volatile.eth0.hwaddr': '02:00:00:c7:cd:8f'}
+2021-09-12 19:31:39 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+2021-09-12 19:31:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:31:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:31:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:31:46 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:31:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humorous-hyena)
+2021-09-12 19:31:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:31:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:31:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:31:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:31:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:31:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED                                                                   [  3%]
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:31:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:31:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:31:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:32:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:32:02 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:32:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=helping-oriole)
+2021-09-12 19:32:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:32:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:32:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:32:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:32:03 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 19:32:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/429b571d-b5aa-4db9-a591-9388ab15d272.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-12 19:32:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/cf60d87a-2f3c-4e3b-8c3e-565f1ead0e9d.tmp /etc/cloud/ds-identify.cfg'
+2021-09-12 19:32:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-12 19:32:04 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:32:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:32:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:32:10 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:32:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  4%]------------------------------ live log logreport ------------------------------
+2021-09-12 19:32:17 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:32:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:32:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:ad:b3:b4\n', 'volatile.eth0.hwaddr': '02:00:00:ad:b3:b4'}
+execute_via_ssh=False
+2021-09-12 19:32:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:32:26 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=winning-anchovy)
+2021-09-12 19:32:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:32:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:32:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:32:27 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:32:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED                                                                   [  4%]
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED [  5%]
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:32:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:32:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-12 19:32:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:32:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:32:41 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:32:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=amused-ape)
+2021-09-12 19:32:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:32:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:32:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:32:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:32:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  6%]
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED [  6%]
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:32:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:32:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-12 19:32:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:32:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:33:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:33:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:33:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=expert-mastodon)
+2021-09-12 19:33:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:33:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:33:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:33:02 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  7%]
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:33:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:33:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:33:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:33:16 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:33:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=tidy-coyote)
+2021-09-12 19:33:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:33:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:33:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:33:17 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-12 19:33:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-12 19:33:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-12 19:33:17 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:33:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:33:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:33:24 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:33:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-12 19:33:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED                                                                   [  9%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED [ 11%]
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:33:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-12 19:33:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:33:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:33:38 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=next-spider)
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED                                                                   [ 13%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-12 19:33:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_key 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-12 19:33:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 15%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-12 19:33:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:33:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED [ 17%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:33:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:33:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-12 19:33:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:33:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:33:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:33:58 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:33:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=guiding-grizzly)
+2021-09-12 19:33:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:34:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:34:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:34:00 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:34:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-12 19:34:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:34:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:34:14 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:34:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=divine-collie)
+2021-09-12 19:34:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:34:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:34:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:34:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:34:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-12 19:34:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:34:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:34:28 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:34:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=devoted-koala)
+2021-09-12 19:34:29 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:34:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:34:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:34:30 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED                                                                   [ 19%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:34:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-12 19:34:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:34:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:34:44 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:34:45 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=upright-sheep)
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:34:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:34:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-12 19:34:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:34:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED                                                                   [ 21%]
+tests/integration_tests/modules/test_cli.py::test_valid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:34:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:34:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-12 19:34:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:34:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:34:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:34:59 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:35:00 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=delicate-deer)
+2021-09-12 19:35:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:35:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:35:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:35:00 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:35:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-12 19:35:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:35:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:35:15 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:35:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=renewed-tick)
+2021-09-12 19:35:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:35:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:35:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:35:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:35:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=## template: jinja
+#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo {{ds.meta_data.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg.def_log_file}} >> /var/tmp/runcmd_output
+
+2021-09-12 19:35:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:35:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:35:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ready-squirrel)
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 23%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 24%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'locale -a'
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd_with_variable_substitution 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED                                                                   [ 26%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-12 19:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED [ 28%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED [ 29%]
+tests/integration_tests/modules/test_command_output.py::test_runcmd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:35:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-12 19:35:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:35:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:35:45 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:35:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=star-killdeer)
+2021-09-12 19:35:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:35:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:35:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:35:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:35:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED                                                                   [ 29%]
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED [ 30%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED [ 31%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED [ 31%]
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED [ 32%]
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:35:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:35:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-12 19:35:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:35:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:35:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:35:59 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:36:00 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=up-shad)
+2021-09-12 19:36:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:36:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:36:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:36:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 34%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:36:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-12 19:36:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:36:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:36:16 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:36:16 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=in-burro)
+2021-09-12 19:36:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:36:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:36:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:36:17 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 36%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:36:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-12 19:36:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:36:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:36:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:36:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=immortal-mite)
+2021-09-12 19:36:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:36:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:36:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:36:31 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 38%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 40%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] SKIPPED [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] SKIPPED [ 42%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge SKIPPED [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:36:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-12 19:36:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:36:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:36:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:36:46 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:36:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=alive-goshawk)
+2021-09-12 19:36:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:36:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:36:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:36:56 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+PASSED                                                                   [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED (/etc/ntp.conf.dist does not exist)                              [ 44%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:36:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:36:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:37:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:37:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+
+2021-09-12 19:37:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:37:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:37:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:37:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=top-puma)
+2021-09-12 19:37:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:37:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:37:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:37:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:37:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-12 19:37:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED                                                                   [ 46%]
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:37:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:37:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+
+2021-09-12 19:37:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:37:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:37:37 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:37:38 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=generous-collie)
+2021-09-12 19:37:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:37:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:37:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:37:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:37:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:37:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:37:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-12 19:37:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:37:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:37:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:37:51 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:38:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=organic-kangaroo)
+2021-09-12 19:38:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:38:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:38:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:38:02 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:38:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+2021-09-12 19:38:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-12 19:38:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:38:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:38:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-12 19:38:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:38:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:38:13 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:38:37 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wired-lemur)
+2021-09-12 19:38:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:38:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:38:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:38:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:38:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED                                                                   [ 48%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:38:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:38:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED                                                                   [ 49%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:38:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:38:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:38:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:38:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:38:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:38:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:38:51 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:38:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=amazed-leech)
+2021-09-12 19:38:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:38:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:38:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:38:52 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:38:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 19:38:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/2930deee-26e1-4d07-ab83-1427fb557354.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 19:38:52 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:38:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:38:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:38:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:38:57 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:38:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait'
+2021-09-12 19:38:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 51%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 53%]
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:39:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-12 19:39:01 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-12 19:39:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:39:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:39:09 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:39:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=concise-kangaroo)
+2021-09-12 19:39:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:39:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:39:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:39:10 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:39:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:39:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-12 19:39:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:39:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:39:24 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:39:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sincere-ape)
+2021-09-12 19:39:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:39:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:39:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:39:26 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:39:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:39:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-12 19:39:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:39:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:39:39 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:39:40 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=skilled-goldfish)
+2021-09-12 19:39:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:39:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:39:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:39:41 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:39:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 55%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:39:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:39:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-12 19:39:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:39:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:39:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:39:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:39:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=crisp-coral)
+2021-09-12 19:39:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:39:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:39:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:39:56 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:39:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:40:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-12 19:40:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:40:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:40:10 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:40:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=inspired-burro)
+2021-09-12 19:40:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:40:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:40:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:40:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 19:40:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-12 19:40:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:40:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-12 19:40:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:40:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:40:26 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=verified-skylark)
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 57%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 59%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 61%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:40:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-12 19:40:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:40:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:40:40 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humorous-oriole)
+2021-09-12 19:40:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:40:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 63%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 65%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 67%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:40:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:40:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:40:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-12 19:40:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:40:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:40:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:40:56 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:41:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fast-oryx)
+2021-09-12 19:41:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:41:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:41:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:41:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:41:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'snap list'
+PASSED                                                                   [ 69%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:41:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:41:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-12 19:41:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:41:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:41:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:41:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:41:31 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:41:32 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=witty-drake)
+2021-09-12 19:41:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:41:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:41:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:41:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:41:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:41:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:41:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-12 19:41:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:41:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:41:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:41:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:41:47 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:41:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=mutual-seagull)
+2021-09-12 19:41:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:41:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:41:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:41:49 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:41:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:41:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:41:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-12 19:41:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:02 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=more-gannet)
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 71%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 73%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 74%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 76%]
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-12 19:42:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:19 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:42:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sweeping-treefrog)
+2021-09-12 19:42:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:42:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:42:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:42:21 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-12 19:42:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:34 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=game-buffalo)
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 78%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED                                                                   [ 80%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 82%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 19:42:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:42:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:49 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:42:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=super-grouper)
+2021-09-12 19:42:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:42:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:42:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:42:50 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:42:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-12 19:42:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 19:42:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 19:42:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:42:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:42:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 19:42:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 84%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:42:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:42:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 19:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:04 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:43:05 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=major-woodcock)
+2021-09-12 19:43:05 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:43:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:43:06 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 19:43:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 19:43:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 19:43:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 19:43:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:43:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 19:43:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:19 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:20 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:43:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=possible-trout)
+2021-09-12 19:43:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:43:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:43:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:43:21 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:43:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-12 19:43:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 19:43:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 19:43:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 19:43:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:43:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 19:43:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:35 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:43:36 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=intense-oarfish)
+2021-09-12 19:43:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:43:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:43:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:43:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:43:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-12 19:43:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 19:43:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-12 19:43:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 19:43:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 19:43:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 86%]
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:43:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-12 19:43:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:49 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:43:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:43:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:43:50 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:43:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=destined-skylark)
+2021-09-12 19:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:43:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:43:51 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED                                                                   [ 87%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:43:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:43:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:44:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:44:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:44:06 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:44:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=loved-sawfish)
+2021-09-12 19:44:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:44:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:44:07 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:44:07 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/ef4174f7-0d38-4198-9132-4eb181fb007c.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-12 19:44:07 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:44:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:19 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:44:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:19 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:45:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:46:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:46:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:46:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:46:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 87%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled_by_default SKIPPED [ 88%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:46:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-12 19:46:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:46:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:46:26 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:46:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clean-lynx)
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:46:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:46:27 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:46:27 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/4f7e8558-2b48-4360-bc50-8b569eced738.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-12 19:46:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-12 19:46:27 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:46:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:46:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:46:33 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:46:33 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-12 19:46:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:46:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 89%]------------------------------ live log logreport ------------------------------
+2021-09-12 19:46:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:46:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-12 19:46:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:46:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:46:43 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:46:44 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=destined-oryx)
+2021-09-12 19:46:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group ubuntu
+PASSED                                                                   [ 89%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group cloud-users
+PASSED                                                                   [ 90%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd ubuntu
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd foobar
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd barfoo
+PASSED                                                                   [ 92%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd cloudy
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:46:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'groups root'
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:46:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:46:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-12 19:46:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:46:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:46:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:46:58 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:00 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=charming-weasel)
+2021-09-12 19:47:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:47:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:47:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:47:00 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:47:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED (Test requires version of sudo installed on groovy and later)    [ 94%]
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:47:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:47:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:47:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:15 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:16 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=well-grizzly)
+2021-09-12 19:47:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:47:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:47:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:47:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:47:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:47:16 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:47:19 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 19:47:23 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-12 19:47:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/802fc0cc-33ac-4513-974f-c95d04f15b02.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 19:47:23 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:47:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:28 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:29 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:47:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:47:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:47:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:38 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=tops-sloth)
+2021-09-12 19:47:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:47:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:47:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:47:40 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:47:40 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 19:47:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/b4cb8e15-6dc7-4ca0-90ed-cc4d98ba2911.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 19:47:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-12 19:47:40 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:47:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:45 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:47:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:47:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=None
+2021-09-12 19:47:47 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-12 19:47:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:47:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:47:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:47:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:47:56 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=casual-cub)
+2021-09-12 19:47:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:47:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:47:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:47:56 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:47:56 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 19:47:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/b1ba51ae-fc74-4c3e-91d7-33418aadd62c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 19:47:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-12 19:47:56 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 19:47:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:48:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:48:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:48:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:48:03 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:48:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 96%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:48:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-12 19:48:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:glad-camel-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-12 19:48:09 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-12 19:48:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:48:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 19:48:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-12 19:48:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 19:48:18 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pet-sole)
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED                                                                   [ 98%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED                                                                   [ 99%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 19:48:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-12 19:48:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_text'
+PASSED                                                                   [100%]
+------------------------------ live log teardown -------------------------------
+2021-09-12 19:48:25 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:glad-camel-snapshot
+
+
+=============================== warnings summary ===============================
+.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
+    _pytest.deprecated.STRICT_OPTION, stacklevel=2
+
+.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
+    import imp
+
+conftest.py:68
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(autouse=True)
+
+conftest.py:168
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:168: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:104
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:104: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='session')
+
+tests/integration_tests/conftest.py:261
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:261: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:268
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:268: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='module')
+
+tests/integration_tests/conftest.py:275
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:275: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='class')
+
+tests/integration_tests/modules/test_disk_setup.py:18
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/modules/test_disk_setup.py:18: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-bionic-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=== 122 passed, 26 skipped, 1 deselected, 10 warnings in 1216.59s (0:20:16) ====
+___________________________________ summary ____________________________________
+  integration-tests-jenkins: commands succeeded
+  congratulations :)
++ cleanup
++ [[ -n cii-lxdcontainer-bionic-proposed-44-debretrieval ]]
++ lxc info cii-lxdcontainer-bionic-proposed-44-debretrieval
+Archiving artifacts
+‘cloud_init_test_logs’ doesn’t match anything
+No artifacts found that match the file pattern "cloud_init_test_logs". Configuration error?
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS

--- a/21.3-1/integration_tests/lxd_container_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_container_focal_integration_tests.txt
@@ -1,0 +1,2752 @@
+Started by timer
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed
+[WS-CLEANUP] Deleting project workspace...
+[WS-CLEANUP] Deferred wipeout is used...
+[WS-CLEANUP] Done
+[cloud-init-integration-lxd_container-focal-proposed] $ /bin/bash /tmp/jenkins17529550218631351938.sh
++ trap cleanup EXIT
++ [[ proposed == proposed ]]
++ proposed=1
++ (( proposed ))
++ repourl=http://archive.ubuntu.com/ubuntu
++ suite=focal-proposed
+++ rmadison --suite focal-proposed cloud-init
++ pversion=' cloud-init | 21.3-1-g6803368d-0ubuntu1~20.04.2 | focal-proposed | source, all'
++ [[ -z  cloud-init | 21.3-1-g6803368d-0ubuntu1~20.04.2 | focal-proposed | source, all ]]
++ container=cii-lxd_container-focal-proposed-44-debretrieval
+++ echo cii-lxd_container-focal-proposed-44-debretrieval
+++ tr -d _
++ container=cii-lxdcontainer-focal-proposed-44-debretrieval
++ lxd_remote=ubuntu-minimal
+++ distro-info --devel
++ [[ impish == focal ]]
++ lxc launch --quiet ubuntu-minimal:focal cii-lxdcontainer-focal-proposed-44-debretrieval --ephemeral
++ sleep 1
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval -- cloud-init status --wait
+.................
+status: done
++ (( !proposed ))
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval -- sh -c 'echo deb '\''http://archive.ubuntu.com/ubuntu focal-proposed main'\'' > /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval -- sh -c 'echo deb-src '\''http://archive.ubuntu.com/ubuntu focal-proposed main'\'' >> /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval -- apt-get -q update
+Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
+Get:2 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [861 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
+Get:4 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [166 kB]
+Get:5 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [405 kB]
+Get:6 http://security.ubuntu.com/ubuntu focal-security/restricted Translation-en [58.1 kB]
+Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [639 kB]
+Get:8 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [101 kB]
+Get:9 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [21.9 kB]
+Get:10 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [4948 B]
+Get:11 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal-backports InRelease [101 kB]
+Get:13 http://archive.ubuntu.com/ubuntu focal-proposed InRelease [267 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [970 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal/main Translation-en [506 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [22.0 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal/restricted Translation-en [6212 B]
+Get:18 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [8628 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal/universe Translation-en [5124 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]
+Get:21 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1205 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [258 kB]
+Get:24 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [442 kB]
+Get:25 http://archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [63.3 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [855 kB]
+Get:27 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [181 kB]
+Get:28 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [24.6 kB]
+Get:29 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [6776 B]
+Get:30 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [2568 B]
+Get:31 http://archive.ubuntu.com/ubuntu focal-backports/main Translation-en [1120 B]
+Get:32 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [5800 B]
+Get:33 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [2068 B]
+Get:34 http://archive.ubuntu.com/ubuntu focal-proposed/main Sources [49.4 kB]
+Get:35 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 Packages [115 kB]
+Get:36 http://archive.ubuntu.com/ubuntu focal-proposed/main Translation-en [32.6 kB]
+Fetched 21.9 MB in 4s (5937 kB/s)
+Reading package lists...
+++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval -- id --user ubuntu
++ ubuntu_uid=1000
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval --user 1000 -- mkdir /tmp/cloud-init-src
++ lxc exec cii-lxdcontainer-focal-proposed-44-debretrieval --user 1000 --cwd /tmp/cloud-init-src -- apt-get -q --download-only source cloud-init/focal-proposed
+Reading package lists...
+Selected version '21.3-1-g6803368d-0ubuntu1~20.04.2' (focal-proposed) for cloud-init
+NOTICE: 'cloud-init' packaging is maintained in the 'Git' version control system at:
+https://github.com/canonical/cloud-init -b ubuntu/devel
+Please use:
+git clone https://github.com/canonical/cloud-init -b ubuntu/devel
+to retrieve the latest (possibly unreleased) updates to the package.
+Need to get 1427 kB of source archives.
+Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2 (dsc) [2321 B]
+Get:2 http://archive.ubuntu.com/ubuntu focal-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2 (tar) [1348 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2 (diff) [76.1 kB]
+Fetched 1427 kB in 1s (1928 kB/s)
+Download complete and in download only mode
++ lxc file pull --recursive cii-lxdcontainer-focal-proposed-44-debretrieval/tmp/cloud-init-src .
++ lxc stop cii-lxdcontainer-focal-proposed-44-debretrieval
++ pushd cloud-init-src
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed
++ dpkg-source -x cloud-init_21.3-1-g6803368d-0ubuntu1~20.04.2.dsc
+gpgv: Signature made Fri 03 Sep 2021 08:06:27 PM UTC
+gpgv:                using RSA key E25451E0221B5773DEBFF178ECDACB160995AD89
+gpgv: Can't check signature: No public key
+dpkg-source: warning: failed to verify signature on ./cloud-init_21.3-1-g6803368d-0ubuntu1~20.04.2.dsc
+dpkg-source: info: extracting cloud-init in cloud-init-21.3-1-g6803368d
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d.orig.tar.gz
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d-0ubuntu1~20.04.2.debian.tar.xz
+dpkg-source: info: applying cpick-28e56d99-Azure-Retry-dhcp-on-timeouts-when-polling
+dpkg-source: info: applying cpick-e69a8874-Set-Azure-to-only-update-metadata-on-BOOT_NEW_INSTANCE
+++ realpath cloud-init-21.3-1-g6803368d/
++ ln -s /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d ../cloud-init
++ popd
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed
++ CLOUD_INIT_PLATFORM=lxd_container
++ CLOUD_INIT_OS_IMAGE=focal
++ (( proposed ))
++ CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED
++ CLOUD_INIT_COLLECT_LOGS=ON_ERROR
++ CLOUD_INIT_LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud_init_test_logs
++ export CLOUD_INIT_PLATFORM
++ export CLOUD_INIT_CLOUD_INIT_SOURCE
++ export CLOUD_INIT_OS_IMAGE
++ export CLOUD_INIT_COLLECT_LOGS
++ export CLOUD_INIT_LOCAL_LOG_PATH
++ cd cloud-init
++ tox -e integration-tests-jenkins -- -vv --showlocals tests/integration_tests
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/setup.py
+integration-tests-jenkins create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins
+integration-tests-jenkins installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/integration-requirements.txt
+integration-tests-jenkins inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip
+integration-tests-jenkins installed: adal==1.2.7,appdirs==1.4.4,applicationinsights==0.11.10,argcomplete==1.12.3,attrs==21.2.0,autopage==0.4.0,azure-cli-core==2.28.1,azure-cli-telemetry==1.0.6,azure-common==1.1.27,azure-core==1.18.0,azure-mgmt-compute==14.0.0,azure-mgmt-core==1.2.2,azure-mgmt-network==13.0.0,azure-mgmt-resource==13.0.0,bcrypt==3.2.0,boto3==1.18.40,botocore==1.21.40,cachetools==4.2.2,certifi==2021.5.30,cffi==1.14.6,chardet==4.0.0,cliff==3.9.0,cloud-init @ file:///var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip,cmd2==2.1.2,colorama==0.4.4,configobj==5.0.6,configparser==4.0.2,cryptography==3.3.2,debtcollector==2.3.0,decorator==5.1.0,dogpile.cache==1.1.4,google-api-core==2.0.1,google-api-python-client==2.20.0,google-auth==2.0.2,google-auth-httplib2==0.1.0,googleapis-common-protos==1.53.0,httplib2==0.19.1,humanfriendly==9.2,idna==2.10,importlib-metadata==4.8.1,importlib-resources==5.2.2,iniconfig==1.1.1,iso8601==0.1.16,isodate==0.6.0,Jinja2==3.0.1,jmespath==0.10.0,jsonpatch==1.32,jsonpointer==2.1,jsonschema==3.2.0,keystoneauth1==4.3.1,knack==0.8.2,MarkupSafe==2.0.1,msal==1.14.0,msgpack==1.0.2,msrest==0.6.21,msrestazure==0.6.4,munch==2.5.0,netaddr==0.8.0,netifaces==0.11.0,oauthlib==3.1.1,oci==2.45.0,openstacksdk==0.59.0,os-service-types==1.7.0,osc-lib==2.4.2,oslo.config==8.7.1,oslo.i18n==5.1.0,oslo.serialization==4.2.0,oslo.utils==4.10.0,packaging==21.0,paramiko==2.7.2,pbr==5.6.0,pkg_resources==0.0.0,pkginfo==1.7.1,pluggy==1.0.0,portalocker==1.7.1,prettytable==2.2.0,protobuf==3.17.3,psutil==5.8.0,py==1.10.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycloudlib @ git+https://github.com/canonical/pycloudlib.git@245ca0b97e71926fdb651147e42d6256b17f6778,pycparser==2.20,Pygments==2.10.0,PyJWT==2.1.0,PyNaCl==1.4.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pyperclip==1.8.2,pyrsistent==0.18.0,PySocks==1.7.1,pytest==6.2.5,python-cinderclient==8.1.0,python-dateutil==2.8.2,python-keystoneclient==4.2.0,python-novaclient==17.6.0,python-openstackclient==5.6.0,python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requestsexceptions==1.4.0,rfc3986==1.5.0,rsa==4.7.2,s3transfer==0.5.0,simplejson==3.17.5,six==1.16.0,stevedore==3.4.0,tabulate==0.8.9,toml==0.10.2,typing-extensions==3.10.0.2,uritemplate==3.0.1,urllib3==1.26.6,wcwidth==0.2.5,wrapt==1.12.1,zipp==3.5.0
+integration-tests-jenkins runtests: PYTHONHASHSEED='2596381979'
+integration-tests-jenkins runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python -m pytest --log-cli-level=INFO -vv --showlocals tests/integration_tests
+============================= test session starts ==============================
+platform linux -- Python 3.6.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python
+cachedir: .pytest_cache
+rootdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d, configfile: tox.ini
+collecting ... collected 149 items / 1 deselected / 148 selected
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:36:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:36:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:36:17 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=ON_ERROR
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud_init_test_logs
+OPENSTACK_NETWORK=None
+ORACLE_AVAILABILITY_DOMAIN=None
+OS_IMAGE=focal
+PLATFORM=lxd_container
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-12 16:36:17 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_container
+2021-09-12 16:36:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:66fdf6ebb370435090e7d09735ba88c7cbbf608e6634080a3ce32edfe6805360
+user_data=None
+2021-09-12 16:36:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:36:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:36:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:36:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:36:27 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:36:34 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=growing-prawn)
+2021-09-12 16:36:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:36:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-12 16:36:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:36:34 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 16:36:34 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 16:36:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 16:36:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 16:36:53 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:36:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 16:36:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 16:36:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 16:36:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 16:36:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 16:36:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 16:37:53 INFO      integration_testing:instances.py:113 Created new image: local:growing-prawn-snapshot
+2021-09-12 16:37:54 INFO      integration_testing:conftest.py:162 Done with environment setup
+2021-09-12 16:37:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:38:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:38:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:38:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:38:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:38:16 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:38:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=next-goat)
+2021-09-12 16:38:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:38:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:38:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:38:19 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:38:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-12 16:38:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED                                                                   [  0%]
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:38:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:38:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:38:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:66fdf6ebb370435090e7d09735ba88c7cbbf608e6634080a3ce32edfe6805360
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-12 16:38:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:38:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:38:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:38:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:38:33 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:38:40 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=select-mustang)
+2021-09-12 16:38:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:38:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-12 16:38:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:38:40 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 16:38:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 16:38:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-12 16:38:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 16:38:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:38:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-12 16:38:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-12 16:38:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-12 16:38:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-12 16:38:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:38:42 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 16:38:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 16:39:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 16:39:01 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:39:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-12 16:39:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-12 16:39:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname something-else'
+2021-09-12 16:39:01 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:39:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:39:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:39:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:39:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:39:08 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:39:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-12 16:39:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init init'
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-12 16:39:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-12 16:39:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-12 16:39:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-12 16:39:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:39:14 INFO      integration_testing.test_upgrade:test_upgrade.py:136 
+=== `systemd-analyze` before:
+Startup finished in 11.414s (userspace) 
+graphical.target reached after 10.094s in userspace
+=== `systemd-analyze` after:
+Startup finished in 6.451s (userspace) 
+graphical.target reached after 5.748s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+4.932s snapd.seeded.service                
+1.359s snapd.service                       
+1.145s cloud-init.service                  
+1.000s cloud-init-local.service            
+ 824ms snap.lxd.activate.service           
+ 751ms cloud-config.service                
+ 604ms systemd-networkd-wait-online.service
+ 589ms snapd.apparmor.service              
+ 565ms cloud-final.service                 
+ 473ms apparmor.service                    
+=== `systemd-analyze blame` after (first 10 lines):
+3.181s snap.lxd.activate.service           
+2.330s snapd.service                       
+1.029s cloud-init.service                  
+ 905ms cloud-init-local.service            
+ 894ms cloud-config.service                
+ 578ms cloud-final.service                 
+ 187ms accounts-daemon.service             
+ 182ms networkd-dispatcher.service         
+ 178ms snapd.apparmor.service              
+ 171ms systemd-udev-trigger.service        
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.38000 seconds
+Finished stage: (init-network) 00.68300 seconds
+Finished stage: (modules-config) 00.25000 seconds
+Finished stage: (modules-final) 00.08100 seconds
+Total Time: 1.39400 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.35700 seconds
+Finished stage: (init-network) 00.55500 seconds
+Finished stage: (modules-config) 00.32200 seconds
+Finished stage: (modules-final) 00.08300 seconds
+Total Time: 1.31700 seconds
+Finished stage: (init-network) 00.18700 seconds
+Total Time: 0.18700 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.44700s (init-network/config-ssh)
+     00.12500s (modules-config/config-grub-dpkg)
+     00.07000s (modules-config/config-apt-configure)
+     00.04400s (init-local/search-NoCloud)
+     00.03700s (init-network/config-users-groups)
+     00.03500s (modules-final/config-keys-to-console)
+     00.02700s (modules-config/config-locale)
+     00.02700s (init-network/config-resizefs)
+     00.00500s (modules-final/config-final-message)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.34200s (init-network/config-ssh)
+     00.17200s (modules-config/config-grub-dpkg)
+     00.08100s (modules-config/config-apt-configure)
+     00.04200s (init-local/search-NoCloud)
+     00.03500s (modules-final/config-keys-to-console)
+     00.03400s (modules-config/config-locale)
+     00.02900s (init-network/config-resizefs)
+     00.01000s (init-network/config-users-groups)
+     00.00600s (init-network/config-set_hostname)
+
+PASSED                                                                   [  1%]
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:39:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:39:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:66fdf6ebb370435090e7d09735ba88c7cbbf608e6634080a3ce32edfe6805360
+user_data=None
+2021-09-12 16:39:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:39:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:39:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:39:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:39:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:39:31 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:39:37 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=valid-dingo)
+2021-09-12 16:39:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:39:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-12 16:39:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:39:38 INFO      integration_testing:clouds.py:183 image serial: 20210907
+2021-09-12 16:39:38 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-12 16:39:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-12 16:39:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-12 16:39:56 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:39:56 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:39:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:40:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:40:03 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:40:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:40:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:40:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:40:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:40:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:40:19 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:40:22 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sound-bee)
+2021-09-12 16:40:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:40:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:40:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:40:22 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:40:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-12 16:40:22 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-12 16:40:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/2483f800-7427-4339-91cd-58799487d747.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-12 16:40:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-12 16:40:23 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:40:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:40:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:40:29 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:40:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-12 16:40:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:40:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:40:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:83:ba:1f\n', 'volatile.eth0.hwaddr': '02:00:00:83:ba:1f'}
+2021-09-12 16:40:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+2021-09-12 16:40:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:40:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:40:43 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:40:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=advanced-sheep)
+2021-09-12 16:40:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:40:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:40:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:40:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:40:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:40:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED                                                                   [  3%]
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:40:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:40:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:40:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:40:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:40:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:41:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:41:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=polished-sheep)
+2021-09-12 16:41:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:41:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:41:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:41:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:41:03 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 16:41:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/33095ecc-170f-415f-8a20-82a9ed0c246c.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-12 16:41:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/00f6f11b-bf1b-46c4-b2de-854533161aae.tmp /etc/cloud/ds-identify.cfg'
+2021-09-12 16:41:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-12 16:41:04 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:41:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:41:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:41:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:41:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:41:10 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:41:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  4%]------------------------------ live log logreport ------------------------------
+2021-09-12 16:41:17 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:41:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:41:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:01:0c:fd\n', 'volatile.eth0.hwaddr': '02:00:00:01:0c:fd'}
+execute_via_ssh=False
+2021-09-12 16:41:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:41:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:41:28 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=superb-bengal)
+2021-09-12 16:41:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:41:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:41:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:41:28 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:41:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED                                                                   [  4%]
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED [  5%]
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:41:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:41:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-12 16:41:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:41:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:41:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:41:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:41:39 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:41:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=discrete-gnat)
+2021-09-12 16:41:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:41:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:41:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:41:51 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:41:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  6%]
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED [  6%]
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:41:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:41:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-12 16:42:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:42:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:42:05 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:42:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=talented-leech)
+2021-09-12 16:42:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:42:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:42:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:42:09 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:42:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  7%]
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:42:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:42:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:42:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:42:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:42:22 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:42:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=shining-emu)
+2021-09-12 16:42:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:42:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:42:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:42:24 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:42:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-12 16:42:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-12 16:42:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-12 16:42:25 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:42:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:42:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:42:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:42:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-12 16:42:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED                                                                   [  9%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED [ 11%]
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:42:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:42:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-12 16:42:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:42:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:42:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:42:46 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=apt-jay)
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED                                                                   [ 13%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-12 16:43:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_key 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-12 16:43:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 15%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-12 16:43:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED [ 17%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:43:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-12 16:43:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:43:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:43:17 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:43:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=patient-prawn)
+2021-09-12 16:43:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:43:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:43:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:43:20 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:43:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-12 16:43:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:43:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:43:33 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:43:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=resolved-toad)
+2021-09-12 16:43:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:43:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:43:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:43:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:43:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-12 16:43:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:43:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:43:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:43:48 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:43:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=set-pheasant)
+2021-09-12 16:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:43:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:43:51 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED                                                                   [ 19%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:43:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:43:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:43:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-12 16:44:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:44:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:44:04 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:44:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=on-tahr)
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:44:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:44:07 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED                                                                   [ 21%]
+tests/integration_tests/modules/test_cli.py::test_valid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:44:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-12 16:44:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:44:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:44:20 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:44:23 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=arriving-frog)
+2021-09-12 16:44:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:44:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:44:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:44:23 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:44:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-12 16:44:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:44:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:44:35 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:44:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=lucky-pheasant)
+2021-09-12 16:44:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:44:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:44:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:44:39 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:44:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=## template: jinja
+#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo {{ds.meta_data.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg.def_log_file}} >> /var/tmp/runcmd_output
+
+2021-09-12 16:44:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:44:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:44:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:44:52 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=darling-katydid)
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 23%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 24%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'locale -a'
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd_with_variable_substitution 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED                                                                   [ 26%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-12 16:44:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:44:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:44:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-12 16:44:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED [ 28%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED [ 29%]
+tests/integration_tests/modules/test_command_output.py::test_runcmd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:45:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-12 16:45:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:45:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:45:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:45:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=solid-earwig)
+2021-09-12 16:45:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:45:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:45:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:45:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED                                                                   [ 29%]
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED [ 30%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED [ 31%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED [ 31%]
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED [ 32%]
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:45:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-12 16:45:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:45:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:45:28 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=proven-prawn)
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 34%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:45:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-12 16:45:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:43 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:45:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:45:44 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:45:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=guided-sawfly)
+2021-09-12 16:45:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:45:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:45:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:45:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 36%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:45:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:45:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:45:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-12 16:45:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:45:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:45:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:45:59 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:46:02 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=trusting-jennet)
+2021-09-12 16:46:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 38%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 40%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] SKIPPED [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] SKIPPED [ 42%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge SKIPPED [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:46:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-12 16:46:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:46:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:46:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:46:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:46:15 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:46:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=classic-hound)
+2021-09-12 16:46:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:46:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:46:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:46:36 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+PASSED                                                                   [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED (/etc/ntp.conf.dist does not exist)                              [ 44%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:46:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:46:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:46:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+
+2021-09-12 16:46:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:46:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:46:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:46:50 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:47:11 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=great-mouse)
+2021-09-12 16:47:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:47:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:47:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:47:11 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:47:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-12 16:47:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED                                                                   [ 46%]
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:47:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:47:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+
+2021-09-12 16:47:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:47:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:47:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:47:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=aware-moccasin)
+2021-09-12 16:47:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:47:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:47:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:47:26 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:47:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:47:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:47:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-12 16:47:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:47:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:47:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:47:38 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:47:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=intent-pangolin)
+2021-09-12 16:47:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:47:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:47:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:47:59 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:47:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+2021-09-12 16:47:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-12 16:47:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:48:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:48:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-12 16:48:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:48:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:48:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:48:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:48:14 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:48:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=trusted-skink)
+2021-09-12 16:48:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:48:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:48:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:48:47 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:48:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED                                                                   [ 48%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:48:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:48:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED                                                                   [ 49%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:48:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:48:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:48:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:48:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:48:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:48:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:48:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:48:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:49:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:49:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clean-ocelot)
+2021-09-12 16:49:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:49:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:49:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:49:03 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:49:03 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 16:49:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/b6d78831-92c2-4783-8132-70ffd580aedb.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 16:49:03 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:49:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:49:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:49:08 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:49:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait'
+2021-09-12 16:49:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 51%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:49:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 53%]
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:49:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-12 16:49:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:49:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:49:25 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:49:28 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=relaxing-oriole)
+2021-09-12 16:49:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:49:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:49:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:49:28 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:49:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:49:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-12 16:49:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:49:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:49:39 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:49:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=champion-ringtail)
+2021-09-12 16:49:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:49:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:49:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:49:43 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:49:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:49:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:49:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-12 16:49:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:49:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:49:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:49:56 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:49:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=adapting-platypus)
+2021-09-12 16:49:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:49:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:49:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:49:59 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:49:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 55%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:50:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-12 16:50:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:50:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:50:11 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:50:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=merry-kiwi)
+2021-09-12 16:50:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:50:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:50:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:50:15 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:50:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-12 16:50:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:50:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:50:29 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:50:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=thorough-quail)
+2021-09-12 16:50:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:50:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:50:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:50:32 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-12 16:50:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-12 16:50:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:50:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-12 16:50:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:50:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:50:44 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ample-scorpion)
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 57%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 59%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 61%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:50:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:50:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:50:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-12 16:50:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:50:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:50:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:51:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:51:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=nearby-lizard)
+2021-09-12 16:51:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 63%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 65%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 67%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:51:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-12 16:51:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:51:15 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:51:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:51:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:51:15 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:51:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=worthy-termite)
+2021-09-12 16:51:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:51:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:51:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:51:39 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'snap list'
+PASSED                                                                   [ 69%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:51:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-12 16:51:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:51:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:51:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:51:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:51:51 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:51:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fine-glowworm)
+2021-09-12 16:51:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:51:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:51:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:51:55 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:51:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:51:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:51:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-12 16:52:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:52:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:52:07 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:52:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=hot-penguin)
+2021-09-12 16:52:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:52:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:52:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:52:10 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:52:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-12 16:52:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:52:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:52:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=liked-lacewing)
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 71%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 73%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 74%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 76%]
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:52:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-12 16:52:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:52:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:52:38 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:52:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=bursting-condor)
+2021-09-12 16:52:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:52:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:52:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:52:42 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:52:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-12 16:52:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:52:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:52:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:52:54 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=grand-lioness)
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 78%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED                                                                   [ 80%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 82%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:52:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:52:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:53:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 16:53:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:09 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:53:12 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=apt-alpaca)
+2021-09-12 16:53:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:53:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:53:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:53:12 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:53:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 16:53:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 16:53:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 16:53:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 16:53:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 84%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:53:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 16:53:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:53:33 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=amusing-lamprey)
+2021-09-12 16:53:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:53:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:53:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:53:33 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:53:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 16:53:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:35 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 16:53:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 16:53:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 16:53:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:53:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 16:53:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:53:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:51 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:53:54 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fast-cardinal)
+2021-09-12 16:53:54 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:53:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:53:54 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:53:54 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:53:54 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-12 16:53:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 16:53:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 16:53:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:53:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:53:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 16:53:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:53:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 16:53:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 16:53:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:54:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-12 16:54:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:54:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=moved-guppy)
+2021-09-12 16:54:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:54:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:54:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:54:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-12 16:54:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-12 16:54:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-12 16:54:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-12 16:54:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-12 16:54:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 86%]
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:54:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-12 16:54:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:33 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:54:37 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=winning-tetra)
+2021-09-12 16:54:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:54:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:54:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:54:37 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:54:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED                                                                   [ 87%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:54:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:54:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:54:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:49 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:54:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:54:50 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:54:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=excited-collie)
+2021-09-12 16:54:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:54:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:54:53 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:54:53 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/21c17611-5a16-477c-9ed0-f422b0c8234b.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:54:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-12 16:54:53 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:54:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:58 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:54:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:55:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:55:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:55:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:55:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 87%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled_by_default SKIPPED [ 88%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:55:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-12 16:55:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-12 16:55:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:55:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:55:14 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:55:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=splendid-yeti)
+2021-09-12 16:55:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:55:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:55:18 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:55:18 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/f357caf5-ba25-4609-a4c1-1baf2529d7f8.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-12 16:55:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-12 16:55:18 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:55:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:55:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:55:25 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:55:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:55:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 89%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:55:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-12 16:55:31 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-12 16:55:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:55:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:55:40 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:55:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=on-cheetah)
+2021-09-12 16:55:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group ubuntu
+PASSED                                                                   [ 89%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group cloud-users
+PASSED                                                                   [ 90%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd ubuntu
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd foobar
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd barfoo
+PASSED                                                                   [ 92%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd cloudy
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'groups root'
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:55:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:55:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-12 16:55:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:55:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:55:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:55:56 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:55:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=splendid-lemur)
+2021-09-12 16:55:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:55:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:55:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:55:59 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:55:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED (Test requires version of sudo installed on groovy and later)    [ 94%]
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:56:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:56:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:56:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:56:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:56:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:56:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=usable-stinkbug)
+2021-09-12 16:56:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:56:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:56:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:56:16 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:56:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:56:16 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:56:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:56:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:56:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:56:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-12 16:56:24 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-12 16:56:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/78100504-f97c-4a09-b7f1-2a7d6b64d400.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 16:56:24 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:56:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:56:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:56:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:56:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:56:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:56:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:56:37 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+2021-09-12 16:56:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:56:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:56:45 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:56:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=premium-collie)
+2021-09-12 16:56:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:56:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:56:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:56:48 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:56:48 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 16:56:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/7fe6a22a-c27c-4681-8db1-5439ee57b980.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 16:56:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-12 16:56:48 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:56:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:56:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:56:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:56:53 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:56:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:57:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=None
+2021-09-12 16:57:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-12 16:57:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:57:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:57:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:57:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:57:10 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:57:13 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pet-gelding)
+2021-09-12 16:57:13 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:57:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:57:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:57:14 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-12 16:57:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/fbb08f98-309a-4c8e-8afc-17bc52700f0b.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-12 16:57:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-12 16:57:14 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-12 16:57:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:57:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:57:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:57:19 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:57:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 96%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-12 16:57:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:growing-prawn-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-12 16:57:27 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-12 16:57:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:57:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-12 16:57:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-12 16:57:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-12 16:57:35 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-12 16:57:38 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=living-pelican)
+2021-09-12 16:57:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:183 image serial: 20210907
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED                                                                   [ 98%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED                                                                   [ 99%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-12 16:57:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-12 16:57:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_text'
+PASSED                                                                   [100%]
+------------------------------ live log teardown -------------------------------
+2021-09-12 16:57:42 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:growing-prawn-snapshot
+
+
+=============================== warnings summary ===============================
+.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
+    _pytest.deprecated.STRICT_OPTION, stacklevel=2
+
+.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
+    import imp
+
+conftest.py:68
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(autouse=True)
+
+conftest.py:168
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:168: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:104
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:104: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='session')
+
+tests/integration_tests/conftest.py:261
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:261: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:268
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:268: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='module')
+
+tests/integration_tests/conftest.py:275
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:275: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='class')
+
+tests/integration_tests/modules/test_disk_setup.py:18
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/modules/test_disk_setup.py:18: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-focal-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=== 122 passed, 26 skipped, 1 deselected, 10 warnings in 1291.03s (0:21:31) ====
+___________________________________ summary ____________________________________
+  integration-tests-jenkins: commands succeeded
+  congratulations :)
++ cleanup
++ [[ -n cii-lxdcontainer-focal-proposed-44-debretrieval ]]
++ lxc info cii-lxdcontainer-focal-proposed-44-debretrieval
+Archiving artifacts
+‘cloud_init_test_logs’ doesn’t match anything
+No artifacts found that match the file pattern "cloud_init_test_logs". Configuration error?
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS

--- a/21.3-1/integration_tests/lxd_container_hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_container_hirsute_integration_tests.txt
@@ -1,0 +1,2767 @@
+Started by timer
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed
+[WS-CLEANUP] Deleting project workspace...
+[WS-CLEANUP] Deferred wipeout is used...
+[WS-CLEANUP] Done
+[cloud-init-integration-lxd_container-hirsute-proposed] $ /bin/bash /tmp/jenkins11882434689946051869.sh
++ trap cleanup EXIT
++ [[ proposed == proposed ]]
++ proposed=1
++ (( proposed ))
++ repourl=http://archive.ubuntu.com/ubuntu
++ suite=hirsute-proposed
+++ rmadison --suite hirsute-proposed cloud-init
++ pversion=' cloud-init | 21.3-1-g6803368d-0ubuntu1~21.04.2 | hirsute-proposed | source, all'
++ [[ -z  cloud-init | 21.3-1-g6803368d-0ubuntu1~21.04.2 | hirsute-proposed | source, all ]]
++ container=cii-lxd_container-hirsute-proposed-44-debretrieval
+++ echo cii-lxd_container-hirsute-proposed-44-debretrieval
+++ tr -d _
++ container=cii-lxdcontainer-hirsute-proposed-44-debretrieval
++ lxd_remote=ubuntu-minimal
+++ distro-info --devel
++ [[ impish == hirsute ]]
++ lxc launch --quiet ubuntu-minimal:hirsute cii-lxdcontainer-hirsute-proposed-44-debretrieval --ephemeral
++ sleep 1
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval -- cloud-init status --wait
+.....................
+status: done
++ (( !proposed ))
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval -- sh -c 'echo deb '\''http://archive.ubuntu.com/ubuntu hirsute-proposed main'\'' > /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval -- sh -c 'echo deb-src '\''http://archive.ubuntu.com/ubuntu hirsute-proposed main'\'' >> /etc/apt/sources.list.d/cloud-init-integration.list'
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval -- apt-get -q update
+Get:1 http://security.ubuntu.com/ubuntu hirsute-security InRelease [110 kB]
+Get:2 http://security.ubuntu.com/ubuntu hirsute-security/main amd64 Packages [237 kB]
+Get:3 http://archive.ubuntu.com/ubuntu hirsute InRelease [269 kB]
+Get:4 http://security.ubuntu.com/ubuntu hirsute-security/main Translation-en [61.9 kB]
+Get:5 http://security.ubuntu.com/ubuntu hirsute-security/restricted amd64 Packages [171 kB]
+Get:6 http://security.ubuntu.com/ubuntu hirsute-security/restricted Translation-en [24.1 kB]
+Get:7 http://security.ubuntu.com/ubuntu hirsute-security/universe amd64 Packages [214 kB]
+Get:8 http://security.ubuntu.com/ubuntu hirsute-security/universe Translation-en [42.8 kB]
+Get:9 http://security.ubuntu.com/ubuntu hirsute-security/multiverse amd64 Packages [3364 B]
+Get:10 http://security.ubuntu.com/ubuntu hirsute-security/multiverse Translation-en [828 B]
+Get:11 http://archive.ubuntu.com/ubuntu hirsute-updates InRelease [115 kB]
+Get:12 http://archive.ubuntu.com/ubuntu hirsute-backports InRelease [101 kB]
+Get:13 http://archive.ubuntu.com/ubuntu hirsute-proposed InRelease [269 kB]
+Get:14 http://archive.ubuntu.com/ubuntu hirsute/main amd64 Packages [1394 kB]
+Get:15 http://archive.ubuntu.com/ubuntu hirsute/main Translation-en [511 kB]
+Get:16 http://archive.ubuntu.com/ubuntu hirsute/restricted amd64 Packages [78.0 kB]
+Get:17 http://archive.ubuntu.com/ubuntu hirsute/restricted Translation-en [12.0 kB]
+Get:18 http://archive.ubuntu.com/ubuntu hirsute/universe amd64 Packages [13.2 MB]
+Get:19 http://archive.ubuntu.com/ubuntu hirsute/universe Translation-en [5441 kB]
+Get:20 http://archive.ubuntu.com/ubuntu hirsute/multiverse amd64 Packages [206 kB]
+Get:21 http://archive.ubuntu.com/ubuntu hirsute/multiverse Translation-en [108 kB]
+Get:22 http://archive.ubuntu.com/ubuntu hirsute-updates/main amd64 Packages [356 kB]
+Get:23 http://archive.ubuntu.com/ubuntu hirsute-updates/main Translation-en [95.8 kB]
+Get:24 http://archive.ubuntu.com/ubuntu hirsute-updates/restricted amd64 Packages [174 kB]
+Get:25 http://archive.ubuntu.com/ubuntu hirsute-updates/restricted Translation-en [24.4 kB]
+Get:26 http://archive.ubuntu.com/ubuntu hirsute-updates/universe amd64 Packages [288 kB]
+Get:27 http://archive.ubuntu.com/ubuntu hirsute-updates/universe Translation-en [69.4 kB]
+Get:28 http://archive.ubuntu.com/ubuntu hirsute-updates/multiverse amd64 Packages [7328 B]
+Get:29 http://archive.ubuntu.com/ubuntu hirsute-updates/multiverse Translation-en [2196 B]
+Get:30 http://archive.ubuntu.com/ubuntu hirsute-backports/universe amd64 Packages [3708 B]
+Get:31 http://archive.ubuntu.com/ubuntu hirsute-backports/universe Translation-en [1252 B]
+Get:32 http://archive.ubuntu.com/ubuntu hirsute-proposed/main Sources [31.9 kB]
+Get:33 http://archive.ubuntu.com/ubuntu hirsute-proposed/main amd64 Packages [94.4 kB]
+Get:34 http://archive.ubuntu.com/ubuntu hirsute-proposed/main Translation-en [24.6 kB]
+Fetched 23.7 MB in 4s (5437 kB/s)
+Reading package lists...
+++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval -- id --user ubuntu
++ ubuntu_uid=1000
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval --user 1000 -- mkdir /tmp/cloud-init-src
++ lxc exec cii-lxdcontainer-hirsute-proposed-44-debretrieval --user 1000 --cwd /tmp/cloud-init-src -- apt-get -q --download-only source cloud-init/hirsute-proposed
+Reading package lists...
+Selected version '21.3-1-g6803368d-0ubuntu1~21.04.2' (hirsute-proposed) for cloud-init
+NOTICE: 'cloud-init' packaging is maintained in the 'Git' version control system at:
+https://github.com/canonical/cloud-init -b ubuntu/devel
+Please use:
+git clone https://github.com/canonical/cloud-init -b ubuntu/devel
+to retrieve the latest (possibly unreleased) updates to the package.
+Need to get 1427 kB of source archives.
+Get:1 http://archive.ubuntu.com/ubuntu hirsute-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2 (dsc) [2319 B]
+Get:2 http://archive.ubuntu.com/ubuntu hirsute-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2 (tar) [1348 kB]
+Get:3 http://archive.ubuntu.com/ubuntu hirsute-proposed/main cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2 (diff) [76.7 kB]
+Fetched 1427 kB in 1s (2014 kB/s)
+Download complete and in download only mode
++ lxc file pull --recursive cii-lxdcontainer-hirsute-proposed-44-debretrieval/tmp/cloud-init-src .
++ lxc stop cii-lxdcontainer-hirsute-proposed-44-debretrieval
++ pushd cloud-init-src
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed
++ dpkg-source -x cloud-init_21.3-1-g6803368d-0ubuntu1~21.04.2.dsc
+gpgv: Signature made Fri 03 Sep 2021 08:07:09 PM UTC
+gpgv:                using RSA key E25451E0221B5773DEBFF178ECDACB160995AD89
+gpgv: Can't check signature: No public key
+dpkg-source: warning: failed to verify signature on ./cloud-init_21.3-1-g6803368d-0ubuntu1~21.04.2.dsc
+dpkg-source: info: extracting cloud-init in cloud-init-21.3-1-g6803368d
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d.orig.tar.gz
+dpkg-source: info: unpacking cloud-init_21.3-1-g6803368d-0ubuntu1~21.04.2.debian.tar.xz
+dpkg-source: info: applying cpick-28e56d99-Azure-Retry-dhcp-on-timeouts-when-polling
+dpkg-source: info: applying cpick-e69a8874-Set-Azure-to-only-update-metadata-on-BOOT_NEW_INSTANCE
+++ realpath cloud-init-21.3-1-g6803368d/
++ ln -s /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d ../cloud-init
++ popd
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed
++ CLOUD_INIT_PLATFORM=lxd_container
++ CLOUD_INIT_OS_IMAGE=hirsute
++ (( proposed ))
++ CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED
++ CLOUD_INIT_COLLECT_LOGS=ON_ERROR
++ CLOUD_INIT_LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud_init_test_logs
++ export CLOUD_INIT_PLATFORM
++ export CLOUD_INIT_CLOUD_INIT_SOURCE
++ export CLOUD_INIT_OS_IMAGE
++ export CLOUD_INIT_COLLECT_LOGS
++ export CLOUD_INIT_LOCAL_LOG_PATH
++ cd cloud-init
++ tox -e integration-tests-jenkins -- -vv --showlocals tests/integration_tests
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/setup.py
+integration-tests-jenkins create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins
+integration-tests-jenkins installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/integration-requirements.txt
+integration-tests-jenkins inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip
+integration-tests-jenkins installed: adal==1.2.7,appdirs==1.4.4,applicationinsights==0.11.10,argcomplete==1.12.3,attrs==21.2.0,autopage==0.4.0,azure-cli-core==2.28.1,azure-cli-telemetry==1.0.6,azure-common==1.1.27,azure-core==1.18.0,azure-mgmt-compute==14.0.0,azure-mgmt-core==1.2.2,azure-mgmt-network==13.0.0,azure-mgmt-resource==13.0.0,bcrypt==3.2.0,boto3==1.18.40,botocore==1.21.40,cachetools==4.2.2,certifi==2021.5.30,cffi==1.14.6,chardet==4.0.0,cliff==3.9.0,cloud-init @ file:///var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/dist/cloud-init-21.3.zip,cmd2==2.1.2,colorama==0.4.4,configobj==5.0.6,configparser==4.0.2,cryptography==3.3.2,debtcollector==2.3.0,decorator==5.1.0,dogpile.cache==1.1.4,google-api-core==2.0.1,google-api-python-client==2.20.0,google-auth==2.0.2,google-auth-httplib2==0.1.0,googleapis-common-protos==1.53.0,httplib2==0.19.1,humanfriendly==9.2,idna==2.10,importlib-metadata==4.8.1,importlib-resources==5.2.2,iniconfig==1.1.1,iso8601==0.1.16,isodate==0.6.0,Jinja2==3.0.1,jmespath==0.10.0,jsonpatch==1.32,jsonpointer==2.1,jsonschema==3.2.0,keystoneauth1==4.3.1,knack==0.8.2,MarkupSafe==2.0.1,msal==1.14.0,msgpack==1.0.2,msrest==0.6.21,msrestazure==0.6.4,munch==2.5.0,netaddr==0.8.0,netifaces==0.11.0,oauthlib==3.1.1,oci==2.45.0,openstacksdk==0.59.0,os-service-types==1.7.0,osc-lib==2.4.2,oslo.config==8.7.1,oslo.i18n==5.1.0,oslo.serialization==4.2.0,oslo.utils==4.10.0,packaging==21.0,paramiko==2.7.2,pbr==5.6.0,pkg_resources==0.0.0,pkginfo==1.7.1,pluggy==1.0.0,portalocker==1.7.1,prettytable==2.2.0,protobuf==3.17.3,psutil==5.8.0,py==1.10.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycloudlib @ git+https://github.com/canonical/pycloudlib.git@245ca0b97e71926fdb651147e42d6256b17f6778,pycparser==2.20,Pygments==2.10.0,PyJWT==2.1.0,PyNaCl==1.4.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pyperclip==1.8.2,pyrsistent==0.18.0,PySocks==1.7.1,pytest==6.2.5,python-cinderclient==8.1.0,python-dateutil==2.8.2,python-keystoneclient==4.2.0,python-novaclient==17.6.0,python-openstackclient==5.6.0,python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requestsexceptions==1.4.0,rfc3986==1.5.0,rsa==4.7.2,s3transfer==0.5.0,simplejson==3.17.5,six==1.16.0,stevedore==3.4.0,tabulate==0.8.9,toml==0.10.2,typing-extensions==3.10.0.2,uritemplate==3.0.1,urllib3==1.26.6,wcwidth==0.2.5,wrapt==1.12.1,zipp==3.5.0
+integration-tests-jenkins runtests: PYTHONHASHSEED='3997975070'
+integration-tests-jenkins runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python -m pytest --log-cli-level=INFO -vv --showlocals tests/integration_tests
+============================= test session starts ==============================
+platform linux -- Python 3.6.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/bin/python
+cachedir: .pytest_cache
+rootdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d, configfile: tox.ini
+collecting ... collected 149 items / 1 deselected / 148 selected
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:01:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:01:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:01:42 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=ON_ERROR
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud_init_test_logs
+OPENSTACK_NETWORK=None
+ORACLE_AVAILABILITY_DOMAIN=None
+OS_IMAGE=hirsute
+PLATFORM=lxd_container
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-13 07:01:42 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_container
+2021-09-13 07:01:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:f9f180749f5ffce3338c337a7f22243e0e1f36ca77373b474a7ffa3b787c4b5e
+user_data=None
+2021-09-13 07:01:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:01:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:01:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:01:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:01:56 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:02:02 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ready-toad)
+2021-09-13 07:02:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:02:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-13 07:02:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:02:03 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-13 07:02:03 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-13 07:02:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-13 07:02:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-13 07:02:20 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:02:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-13 07:02:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-13 07:02:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-13 07:02:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-13 07:02:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-13 07:02:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-13 07:03:26 INFO      integration_testing:instances.py:113 Created new image: local:ready-toad-snapshot
+2021-09-13 07:03:26 INFO      integration_testing:conftest.py:162 Done with environment setup
+2021-09-13 07:03:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:03:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:03:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:03:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:03:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:03:52 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:03:56 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=tough-satyr)
+2021-09-13 07:03:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:03:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:03:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:03:56 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:03:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-13 07:03:56 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED                                                                   [  0%]
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:03:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:03:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:03:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:f9f180749f5ffce3338c337a7f22243e0e1f36ca77373b474a7ffa3b787c4b5e
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-13 07:04:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:04:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:04:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:04:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:04:10 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:04:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=smooth-bedbug)
+2021-09-13 07:04:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:04:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-13 07:04:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:04:18 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-13 07:04:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-13 07:04:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-13 07:04:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-13 07:04:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:04:20 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-13 07:04:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-13 07:04:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-13 07:04:38 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:04:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-13 07:04:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-13 07:04:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname something-else'
+2021-09-13 07:04:39 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:04:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:04:46 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:04:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:04:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:04:46 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:04:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-13 07:04:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init init'
+2021-09-13 07:04:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-13 07:04:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c cloud-id
+2021-09-13 07:04:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-13 07:04:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:04:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c systemd-analyze
+2021-09-13 07:04:51 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-13 07:04:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-13 07:04:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-13 07:04:53 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:04:53 INFO      integration_testing.test_upgrade:test_upgrade.py:136 
+=== `systemd-analyze` before:
+Startup finished in 10.789s (userspace) 
+graphical.target reached after 9.348s in userspace
+=== `systemd-analyze` after:
+Startup finished in 6.509s (userspace) 
+graphical.target reached after 5.822s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+4.460s snapd.seeded.service
+1.607s snapd.service
+1.210s cloud-init.service
+ 987ms cloud-init-local.service
+ 876ms snap.lxd.activate.service
+ 828ms cloud-config.service
+ 679ms snapd.apparmor.service
+ 610ms cloud-final.service
+ 518ms apparmor.service
+ 175ms networkd-dispatcher.service
+=== `systemd-analyze blame` after (first 10 lines):
+3.223s snap.lxd.activate.service
+2.407s snapd.service
+1.010s cloud-init.service
+ 959ms cloud-init-local.service
+ 799ms cloud-config.service
+ 619ms cloud-final.service
+ 211ms networkd-dispatcher.service
+ 159ms accounts-daemon.service
+ 133ms systemd-udev-settle.service
+ 129ms udisks2.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.39000 seconds
+Finished stage: (init-network) 00.79100 seconds
+Finished stage: (modules-config) 00.31800 seconds
+Finished stage: (modules-final) 00.10000 seconds
+Total Time: 1.59900 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.40800 seconds
+Finished stage: (init-network) 00.54400 seconds
+Finished stage: (modules-config) 00.29700 seconds
+Finished stage: (modules-final) 00.09100 seconds
+Total Time: 1.34000 seconds
+Finished stage: (init-network) 00.17400 seconds
+Total Time: 0.17400 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.53700s (init-network/config-ssh)
+     00.15200s (modules-config/config-grub-dpkg)
+     00.08800s (modules-config/config-apt-configure)
+     00.04500s (modules-final/config-keys-to-console)
+     00.03600s (init-network/config-users-groups)
+     00.03300s (modules-config/config-locale)
+     00.03100s (init-local/search-NoCloud)
+     00.03000s (init-network/config-resizefs)
+     00.00600s (init-network/config-set_hostname)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.32100s (init-network/config-ssh)
+     00.14600s (modules-config/config-grub-dpkg)
+     00.08900s (modules-config/config-apt-configure)
+     00.04000s (modules-final/config-keys-to-console)
+     00.03300s (init-local/search-NoCloud)
+     00.03000s (modules-config/config-locale)
+     00.03000s (init-network/config-resizefs)
+     00.01000s (init-network/config-users-groups)
+     00.00600s (init-network/config-growpart)
+
+PASSED                                                                   [  1%]
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:04:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:04:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:f9f180749f5ffce3338c337a7f22243e0e1f36ca77373b474a7ffa3b787c4b5e
+user_data=None
+2021-09-13 07:05:05 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:05:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:05:09 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:05:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pro-meerkat)
+2021-09-13 07:05:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:05:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-13 07:05:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:05:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+2021-09-13 07:05:16 INFO      integration_testing:instances.py:144 Installing proposed image
+2021-09-13 07:05:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init'
+2021-09-13 07:05:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-13 07:05:33 INFO      integration_testing:instances.py:136 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:05:33 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:05:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:05:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:05:39 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:05:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:05:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:05:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:05:52 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:05:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:05:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:05:56 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:05:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=gentle-walleye)
+2021-09-13 07:05:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:05:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:05:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:05:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:05:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-13 07:05:59 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-13 07:05:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/f9e6958c-6914-4c91-963b-901c542d037b.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-13 07:06:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-13 07:06:00 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:06:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:06 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:06:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:06:08 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:06:10 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-13 07:06:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED                                                                   [  2%]
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:06:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:06:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:8d:21:10\n', 'volatile.eth0.hwaddr': '02:00:00:8d:21:10'}
+2021-09-13 07:06:13 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+2021-09-13 07:06:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:06:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:06:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:06:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=unbiased-poodle)
+2021-09-13 07:06:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:06:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:06:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:06:27 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:06:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:06:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED                                                                   [  3%]
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:06:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:06:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:06:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:06:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:06:41 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:06:44 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=darling-chimp)
+2021-09-13 07:06:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:06:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:06:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:06:45 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:06:45 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-13 07:06:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/219eedab-bb2a-4037-890e-c2d48a690df7.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-13 07:06:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/7147cbb5-bcfc-459d-a40d-934cef3675ce.tmp /etc/cloud/ds-identify.cfg'
+2021-09-13 07:06:45 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-13 07:06:45 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:06:48 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:06:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:06:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:06:52 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:06:55 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  4%]------------------------------ live log logreport ------------------------------
+2021-09-13 07:06:59 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:06:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:06:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:b9:d1:a1\n', 'volatile.eth0.hwaddr': '02:00:00:b9:d1:a1'}
+execute_via_ssh=False
+2021-09-13 07:07:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:07:04 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:07:23 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=civil-rhino)
+2021-09-13 07:07:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:07:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:07:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:07:24 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:07:24 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED                                                                   [  4%]
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED [  5%]
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:07:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:07:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-13 07:07:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:07:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:07:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:07:40 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:07:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=intent-sunbeam)
+2021-09-13 07:07:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:07:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:07:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:07:50 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:07:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  6%]
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED [  6%]
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:07:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:07:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-13 07:08:04 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:08:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:08:08 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:08:11 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=dynamic-oryx)
+2021-09-13 07:08:11 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:08:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:08:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:08:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:08:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [  7%]
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED [  8%]
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:08:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:08:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:08:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:08:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:08:25 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:08:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fluent-wallaby)
+2021-09-13 07:08:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:08:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:08:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:08:28 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:08:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-13 07:08:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-13 07:08:28 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-13 07:08:28 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:08:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:08:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:08:34 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:08:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status'
+2021-09-13 07:08:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED                                                                   [  9%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED [ 10%]
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED [ 11%]
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:08:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:08:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-13 07:08:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:08:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:08:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:08:52 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=funky-osprey)
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 12%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED                                                                   [ 13%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-13 07:09:08 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 14%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_key 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-13 07:09:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 15%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-13 07:09:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'apt-key finger'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:09 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 16%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED [ 17%]
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:09:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-13 07:09:19 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:09:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:09:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:09:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=knowing-duckling)
+2021-09-13 07:09:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:09:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:09:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:09:27 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:27 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:09:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-13 07:09:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:09:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:09:39 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:09:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=up-robin)
+2021-09-13 07:09:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:09:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:09:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:09:43 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED                                                                   [ 18%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:09:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-13 07:09:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:09:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:09:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:09:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:09:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=optimum-javelin)
+2021-09-13 07:09:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:09:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:09:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:09:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED                                                                   [ 19%]
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:09:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:09:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:10:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:10:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-13 07:10:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:10:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:10:11 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:10:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=healthy-guppy)
+2021-09-13 07:10:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:10:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:10:15 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED                                                                   [ 20%]
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:10:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:10:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED                                                                   [ 21%]
+tests/integration_tests/modules/test_cli.py::test_valid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:10:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:10:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-13 07:10:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:27 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:10:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:10:28 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:10:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=gentle-chamois)
+2021-09-13 07:10:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:10:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:10:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:10:31 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:10:31 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:10:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:10:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-13 07:10:40 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:10:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:10:43 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:10:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=kind-worm)
+2021-09-13 07:10:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:10:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:10:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:10:48 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:10:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED                                                                   [ 22%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:10:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:10:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=## template: jinja
+#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo {{ds.meta_data.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg.def_log_file}} >> /var/tmp/runcmd_output
+
+2021-09-13 07:10:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:10:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:10:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:11:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:11:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humane-raccoon)
+2021-09-13 07:11:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:11:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:11:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:11:06 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 23%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 24%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'locale -a'
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED                                                                   [ 25%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd_with_variable_substitution 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED                                                                   [ 26%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-13 07:11:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED                                                                   [ 27%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED [ 28%]
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED [ 29%]
+tests/integration_tests/modules/test_command_output.py::test_runcmd 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:11:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-13 07:11:18 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:11:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:11:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:11:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:11:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:11:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=precise-snake)
+2021-09-13 07:11:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:11:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:11:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:11:26 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED                                                                   [ 29%]
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED [ 30%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED [ 31%]
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED [ 31%]
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED [ 32%]
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:11:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-13 07:11:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:11:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:11:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:11:37 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:11:41 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=keen-ox)
+2021-09-13 07:11:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:11:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:11:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:11:42 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 33%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 34%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 35%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:11:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-13 07:11:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:11:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:11:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:11:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:11:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:11:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=awaited-monitor)
+2021-09-13 07:11:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:11:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:11:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:11:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 36%]
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:11:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:11:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:12:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-13 07:12:08 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:12:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:12:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:12:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:12:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:12:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=helpful-krill)
+2021-09-13 07:12:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 37%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 38%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 39%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 40%]
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:16 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] SKIPPED [ 41%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] SKIPPED [ 42%]
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge SKIPPED [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:12:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-13 07:12:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:12:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:12:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:12:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:12:28 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=enormous-oarfish)
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+PASSED                                                                   [ 43%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED (/etc/ntp.conf.dist does not exist)                              [ 44%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:12:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED                                                                   [ 45%]
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:12:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:12:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+
+2021-09-13 07:12:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:13:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:13:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:13:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clever-oriole)
+2021-09-13 07:13:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:13:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:13:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:13:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:13:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-13 07:13:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED                                                                   [ 46%]
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:13:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:13:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+
+2021-09-13 07:13:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:33 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:13:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:13:34 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:13:37 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=mint-lionfish)
+2021-09-13 07:13:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:13:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:13:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:13:38 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:13:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:13:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:13:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-13 07:13:50 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:13:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:13:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:13:54 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:14:12 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=oriented-aardvark)
+2021-09-13 07:14:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:14:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:14:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:14:12 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:14:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ntpd --version'
+2021-09-13 07:14:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-13 07:14:12 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED                                                                   [ 47%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:14:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:14:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-13 07:14:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:14:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:14:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:14:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:14:26 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:14:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=safe-midge)
+2021-09-13 07:14:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:14:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:14:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:14:50 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:14:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED                                                                   [ 48%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:14:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:14:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED                                                                   [ 49%]
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:14:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:14:50 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:14:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:14:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:14:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:02 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:15:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:15:03 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:15:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=innocent-beagle)
+2021-09-13 07:15:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:15:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:15:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:15:06 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:15:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-13 07:15:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/8365c1a8-c958-4ece-b3b8-aa25b40f9814.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-13 07:15:06 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:15:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:15:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:15:12 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:15:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init status --wait'
+2021-09-13 07:15:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 50%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 51%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 52%]
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:15:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+SKIPPED (Test marked unstable. Manually remove mark to run it)           [ 53%]
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:15:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-13 07:15:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:15:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:15:29 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:15:32 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=innocent-anchovy)
+2021-09-13 07:15:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:15:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:15:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:15:32 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:15:32 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:15:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-13 07:15:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:15:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:15:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:15:45 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:15:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sincere-yak)
+2021-09-13 07:15:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:15:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:15:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:15:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:15:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 54%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:15:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:15:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-13 07:15:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:01 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:16:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:16:02 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:16:05 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=keen-primate)
+2021-09-13 07:16:05 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:16:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:16:05 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:16:05 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:16:05 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 55%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:16:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:16:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-13 07:16:14 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:16:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:16:18 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:16:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=smart-toucan)
+2021-09-13 07:16:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:16:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:16:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:16:22 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:16:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:16:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:16:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-13 07:16:31 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:35 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:16:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:16:37 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:16:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=massive-panda)
+2021-09-13 07:16:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:16:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:16:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:16:40 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:16:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c hostname
+2021-09-13 07:16:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-13 07:16:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED                                                                   [ 56%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:16:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:16:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-13 07:16:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:16:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:16:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:16:57 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=rational-fox)
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 57%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 58%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 59%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED                                                                   [ 60%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 61%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 62%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:17:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-13 07:17:09 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:17:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:17:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:17:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:17:13 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=hot-flea)
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 63%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 64%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 65%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED                                                                   [ 66%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 67%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:17:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 68%]
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:17:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:17:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-13 07:17:25 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:17:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:17:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:17:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:17:29 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:17:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=notable-pug)
+2021-09-13 07:17:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:18:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:18:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:18:00 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'snap list'
+PASSED                                                                   [ 69%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:18:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-13 07:18:07 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:10 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:18:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:18:11 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:18:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=relaxed-shad)
+2021-09-13 07:18:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:18:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:18:14 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:18:15 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:15 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:18:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-13 07:18:24 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:18:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:18:27 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:18:30 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=safe-serval)
+2021-09-13 07:18:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:18:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:18:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:18:30 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:30 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED                                                                   [ 70%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:18:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-13 07:18:41 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:18:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:18:43 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=easy-ram)
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 71%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 72%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:46 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 73%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 74%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 75%]
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:18:47 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 76%]
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:18:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:18:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-13 07:18:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:18:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:18:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:19:04 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=proven-ape)
+2021-09-13 07:19:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:19:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:19:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:19:04 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:04 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-13 07:19:12 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:17 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:19:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=lenient-giraffe)
+2021-09-13 07:19:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED                                                                   [ 77%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED                                                                   [ 78%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED                                                                   [ 79%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED                                                                   [ 80%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED                                                                   [ 81%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED                                                                   [ 82%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED                                                                   [ 83%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-13 07:19:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:32 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:33 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:19:36 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=valid-osprey)
+2021-09-13 07:19:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:19:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:19:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:19:36 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:36 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-13 07:19:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-13 07:19:37 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-13 07:19:38 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-13 07:19:39 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-13 07:19:40 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 84%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:19:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-13 07:19:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:54 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:19:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:55 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:19:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=hot-gecko)
+2021-09-13 07:19:58 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:19:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:19:59 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:19:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:19:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-13 07:19:59 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-13 07:20:00 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-13 07:20:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-13 07:20:02 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:20:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-13 07:20:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:17 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:20:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=leading-tick)
+2021-09-13 07:20:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:20:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:20:20 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-13 07:20:20 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-13 07:20:21 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-13 07:20:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-13 07:20:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 85%]
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:20:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-13 07:20:34 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:37 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:38 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:20:41 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=flowing-sparrow)
+2021-09-13 07:20:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:20:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:20:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:20:41 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:20:41 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-13 07:20:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-13 07:20:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-13 07:20:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+2021-09-13 07:20:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-13 07:20:44 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED                                                                   [ 86%]
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:20:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:20:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-13 07:20:56 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:20:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:20:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:21:00 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:21:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=brief-hog)
+2021-09-13 07:21:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:21:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:21:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:21:03 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:21:03 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED                                                                   [ 87%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:21:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:21:05 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:21:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:13 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:21:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:21:14 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:21:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ready-krill)
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:21:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:21:17 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:21:17 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/de8a097d-edf3-4f33-808a-83e4f3a4f5c3.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:21:17 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-13 07:21:17 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:21:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:22 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:21:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:21:23 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:21:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:21:26 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 87%]------------------------------ live log logreport ------------------------------
+2021-09-13 07:21:30 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled_by_default SKIPPED [ 88%]
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:21:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:21:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-13 07:21:36 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:38 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:39 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:21:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:21:40 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:21:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=subtle-hermit)
+2021-09-13 07:21:42 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:21:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:21:43 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:21:43 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/97d2ffd0-6f83-4cd4-be7c-e6d2fa818173.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-13 07:21:43 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-13 07:21:43 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:21:45 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:49 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:21:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:21:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:21:49 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:21:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:21:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED                                                                   [ 89%]------------------------------ live log logreport ------------------------------
+2021-09-13 07:21:54 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:21:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:21:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-13 07:22:00 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:22:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:22:04 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=hopeful-monkey)
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group ubuntu
+PASSED                                                                   [ 89%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent group cloud-users
+PASSED                                                                   [ 90%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd ubuntu
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd foobar
+PASSED                                                                   [ 91%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd barfoo
+PASSED                                                                   [ 92%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- getent passwd cloudy
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:07 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'groups root'
+PASSED                                                                   [ 93%]
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:22:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-13 07:22:16 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:22:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:22:19 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:22:22 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sweeping-octopus)
+2021-09-13 07:22:22 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:22:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:22:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:22:23 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:22:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-13 07:22:23 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-13 07:22:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-13 07:22:23 INFO      pycloudlib.instance:instance.py:167 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-13 07:22:23 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:22:26 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:29 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:22:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:22:30 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:22:33 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED                                                                   [ 94%]
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:22:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:22:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:22:42 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:22:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:22:45 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:22:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pleasant-antelope)
+2021-09-13 07:22:48 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:22:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:22:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:22:49 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:22:49 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:22:49 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:22:51 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:53 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:22:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:22:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:22:54 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:22:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-13 07:22:57 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-13 07:22:57 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/95372bb2-a300-48d0-bc5a-bfc0d4cddc2f.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-13 07:22:57 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:22:59 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:03 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:23:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:23:04 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:23:06 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]------------------------------ live log logreport ------------------------------
+2021-09-13 07:23:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:23:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:23:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:23:17 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:20 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:21 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:23:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:23:21 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:23:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=prompt-hound)
+2021-09-13 07:23:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:23:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:23:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:23:25 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:23:25 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-13 07:23:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/f04c9890-ee07-4628-856c-a4ea31ad16dc.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-13 07:23:25 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-13 07:23:25 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:23:28 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:30 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:23:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:23:31 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:23:34 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 95%]------------------------------ live log logreport ------------------------------
+2021-09-13 07:23:38 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:23:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:23:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=None
+2021-09-13 07:23:44 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:47 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:23:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:23:48 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:23:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=brief-cobra)
+2021-09-13 07:23:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:23:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:23:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:23:52 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:23:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-13 07:23:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'mv /var/tmp/58afaa42-520a-40a5-b17a-2f94a6f306c6.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-13 07:23:52 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-13 07:23:52 INFO      integration_testing:instances.py:65 Restarting instance and waiting for boot
+2021-09-13 07:23:55 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:57 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:23:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:23:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:23:58 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:24:01 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED                                                                   [ 96%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:24:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-13 07:24:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:ready-toad-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-13 07:24:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-13 07:24:11 INFO      pycloudlib.instance:instance.py:167 executing: sh -c whoami
+2021-09-13 07:24:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-13 07:24:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-13 07:24:15 INFO      pycloudlib.instance:instance.py:167 executing: cloud-init status --wait --long
+2021-09-13 07:24:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=measured-kangaroo)
+2021-09-13 07:24:18 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:183 image serial: 20210908
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED                                                                   [ 97%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED                                                                   [ 98%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED                                                                   [ 99%]
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] 
+-------------------------------- live log setup --------------------------------
+2021-09-13 07:24:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-13 07:24:19 INFO      pycloudlib.instance:instance.py:167 executing: sudo -- sh -c 'file /root/file_text'
+PASSED                                                                   [100%]
+------------------------------ live log teardown -------------------------------
+2021-09-13 07:24:22 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:ready-toad-snapshot
+
+
+=============================== warnings summary ===============================
+.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/_pytest/config/__init__.py:1184: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
+    _pytest.deprecated.STRICT_OPTION, stacklevel=2
+
+.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
+    import imp
+
+conftest.py:68
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(autouse=True)
+
+conftest.py:168
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/conftest.py:168: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:104
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:104: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='session')
+
+tests/integration_tests/conftest.py:261
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:261: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/conftest.py:268
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:268: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='module')
+
+tests/integration_tests/conftest.py:275
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/conftest.py:275: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture(scope='class')
+
+tests/integration_tests/modules/test_disk_setup.py:18
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/tests/integration_tests/modules/test_disk_setup.py:18: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
+  Use @pytest.fixture instead; they are the same.
+    @pytest.yield_fixture
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /var/lib/jenkins/servers/server/workspace/cloud-init-integration-lxd_container-hirsute-proposed/cloud-init-src/cloud-init-21.3-1-g6803368d/.tox/integration-tests-jenkins/lib/python3.6/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=== 123 passed, 25 skipped, 1 deselected, 10 warnings in 1367.93s (0:22:47) ====
+___________________________________ summary ____________________________________
+  integration-tests-jenkins: commands succeeded
+  congratulations :)
++ cleanup
++ [[ -n cii-lxdcontainer-hirsute-proposed-44-debretrieval ]]
++ lxc info cii-lxdcontainer-hirsute-proposed-44-debretrieval
+Archiving artifacts
+‘cloud_init_test_logs’ doesn’t match anything
+No artifacts found that match the file pattern "cloud_init_test_logs". Configuration error?
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS

--- a/21.3-1/integration_tests/lxd_vm_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_vm_bionic_integration_tests.txt
@@ -1,0 +1,5496 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:44:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 18:44:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 18:44:39 DEBUG     pycloudlib.cloud:cloud.py:338 finding released Ubuntu image for bionic
+2021-09-07 18:44:39 DEBUG     pycloudlib.streams:streams.py:46 looking for image with the following config:
+2021-09-07 18:44:39 DEBUG     pycloudlib.streams:streams.py:47 {'filters': [datatype = image-downloads [none=], ftype = lxd.tar.xz [none=], arch = amd64 [none=], release = bionic [none=]]}
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-07 18:44:45 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for lxd_vm
+2021-09-07 18:44:45 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_vm
+Launching instance with launch_kwargs:
+image_id=ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732
+user_data=None
+2021-09-07 18:44:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732
+user_data=None
+2021-09-07 18:44:46 DEBUG     pycloudlib.cloud:cloud.py:64 The profile named pycloudlib-vm-bionic-v3 already exists
+The profile named pycloudlib-vm-bionic-v3 already exists
+2021-09-07 18:44:47 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732'
+['lxc', 'init', 'ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:44:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created settling-crappie
+2021-09-07 18:44:48 DEBUG     pycloudlib.instance:instance.py:394 starting settling-crappie
+2021-09-07 18:45:48 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:45:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:45:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:45:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:45:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:45:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:45:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:45:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:45:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:45:51 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:45:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:45:51 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=settling-crappie)
+2021-09-07 18:45:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=settling-crappie)
+2021-09-07 18:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-07 18:45:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-07 18:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:45:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-07 18:45:52 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-07 18:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 18:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 18:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 18:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 18:46:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 18:46:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 18:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-07 18:46:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:46:06 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 18:46:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 18:46:07 DEBUG     pycloudlib.instance:instance.py:331 shutting down settling-crappie
+2021-09-07 18:46:08 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: settling-crappie
+2021-09-07 18:46:09 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot settling-crappie-snapshot
+Created new image: local:settling-crappie-snapshot
+2021-09-07 18:47:29 INFO      integration_testing:instances.py:114 Created new image: local:settling-crappie-snapshot
+2021-09-07 18:47:29 DEBUG     pycloudlib.instance:instance.py:200 deleting settling-crappie
+Done with environment setup
+2021-09-07 18:47:29 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:47:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:47:29 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:48:44 DEBUG     pycloudlib.cloud:cloud.py:275 Created united-elk
+2021-09-07 18:48:45 DEBUG     pycloudlib.instance:instance.py:394 starting united-elk
+2021-09-07 18:49:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:49:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:49:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:49:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:49:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:49:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:49:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:49:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:49:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:49:40 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:49:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:49:40 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=united-elk)
+2021-09-07 18:49:41 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=united-elk)
+2021-09-07 18:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:49:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:49:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:49:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:49:41 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-07 18:49:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-07 18:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+2021-09-07 18:49:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:49:41 DEBUG     pycloudlib.instance:instance.py:200 deleting united-elk
+
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:49:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:49:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:49:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:49:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732
+user_data=None
+2021-09-07 18:49:43 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732'
+['lxc', 'init', 'ubuntu:2ca9694e2d3e01dce8b581fa7949649f920213ff767803113297538761dbf732', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:49:43 DEBUG     pycloudlib.cloud:cloud.py:275 Created humorous-marmoset
+2021-09-07 18:49:43 DEBUG     pycloudlib.instance:instance.py:394 starting humorous-marmoset
+2021-09-07 18:50:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:50:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:50:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:50:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:50:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:50:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:50:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:50:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:50:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=humorous-marmoset)
+2021-09-07 18:50:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humorous-marmoset)
+2021-09-07 18:50:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:50:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-07 18:50:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-07 18:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:50:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:50:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-07 18:50:51 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-07 18:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 18:50:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 18:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 18:50:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 18:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 18:51:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 18:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-07 18:51:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:51:07 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-07 18:51:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 18:51:07 DEBUG     pycloudlib.instance:instance.py:296 restarting humorous-marmoset
+2021-09-07 18:51:34 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:51:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:51:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:51:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:51:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:51:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:51:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:51:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:51:38 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:51:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:51:38 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 18:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 18:51:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 18:51:39 DEBUG     pycloudlib.instance:instance.py:200 deleting humorous-marmoset
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:51:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:51:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:51:40 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:51:40 DEBUG     pycloudlib.cloud:cloud.py:275 Created sincere-parrot
+2021-09-07 18:51:40 DEBUG     pycloudlib.instance:instance.py:394 starting sincere-parrot
+2021-09-07 18:52:28 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:52:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:52:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:52:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:52:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:52:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:52:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:52:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:52:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:52:34 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:52:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:52:34 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sincere-parrot)
+2021-09-07 18:52:36 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sincere-parrot)
+2021-09-07 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:52:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:52:36 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpcmofgnye to /var/tmp/47e3260e-4de6-4202-8f53-0f157b27827b.tmp
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpcmofgnye to /var/tmp/47e3260e-4de6-4202-8f53-0f157b27827b.tmp
+2021-09-07 18:52:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-07 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/47e3260e-4de6-4202-8f53-0f157b27827b.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/47e3260e-4de6-4202-8f53-0f157b27827b.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-07 18:52:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 18:52:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 18:52:37 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 18:52:37 DEBUG     pycloudlib.instance:instance.py:296 restarting sincere-parrot
+2021-09-07 18:53:08 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:53:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:53:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:53:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:53:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:53:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:53:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:53:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:53:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:53:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 18:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 18:53:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 18:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /var/tmp'
+2021-09-07 18:53:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:53:22 DEBUG     pycloudlib.instance:instance.py:200 deleting sincere-parrot
+------------------------------ live log logreport ------------------------------
+2021-09-07 18:53:23 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:53:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:15:d8:53\n', 'volatile.eth0.hwaddr': '02:00:00:15:d8:53'}
+user_data=None
+2021-09-07 18:53:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:15:d8:53\n', 'volatile.eth0.hwaddr': '02:00:00:15:d8:53'}
+user_data=None
+2021-09-07 18:53:23 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:15:d8:53\n', '--config', 'volatile.eth0.hwaddr=02:00:00:15:d8:53', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:53:23 DEBUG     pycloudlib.cloud:cloud.py:275 Created harmless-ghoul
+2021-09-07 18:53:24 DEBUG     pycloudlib.instance:instance.py:394 starting harmless-ghoul
+2021-09-07 18:54:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:54:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:54:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:54:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:54:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:54:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:54:21 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:54:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:54:21 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=harmless-ghoul)
+2021-09-07 18:54:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=harmless-ghoul)
+2021-09-07 18:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:54:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:54:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:54:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:54:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:54:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 18:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 18:54:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:54:22 DEBUG     pycloudlib.instance:instance.py:200 deleting harmless-ghoul
+
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:54:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:54:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 18:54:22 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:54:22 DEBUG     pycloudlib.cloud:cloud.py:275 Created summary-bee
+2021-09-07 18:54:22 DEBUG     pycloudlib.instance:instance.py:394 starting summary-bee
+2021-09-07 18:55:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:55:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:55:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:55:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:55:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:55:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:55:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:55:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:55:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:55:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=summary-bee)
+2021-09-07 18:55:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=summary-bee)
+2021-09-07 18:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:55:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:55:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:55:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:55:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:55:19 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpt9qqklbz to /var/tmp/58eff40a-1a4d-4455-8a52-0fa08883c9af.tmp
+2021-09-07 18:55:19 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpt9qqklbz to /var/tmp/58eff40a-1a4d-4455-8a52-0fa08883c9af.tmp
+2021-09-07 18:55:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 18:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/58eff40a-1a4d-4455-8a52-0fa08883c9af.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/58eff40a-1a4d-4455-8a52-0fa08883c9af.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmp3ziq_sto to /var/tmp/fb9930ac-07a2-43dc-8005-a9ec55a29b4c.tmp
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmp3ziq_sto to /var/tmp/fb9930ac-07a2-43dc-8005-a9ec55a29b4c.tmp
+2021-09-07 18:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/fb9930ac-07a2-43dc-8005-a9ec55a29b4c.tmp /etc/cloud/ds-identify.cfg'
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/fb9930ac-07a2-43dc-8005-a9ec55a29b4c.tmp /etc/cloud/ds-identify.cfg'
+2021-09-07 18:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 18:55:20 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 18:55:20 DEBUG     pycloudlib.instance:instance.py:296 restarting summary-bee
+2021-09-07 18:55:47 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:55:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:55:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:55:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:55:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:55:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:55:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:55:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:55:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:55:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:55:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 18:55:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 18:55:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:55:54 DEBUG     pycloudlib.instance:instance.py:200 deleting summary-bee
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:55:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 18:55:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+execute_via_ssh=False
+image_id=local:settling-crappie-snapshot
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:ef:ea:99\n', 'volatile.eth0.hwaddr': '02:00:00:ef:ea:99'}
+user_data=None
+2021-09-07 18:55:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+execute_via_ssh=False
+image_id=local:settling-crappie-snapshot
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:ef:ea:99\n', 'volatile.eth0.hwaddr': '02:00:00:ef:ea:99'}
+user_data=None
+2021-09-07 18:55:54 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:ef:ea:99\n', '--config', 'volatile.eth0.hwaddr=02:00:00:ef:ea:99', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 18:55:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created feasible-ibex
+2021-09-07 18:55:54 DEBUG     pycloudlib.instance:instance.py:394 starting feasible-ibex
+2021-09-07 18:56:43 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:56:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:56:43 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:56:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:56:43 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=feasible-ibex)
+2021-09-07 18:56:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=feasible-ibex)
+2021-09-07 18:56:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:56:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:56:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:56:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:56:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:56:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+2021-09-07 18:56:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:56:49 DEBUG     pycloudlib.instance:instance.py:200 deleting feasible-ibex
+
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:56:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-07 18:56:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-07 18:56:50 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-07 18:56:50 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nchef:\n  install_type: omnibus\n  chef_license: accept\n  server_url: https://chef.yourorg.invalid\n  validation_name: some-validator\n', '--vm']
+2021-09-07 18:56:50 DEBUG     pycloudlib.cloud:cloud.py:275 Created expert-caribou
+2021-09-07 18:56:50 DEBUG     pycloudlib.instance:instance.py:394 starting expert-caribou
+2021-09-07 18:57:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:57:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:57:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:57:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:57:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:57:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:57:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:57:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:57:42 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:57:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:57:42 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=expert-caribou)
+2021-09-07 18:57:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=expert-caribou)
+2021-09-07 18:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:57:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:57:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:57:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:57:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:57:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 18:57:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:57:49 DEBUG     pycloudlib.instance:instance.py:200 deleting expert-caribou
+
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:57:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-07 18:57:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-07 18:57:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  sources:\n    cloudinit:\n      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'\n      keyserver: keyserver.ubuntu.com\n      keyid: E4D304DF\n", '--vm']
+2021-09-07 18:57:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created glorious-dodo
+2021-09-07 18:57:49 DEBUG     pycloudlib.instance:instance.py:394 starting glorious-dodo
+2021-09-07 18:58:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:58:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:58:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:58:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:58:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:58:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:58:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:58:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:58:44 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:58:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:58:44 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=glorious-dodo)
+2021-09-07 18:58:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=glorious-dodo)
+2021-09-07 18:58:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:58:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:58:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:58:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:58:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:58:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:58:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 18:58:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:58:52 DEBUG     pycloudlib.instance:instance.py:200 deleting glorious-dodo
+
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:58:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-07 18:58:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-07 18:58:53 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n- rm -f /etc/fstab\n', '--vm']
+2021-09-07 18:58:53 DEBUG     pycloudlib.cloud:cloud.py:275 Created enabled-piglet
+2021-09-07 18:58:53 DEBUG     pycloudlib.instance:instance.py:394 starting enabled-piglet
+2021-09-07 18:59:42 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 18:59:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:59:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:59:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:59:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 18:59:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 18:59:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 18:59:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 18:59:46 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 18:59:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 18:59:46 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=enabled-piglet)
+2021-09-07 18:59:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=enabled-piglet)
+2021-09-07 18:59:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 18:59:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:59:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 18:59:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 18:59:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 18:59:48 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 18:59:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 18:59:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 18:59:48 DEBUG     pycloudlib.instance:instance.py:200 deleting enabled-piglet
+
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 18:59:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-07 18:59:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-07 18:59:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n  - echo 'whoops' > /usr/bin/fallocate\nswap:\n  filename: /swap.img\n  size: 10000000\n  maxsize: 10000000\n", '--vm']
+2021-09-07 18:59:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created distinct-kodiak
+2021-09-07 18:59:49 DEBUG     pycloudlib.instance:instance.py:394 starting distinct-kodiak
+2021-09-07 19:00:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:00:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:00:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:00:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:00:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:00:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:00:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:00:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:00:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:00:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:00:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:00:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=distinct-kodiak)
+2021-09-07 19:00:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=distinct-kodiak)
+2021-09-07 19:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:00:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:00:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:00:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:00:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:00:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-07 19:00:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-07 19:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+2021-09-07 19:00:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:00:51 DEBUG     pycloudlib.instance:instance.py:200 deleting distinct-kodiak
+
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:00:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:00:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:00:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:00:52 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:00:52 DEBUG     pycloudlib.cloud:cloud.py:275 Created special-sponge
+2021-09-07 19:00:53 DEBUG     pycloudlib.instance:instance.py:394 starting special-sponge
+2021-09-07 19:01:41 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:01:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:01:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:01:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:01:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:01:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:01:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:01:46 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:01:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:01:46 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=special-sponge)
+2021-09-07 19:01:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=special-sponge)
+2021-09-07 19:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:01:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:01:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:01:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:01:48 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 19:01:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 19:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-07 19:01:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-07 19:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 19:01:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 19:01:48 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:01:48 DEBUG     pycloudlib.instance:instance.py:296 restarting special-sponge
+2021-09-07 19:02:14 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:02:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:02:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:02:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:02:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:02:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:02:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:02:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:02:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:02:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 19:02:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 19:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 19:02:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:02:18 DEBUG     pycloudlib.instance:instance.py:200 deleting special-sponge
+
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:02:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+2021-09-07 19:02:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+2021-09-07 19:02:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n- openvswitch-switch\n', '--vm']
+2021-09-07 19:02:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created worthy-martin
+2021-09-07 19:02:19 DEBUG     pycloudlib.instance:instance.py:394 starting worthy-martin
+2021-09-07 19:03:07 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:03:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:03:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:03:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:03:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:03:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:03:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:03:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:03:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:03:11 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:03:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:03:11 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=worthy-martin)
+2021-09-07 19:03:23 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=worthy-martin)
+2021-09-07 19:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:03:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:03:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:03:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:03:23 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-07 19:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 19:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 19:03:24 DEBUG     pycloudlib.instance:instance.py:331 shutting down worthy-martin
+2021-09-07 19:03:26 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: worthy-martin
+2021-09-07 19:03:26 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot worthy-martin-snapshot
+Created new image: local:worthy-martin-snapshot
+2021-09-07 19:04:59 INFO      integration_testing:instances.py:114 Created new image: local:worthy-martin-snapshot
+2021-09-07 19:04:59 DEBUG     pycloudlib.instance:instance.py:200 deleting worthy-martin
+Launching instance with launch_kwargs:
+image_id=local:worthy-martin-snapshot
+config_dict={'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:a2:30:26\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:a2:30:26\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:a2:30:26\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', 'volatile.eth0.hwaddr': '02:00:00:a2:30:26'}
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:05:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:worthy-martin-snapshot
+config_dict={'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:a2:30:26\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:a2:30:26\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:a2:30:26\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', 'volatile.eth0.hwaddr': '02:00:00:a2:30:26'}
+user_data=None
+2021-09-07 19:05:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:worthy-martin-snapshot'
+['lxc', 'init', 'local:worthy-martin-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.network-config=bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:a2:30:26\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:a2:30:26\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:a2:30:26\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', '--config', 'volatile.eth0.hwaddr=02:00:00:a2:30:26', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:06:24 DEBUG     pycloudlib.cloud:cloud.py:275 Created steady-guppy
+2021-09-07 19:06:25 DEBUG     pycloudlib.instance:instance.py:394 starting steady-guppy
+2021-09-07 19:07:18 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:07:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:07:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:07:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:07:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:07:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:07:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:07:24 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:07:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:07:24 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=steady-guppy)
+2021-09-07 19:07:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=steady-guppy)
+2021-09-07 19:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:07:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:07:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:07:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:07:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-07 19:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-07 19:07:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-07 19:07:26 DEBUG     pycloudlib.instance:instance.py:200 deleting steady-guppy
+PASSEDDeleting snapshot image created for this testrun: local:worthy-martin-snapshot
+
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:07:26 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:worthy-martin-snapshot
+2021-09-07 19:07:26 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:worthy-martin-snapshot'
+2021-09-07 19:07:27 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:worthy-martin-snapshot
+
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:07:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-07 19:07:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-07 19:07:27 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  conf: |\n    APT {\n        Get {\n            Assume-Yes "true";\n            Fix-Broken "true";\n        }\n    }\n  proxy: "http://proxy.internal:3128"\n  http_proxy: "http://squid.internal:3128"\n  ftp_proxy: "ftp://squid.internal:3128"\n  https_proxy: "https://squid.internal:3128"\n  primary:\n    - arches: [default]\n      uri: http://badarchive.ubuntu.com/ubuntu\n  security:\n    - arches: [default]\n      uri: http://badsecurity.ubuntu.com/ubuntu\n  sources_list: |\n    deb $MIRROR $RELEASE main restricted\n    deb-src $MIRROR $RELEASE main restricted\n    deb $PRIMARY $RELEASE universe restricted\n    deb-src $PRIMARY $RELEASE universe restricted\n    deb $SECURITY $RELEASE-security multiverse\n    deb-src $SECURITY $RELEASE-security multiverse\n  sources:\n    test_keyserver:\n        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937\n        keyserver: keyserver.ubuntu.com\n        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"\n    test_ppa:\n      keyid: 441614D8\n      keyserver: keyserver.ubuntu.com\n      source: "ppa:simplestreams-dev/trunk"\n    test_key:\n      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"\n      key: |\n        -----BEGIN PGP PUBLIC KEY BLOCK-----\n        Version: SKS 1.1.6\n        Comment: Hostname: keyserver.ubuntu.com\n\n        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI\n        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf\n        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq\n        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot\n        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX\n        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6\n        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6\n        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj\n        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l\n        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg\n        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG\n        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN\n        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH\n        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2\n        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj\n        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL\n        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq\n        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH\n        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ\n        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e\n        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf\n        pb0uBy+g0oxJQg15\n        =uy53\n        -----END PGP PUBLIC KEY BLOCK-----\napt_pipelining: os\n', '--vm']
+2021-09-07 19:07:27 DEBUG     pycloudlib.cloud:cloud.py:275 Created fluent-colt
+2021-09-07 19:07:27 DEBUG     pycloudlib.instance:instance.py:394 starting fluent-colt
+2021-09-07 19:08:15 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:08:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:08:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:08:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:08:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:08:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:08:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:08:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fluent-colt)
+2021-09-07 19:08:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fluent-colt)
+2021-09-07 19:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:08:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:08:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:08:30 DEBUG     pycloudlib.instance:instance.py:200 deleting fluent-colt
+
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:08:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-07 19:08:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-07 19:08:31 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      \n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-07 19:08:31 DEBUG     pycloudlib.cloud:cloud.py:275 Created leading-seagull
+2021-09-07 19:08:31 DEBUG     pycloudlib.instance:instance.py:394 starting leading-seagull
+2021-09-07 19:09:21 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:09:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:09:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:09:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:09:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:09:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:09:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:09:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:09:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:09:26 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:09:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:09:26 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=leading-seagull)
+2021-09-07 19:09:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=leading-seagull)
+2021-09-07 19:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:09:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:09:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:09:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:09:27 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 19:09:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:09:27 DEBUG     pycloudlib.instance:instance.py:200 deleting leading-seagull
+
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:09:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-07 19:09:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-07 19:09:28 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      uri: "http://something.random.invalid/ubuntu"\n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-07 19:09:28 DEBUG     pycloudlib.cloud:cloud.py:275 Created sacred-bison
+2021-09-07 19:09:28 DEBUG     pycloudlib.instance:instance.py:394 starting sacred-bison
+2021-09-07 19:10:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:10:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:10:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:10:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:10:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:10:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:10:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:10:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:10:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:10:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:10:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:10:22 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:10:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:10:22 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sacred-bison)
+2021-09-07 19:10:22 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sacred-bison)
+2021-09-07 19:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:10:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:10:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:10:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:10:23 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:10:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 19:10:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:10:23 DEBUG     pycloudlib.instance:instance.py:200 deleting sacred-bison
+
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:10:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-07 19:10:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-07 19:10:23 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  disable_suites:\n  - $RELEASE\n  - $RELEASE-updates\n  - $RELEASE-backports\n  - $RELEASE-security\napt_pipelining: false\n', '--vm']
+2021-09-07 19:10:24 DEBUG     pycloudlib.cloud:cloud.py:275 Created native-gobbler
+2021-09-07 19:10:24 DEBUG     pycloudlib.instance:instance.py:394 starting native-gobbler
+2021-09-07 19:11:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:11:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:11:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:11:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:11:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:11:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:11:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:11:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:11:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:11:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=native-gobbler)
+2021-09-07 19:11:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=native-gobbler)
+2021-09-07 19:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:11:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:11:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:11:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:11:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+2021-09-07 19:11:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:11:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-07 19:11:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:11:19 DEBUG     pycloudlib.instance:instance.py:200 deleting native-gobbler
+
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:11:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-07 19:11:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-07 19:11:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nca-certs:\n  remove-defaults: true\n  trusted:\n    - |\n      -----BEGIN CERTIFICATE-----\n      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx\n      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP\n      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl\n      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW\n      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz\n      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93\n      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl\n      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG\n      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc\n      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ\n      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX\n      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6\n      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2\n      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S\n      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o\n      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4\n      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF\n      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1\n      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3\n      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT\n      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5\n      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3\n      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr\n      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf\n      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ\n      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM\n      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L\n      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT\n      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro\n      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586\n      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l\n      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i\n      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==\n      -----END CERTIFICATE-----\n', '--vm']
+2021-09-07 19:11:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created excited-moccasin
+2021-09-07 19:11:20 DEBUG     pycloudlib.instance:instance.py:394 starting excited-moccasin
+2021-09-07 19:12:08 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:12:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:12:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:12:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:12:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:12:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:12:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:12:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:12:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:12:13 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:12:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:12:13 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=excited-moccasin)
+2021-09-07 19:12:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=excited-moccasin)
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:12:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:12:15 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:12:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:12:15 DEBUG     pycloudlib.instance:instance.py:200 deleting excited-moccasin
+
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:12:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-07 19:12:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-07 19:12:16 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nruncmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-07 19:12:16 DEBUG     pycloudlib.cloud:cloud.py:275 Created positive-kit
+2021-09-07 19:12:16 DEBUG     pycloudlib.instance:instance.py:394 starting positive-kit
+2021-09-07 19:13:05 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:13:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:13:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:13:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:13:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:13:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:13:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:13:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:13:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:13:09 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:13:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:13:09 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=positive-kit)
+2021-09-07 19:13:11 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=positive-kit)
+2021-09-07 19:13:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:13:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:13:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:13:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:13:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:13:11 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:13:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-07 19:13:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:13:11 DEBUG     pycloudlib.instance:instance.py:200 deleting positive-kit
+
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:13:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-07 19:13:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-07 19:13:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=runcmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-07 19:13:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created cuddly-squirrel
+2021-09-07 19:13:12 DEBUG     pycloudlib.instance:instance.py:394 starting cuddly-squirrel
+2021-09-07 19:14:01 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:14:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:14:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:14:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:14:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:14:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:14:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:14:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:14:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:14:06 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:14:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:14:06 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=cuddly-squirrel)
+2021-09-07 19:14:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=cuddly-squirrel)
+2021-09-07 19:14:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:14:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:14:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:14:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:14:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:14:08 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:14:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-07 19:14:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:14:08 DEBUG     pycloudlib.instance:instance.py:200 deleting cuddly-squirrel
+
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:14:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-07 19:14:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-07 19:14:09 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  primary:\n    - arches: [default]\n      uri: http://us.archive.ubuntu.com/ubuntu/\nbyobu_by_default: enable\nfinal_message: |\n  This is my final message!\n  $version\n  $timestamp\n  $datasource\n  $uptime\nlocale: en_GB.UTF-8\nlocale_configfile: /etc/default/locale\nntp:\n  servers: ['ntp.ubuntu.com']\nruncmd:\n  - echo 'hello world' > /var/tmp/runcmd_output\n", '--vm']
+2021-09-07 19:14:09 DEBUG     pycloudlib.cloud:cloud.py:275 Created sharing-loon
+2021-09-07 19:14:09 DEBUG     pycloudlib.instance:instance.py:394 starting sharing-loon
+2021-09-07 19:14:58 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:14:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:14:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:14:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:14:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:15:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:15:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:15:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:15:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:15:02 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:15:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:15:02 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sharing-loon)
+2021-09-07 19:15:05 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sharing-loon)
+2021-09-07 19:15:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:15:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'locale -a'
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:15:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:15:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:15:06 DEBUG     pycloudlib.instance:instance.py:200 deleting sharing-loon
+
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:15:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-07 19:15:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-07 19:15:07 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\noutput: { all: "| tee -a /var/log/cloud-init-test-output" }\nfinal_message: "should be last line in cloud-init-test-output file"\n', '--vm']
+2021-09-07 19:15:07 DEBUG     pycloudlib.cloud:cloud.py:275 Created musical-adder
+2021-09-07 19:15:07 DEBUG     pycloudlib.instance:instance.py:394 starting musical-adder
+2021-09-07 19:15:57 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:15:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:15:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:15:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:15:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:15:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:15:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:16:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:16:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:16:01 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:16:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:16:01 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=musical-adder)
+2021-09-07 19:16:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=musical-adder)
+2021-09-07 19:16:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:16:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:16:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:16:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:16:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:16:03 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:16:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+2021-09-07 19:16:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:16:03 DEBUG     pycloudlib.instance:instance.py:200 deleting musical-adder
+
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:16:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+2021-09-07 19:16:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+2021-09-07 19:16:04 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndevice_aliases:\n  my_alias: /dev/sdb\ndisk_setup:\n  my_alias:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n- label: fs1\n  device: my_alias.1\n  filesystem: ext4\n- label: fs2\n  device: my_alias.2\n  filesystem: ext4\nmounts:\n- ["my_alias.1", "/mnt1"]\n- ["my_alias.2", "/mnt2"]\n', '--vm']
+2021-09-07 19:16:04 DEBUG     pycloudlib.cloud:cloud.py:275 Created accurate-feline
+Running callback specified by 'lxd_setup' mark
+2021-09-07 19:16:04 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-07 19:16:04 DEBUG     pycloudlib.instance:instance.py:394 starting accurate-feline
+2021-09-07 19:16:54 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:16:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:16:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:17:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:17:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:17:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=accurate-feline)
+2021-09-07 19:17:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=accurate-feline)
+2021-09-07 19:17:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:17:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:17:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:17:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:17:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:17:02 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:17:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:17:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:17:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 19:17:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:17:02 DEBUG     pycloudlib.instance:instance.py:200 deleting accurate-feline
+
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:17:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:17:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-07 19:17:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-07 19:17:03 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisk_setup:\n  /dev/sdb:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n  - label: test\n    device: /dev/sdb1\n    filesystem: ext4\n  - label: test2\n    device: /dev/sdb2\n    filesystem: ext4\nmounts:\n- ["/dev/sdb1", "/mnt1"]\n- ["/dev/sdb2", "/mnt2"]\n', '--vm']
+2021-09-07 19:17:03 DEBUG     pycloudlib.cloud:cloud.py:275 Created humorous-tarpon
+Running callback specified by 'lxd_setup' mark
+2021-09-07 19:17:03 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-07 19:17:03 DEBUG     pycloudlib.instance:instance.py:394 starting humorous-tarpon
+2021-09-07 19:17:53 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:17:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:17:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:17:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:17:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:17:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:17:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:17:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:17:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:17:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:17:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=humorous-tarpon)
+2021-09-07 19:17:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humorous-tarpon)
+2021-09-07 19:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:17:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:17:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:17:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:17:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-07 19:17:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-07 19:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 19:17:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 19:18:00 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:18:00 DEBUG     pycloudlib.instance:instance.py:296 restarting humorous-tarpon
+2021-09-07 19:18:26 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:18:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:18:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:18:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:18:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:18:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:18:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:18:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:18:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:18:32 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:18:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:18:32 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:18:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:18:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:18:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 19:18:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:18:34 DEBUG     pycloudlib.instance:instance.py:200 deleting humorous-tarpon
+
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:18:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-07 19:18:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-07 19:18:35 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=## template: jinja\n#cloud-config\nruncmd:\n  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output\n  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output\n', '--vm']
+2021-09-07 19:18:35 DEBUG     pycloudlib.cloud:cloud.py:275 Created workable-ocelot
+2021-09-07 19:18:35 DEBUG     pycloudlib.instance:instance.py:394 starting workable-ocelot
+2021-09-07 19:19:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:19:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:19:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:19:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:19:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:19:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:19:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:19:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:19:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:19:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=workable-ocelot)
+2021-09-07 19:19:30 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=workable-ocelot)
+2021-09-07 19:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:19:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:19:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:19:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:19:30 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 19:19:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 19:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-07 19:19:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:19:30 DEBUG     pycloudlib.instance:instance.py:200 deleting workable-ocelot
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:19:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-07 19:19:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-07 19:19:31 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\nssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-07 19:19:31 DEBUG     pycloudlib.cloud:cloud.py:275 Created meet-sawfish
+2021-09-07 19:19:31 DEBUG     pycloudlib.instance:instance.py:394 starting meet-sawfish
+2021-09-07 19:20:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:20:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:20:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:20:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:20:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:20:27 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:20:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:20:27 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=meet-sawfish)
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=meet-sawfish)
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:20:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:20:29 DEBUG     pycloudlib.instance:instance.py:200 deleting meet-sawfish
+
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:20:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-07 19:20:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-07 19:20:30 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-07 19:20:30 DEBUG     pycloudlib.cloud:cloud.py:275 Created suitable-earwig
+2021-09-07 19:20:30 DEBUG     pycloudlib.instance:instance.py:394 starting suitable-earwig
+2021-09-07 19:21:19 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:21:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:21:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:21:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:21:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:21:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:21:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:21:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:21:24 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:21:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:21:24 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=suitable-earwig)
+2021-09-07 19:21:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=suitable-earwig)
+2021-09-07 19:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:21:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:21:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:21:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:21:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:21:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:21:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:21:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:21:25 DEBUG     pycloudlib.instance:instance.py:200 deleting suitable-earwig
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:21:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-07 19:21:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-07 19:21:25 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh:\n  emit_keys_to_console: false\n', '--vm']
+2021-09-07 19:21:26 DEBUG     pycloudlib.cloud:cloud.py:275 Created accepted-newt
+2021-09-07 19:21:26 DEBUG     pycloudlib.instance:instance.py:394 starting accepted-newt
+2021-09-07 19:22:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:22:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:22:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:22:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:22:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:22:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:22:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:22:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:22:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:22:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=accepted-newt)
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=accepted-newt)
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:22:20 DEBUG     pycloudlib.instance:instance.py:200 deleting accepted-newt
+
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:22:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-07 19:22:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-07 19:22:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nlxd:\n  init:\n    storage_backend: dir\n  bridge:\n    mode: new\n    name: lxdbr0\n    ipv4_address: 10.100.100.1\n    ipv4_netmask: 24\n    ipv4_dhcp_first: 10.100.100.100\n    ipv4_dhcp_last: 10.100.100.200\n    ipv4_nat: true\n    domain: lxd\n', '--vm']
+2021-09-07 19:22:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created topical-snail
+2021-09-07 19:22:20 DEBUG     pycloudlib.instance:instance.py:394 starting topical-snail
+2021-09-07 19:23:08 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:23:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:23:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:23:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:23:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:23:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:23:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:23:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:23:13 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:23:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:23:13 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=topical-snail)
+2021-09-07 19:23:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=topical-snail)
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:23:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:23:24 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:23:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:23:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-07 19:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:23:24 DEBUG     pycloudlib.instance:instance.py:200 deleting topical-snail
+
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:23:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-07 19:23:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-07 19:23:25 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  servers:\n      - 172.16.15.14\n      - 172.16.17.18\n  pools:\n      - 0.cloud-init.mypool\n      - 1.cloud-init.mypool\n      - 172.16.15.15\n', '--vm']
+2021-09-07 19:23:25 DEBUG     pycloudlib.cloud:cloud.py:275 Created beloved-ladybird
+2021-09-07 19:23:25 DEBUG     pycloudlib.instance:instance.py:394 starting beloved-ladybird
+2021-09-07 19:24:15 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:24:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:24:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:24:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:24:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:24:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:24:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:24:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:24:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:24:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:24:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=beloved-ladybird)
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=beloved-ladybird)
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:24:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:24:31 DEBUG     pycloudlib.instance:instance.py:200 deleting beloved-ladybird
+
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:24:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-07 19:24:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-07 19:24:32 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: chrony\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-07 19:24:32 DEBUG     pycloudlib.cloud:cloud.py:275 Created fancy-maggot
+2021-09-07 19:24:32 DEBUG     pycloudlib.instance:instance.py:394 starting fancy-maggot
+2021-09-07 19:25:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:25:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:25:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:25:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:25:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:25:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:25:26 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:25:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:25:26 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fancy-maggot)
+2021-09-07 19:25:36 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fancy-maggot)
+2021-09-07 19:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:25:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:25:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:25:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:25:36 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-07 19:25:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-07 19:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+2021-09-07 19:25:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:25:36 DEBUG     pycloudlib.instance:instance.py:200 deleting fancy-maggot
+
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:25:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-07 19:25:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-07 19:25:37 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: systemd-timesyncd\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-07 19:25:37 DEBUG     pycloudlib.cloud:cloud.py:275 Created sensible-skunk
+2021-09-07 19:25:37 DEBUG     pycloudlib.instance:instance.py:394 starting sensible-skunk
+2021-09-07 19:26:25 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:26:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:26:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:26:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:26:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:26:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:26:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:26:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:26:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:26:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:26:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:26:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sensible-skunk)
+2021-09-07 19:26:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sensible-skunk)
+2021-09-07 19:26:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:26:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:26:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:26:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:26:32 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+2021-09-07 19:26:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:26:32 DEBUG     pycloudlib.instance:instance.py:200 deleting sensible-skunk
+
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:26:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-07 19:26:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-07 19:26:32 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  pools: []\n  servers: []\n', '--vm']
+2021-09-07 19:26:33 DEBUG     pycloudlib.cloud:cloud.py:275 Created curious-anchovy
+2021-09-07 19:26:33 DEBUG     pycloudlib.instance:instance.py:394 starting curious-anchovy
+2021-09-07 19:27:21 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:27:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:27:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:27:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:27:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:27:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:27:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:27:25 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:27:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:27:25 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=curious-anchovy)
+2021-09-07 19:27:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=curious-anchovy)
+2021-09-07 19:27:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:27:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:27:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:27:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:27:36 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 19:27:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 19:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-07 19:27:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-07 19:27:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+2021-09-07 19:27:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:27:36 DEBUG     pycloudlib.instance:instance.py:200 deleting curious-anchovy
+
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:27:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-07 19:27:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-07 19:27:36 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n  - sl\n  - tree\npackage_update: true\npackage_upgrade: true\n', '--vm']
+2021-09-07 19:27:37 DEBUG     pycloudlib.cloud:cloud.py:275 Created bursting-panda
+2021-09-07 19:27:37 DEBUG     pycloudlib.instance:instance.py:394 starting bursting-panda
+2021-09-07 19:28:25 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:28:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:28:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:28:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:28:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:28:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:28:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:28:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:28:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:28:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:28:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:28:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=bursting-panda)
+2021-09-07 19:29:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=bursting-panda)
+2021-09-07 19:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:29:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:29:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:29:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:29:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:29:21 DEBUG     pycloudlib.instance:instance.py:200 deleting bursting-panda
+
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:29:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-07 19:29:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-07 19:29:23 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nrandom_seed:\n  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'\n  encoding: raw\n  file: /root/seed\n", '--vm']
+2021-09-07 19:29:23 DEBUG     pycloudlib.cloud:cloud.py:275 Created composed-spider
+2021-09-07 19:29:23 DEBUG     pycloudlib.instance:instance.py:394 starting composed-spider
+2021-09-07 19:30:14 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:30:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:30:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:30:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:30:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:30:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:30:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:30:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:30:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:30:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=composed-spider)
+2021-09-07 19:30:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=composed-spider)
+2021-09-07 19:30:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:30:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:30:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:30:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:30:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:30:20 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:30:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+2021-09-07 19:30:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:30:20 DEBUG     pycloudlib.instance:instance.py:200 deleting composed-spider
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:30:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-07 19:30:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-07 19:30:21 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nhostname: cloudinit2\n', '--vm']
+2021-09-07 19:30:21 DEBUG     pycloudlib.cloud:cloud.py:275 Created emerging-lionfish
+2021-09-07 19:30:21 DEBUG     pycloudlib.instance:instance.py:394 starting emerging-lionfish
+2021-09-07 19:31:09 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:31:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:31:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:31:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:31:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:31:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:31:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:31:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:31:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:31:13 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:31:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:31:13 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=emerging-lionfish)
+2021-09-07 19:31:15 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=emerging-lionfish)
+2021-09-07 19:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:31:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:31:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:31:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:31:15 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 19:31:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:31:15 DEBUG     pycloudlib.instance:instance.py:200 deleting emerging-lionfish
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:31:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-07 19:31:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-07 19:31:16 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: True\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-07 19:31:16 DEBUG     pycloudlib.cloud:cloud.py:275 Created famous-glider
+2021-09-07 19:31:16 DEBUG     pycloudlib.instance:instance.py:394 starting famous-glider
+2021-09-07 19:32:05 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:32:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:32:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:32:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:32:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:32:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:32:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:32:09 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:32:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:32:09 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=famous-glider)
+2021-09-07 19:32:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=famous-glider)
+2021-09-07 19:32:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:32:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:32:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:32:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:32:11 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 19:32:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:32:11 DEBUG     pycloudlib.instance:instance.py:200 deleting famous-glider
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:32:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-07 19:32:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-07 19:32:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: False\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-07 19:32:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created witty-ghoul
+2021-09-07 19:32:12 DEBUG     pycloudlib.instance:instance.py:394 starting witty-ghoul
+2021-09-07 19:33:00 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:33:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:33:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:33:05 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:33:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:33:05 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=witty-ghoul)
+2021-09-07 19:33:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=witty-ghoul)
+2021-09-07 19:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:33:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:33:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:33:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:33:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:33:07 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:33:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 19:33:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:33:07 DEBUG     pycloudlib.instance:instance.py:200 deleting witty-ghoul
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:33:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-07 19:33:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-07 19:33:07 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nmanage_etc_hosts: true\nhostname: cloudinit1\nfqdn: cloudinit2.i9n.cloud-init.io\n', '--vm']
+2021-09-07 19:33:08 DEBUG     pycloudlib.cloud:cloud.py:275 Created tender-primate
+2021-09-07 19:33:08 DEBUG     pycloudlib.instance:instance.py:394 starting tender-primate
+2021-09-07 19:33:56 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:33:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:33:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:33:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:34:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:34:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:34:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=tender-primate)
+2021-09-07 19:34:01 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=tender-primate)
+2021-09-07 19:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:34:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:34:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:34:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:34:02 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 19:34:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 19:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-07 19:34:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-07 19:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+2021-09-07 19:34:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:34:02 DEBUG     pycloudlib.instance:instance.py:200 deleting tender-primate
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-07 19:34:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-07 19:34:03 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n  list:\n    - tom:mypassword123!\n    - dick:RANDOM\n    - harry:RANDOM\n    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-07 19:34:03 DEBUG     pycloudlib.cloud:cloud.py:275 Created wondrous-cub
+2021-09-07 19:34:03 DEBUG     pycloudlib.instance:instance.py:394 starting wondrous-cub
+2021-09-07 19:34:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:34:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:34:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:34:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:34:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:34:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:34:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:34:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:34:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:34:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:34:56 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:34:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:34:56 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=wondrous-cub)
+2021-09-07 19:34:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wondrous-cub)
+2021-09-07 19:34:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:34:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 getting console log for wondrous-cub
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:34:58 DEBUG     pycloudlib.instance:instance.py:200 deleting wondrous-cub
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:34:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-07 19:34:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-07 19:34:59 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n    list: |\n      tom:mypassword123!\n      dick:RANDOM\n      harry:RANDOM\n      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-07 19:34:59 DEBUG     pycloudlib.cloud:cloud.py:275 Created more-gopher
+2021-09-07 19:34:59 DEBUG     pycloudlib.instance:instance.py:394 starting more-gopher
+2021-09-07 19:35:48 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:35:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:35:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:35:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:35:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:35:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:35:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:35:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:35:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:35:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=more-gopher)
+2021-09-07 19:35:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=more-gopher)
+2021-09-07 19:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:35:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:35:55 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 getting console log for more-gopher
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:35:56 DEBUG     pycloudlib.instance:instance.py:200 deleting more-gopher
+
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:35:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-07 19:35:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-07 19:35:57 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackage_update: true\nsnap:\n  squashfuse_in_container: true\n  commands:\n    - snap install hello-world\n', '--vm']
+2021-09-07 19:35:57 DEBUG     pycloudlib.cloud:cloud.py:275 Created knowing-orca
+2021-09-07 19:35:57 DEBUG     pycloudlib.instance:instance.py:394 starting knowing-orca
+2021-09-07 19:36:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:36:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:36:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:36:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:36:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:36:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:36:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:36:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:36:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:36:49 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:36:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:36:49 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=knowing-orca)
+2021-09-07 19:37:12 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=knowing-orca)
+2021-09-07 19:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:37:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:37:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:37:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:37:12 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:37:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+2021-09-07 19:37:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'snap list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:37:13 DEBUG     pycloudlib.instance:instance.py:200 deleting knowing-orca
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:37:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-07 19:37:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-07 19:37:14 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nno_ssh_fingerprints: true\n', '--vm']
+2021-09-07 19:37:14 DEBUG     pycloudlib.cloud:cloud.py:275 Created ace-cobra
+2021-09-07 19:37:14 DEBUG     pycloudlib.instance:instance.py:394 starting ace-cobra
+2021-09-07 19:38:02 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:38:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:38:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:38:06 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:38:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:38:06 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=ace-cobra)
+2021-09-07 19:38:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ace-cobra)
+2021-09-07 19:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:38:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:38:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:38:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:38:07 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:38:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:38:07 DEBUG     pycloudlib.instance:instance.py:200 deleting ace-cobra
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:38:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-07 19:38:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-07 19:38:08 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\n', '--vm']
+2021-09-07 19:38:08 DEBUG     pycloudlib.cloud:cloud.py:275 Created set-polliwog
+2021-09-07 19:38:08 DEBUG     pycloudlib.instance:instance.py:394 starting set-polliwog
+2021-09-07 19:38:56 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:38:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:38:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:38:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:39:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:39:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:39:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=set-polliwog)
+2021-09-07 19:39:02 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=set-polliwog)
+2021-09-07 19:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:39:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:39:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:39:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:39:02 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 19:39:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:39:02 DEBUG     pycloudlib.instance:instance.py:200 deleting set-polliwog
+
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-07 19:39:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-07 19:39:03 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nauthkey_hash: sha512\n', '--vm']
+2021-09-07 19:39:03 DEBUG     pycloudlib.cloud:cloud.py:275 Created better-mustang
+2021-09-07 19:39:03 DEBUG     pycloudlib.instance:instance.py:394 starting better-mustang
+2021-09-07 19:39:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:39:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:39:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:39:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:39:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:39:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:39:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:39:55 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:39:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:39:55 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=better-mustang)
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=better-mustang)
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:39:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-07 19:39:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:39:57 DEBUG     pycloudlib.instance:instance.py:200 deleting better-mustang
+
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:39:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-07 19:39:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-07 19:39:57 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_import_id:\n  - gh:powersj\n  - lp:smoser\n', '--vm']
+2021-09-07 19:39:57 DEBUG     pycloudlib.cloud:cloud.py:275 Created dominant-cheetah
+2021-09-07 19:39:57 DEBUG     pycloudlib.instance:instance.py:394 starting dominant-cheetah
+2021-09-07 19:40:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:40:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:40:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:40:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:40:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:40:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:40:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:40:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:40:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:40:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:40:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=dominant-cheetah)
+2021-09-07 19:40:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=dominant-cheetah)
+2021-09-07 19:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:40:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:40:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:40:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:40:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 19:40:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:40:52 DEBUG     pycloudlib.instance:instance.py:200 deleting dominant-cheetah
+
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:40:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-07 19:40:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-07 19:40:53 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisable_root: false\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\nssh_keys:\n  rsa_private: |\n    -----BEGIN RSA PRIVATE KEY-----\n    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj\n    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9\n    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y\n    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu\n    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c\n    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5\n    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw\n    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm\n    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl\n    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA\n    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ\n    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu\n    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP\n    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN\n    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW\n    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N\n    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr\n    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN\n    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO\n    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR\n    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A\n    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW\n    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2\n    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+\n    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE\n    -----END RSA PRIVATE KEY-----\n  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd\n  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd\n  dsa_private: |\n    -----BEGIN DSA PRIVATE KEY-----\n    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP\n    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d\n    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i\n    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE\n    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI\n    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED\n    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf\n    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E\n    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW\n    nCPOXEQsayANi8+Cb7BH\n    -----END DSA PRIVATE KEY-----\n  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd\n  ed25519_private: |\n    -----BEGIN OPENSSH PRIVATE KEY-----\n    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp\n    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q\n    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg\n    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==\n    -----END OPENSSH PRIVATE KEY-----\n  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd\n  ecdsa_private: |\n    -----BEGIN EC PRIVATE KEY-----\n    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49\n    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb\n    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==\n    -----END EC PRIVATE KEY-----\n  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd\n', '--vm']
+2021-09-07 19:40:53 DEBUG     pycloudlib.cloud:cloud.py:275 Created adequate-silkworm
+2021-09-07 19:40:53 DEBUG     pycloudlib.instance:instance.py:394 starting adequate-silkworm
+2021-09-07 19:41:42 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:41:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:41:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:41:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:41:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:41:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:41:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:41:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:41:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:41:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=adequate-silkworm)
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=adequate-silkworm)
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+2021-09-07 19:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:41:48 DEBUG     pycloudlib.instance:instance.py:200 deleting adequate-silkworm
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:41:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:41:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n - ""\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n', '--vm']
+2021-09-07 19:41:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created fancy-monitor
+2021-09-07 19:41:49 DEBUG     pycloudlib.instance:instance.py:394 starting fancy-monitor
+2021-09-07 19:42:37 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:42:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:42:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:42:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:42:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:42:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:42:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:42:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:42:42 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:42:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:42:42 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fancy-monitor)
+2021-09-07 19:42:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fancy-monitor)
+2021-09-07 19:42:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:42:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:42:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:42:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:42:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:42:43 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:42:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-07 19:42:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-07 19:42:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 19:42:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 19:42:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 19:42:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-07 19:42:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 19:42:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 19:42:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:42:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:42:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:42:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-07 19:42:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-07 19:42:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 19:42:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 19:42:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:42:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:42:50 DEBUG     pycloudlib.instance:instance.py:200 deleting fancy-monitor
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:42:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:42:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:42:51 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 19:42:51 DEBUG     pycloudlib.cloud:cloud.py:275 Created definite-monarch
+2021-09-07 19:42:51 DEBUG     pycloudlib.instance:instance.py:394 starting definite-monarch
+2021-09-07 19:43:40 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:43:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:43:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:43:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:43:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:43:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:43:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:43:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:43:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:43:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:43:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=definite-monarch)
+2021-09-07 19:43:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=definite-monarch)
+2021-09-07 19:43:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:43:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:43:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:43:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:43:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:43:47 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:43:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 19:43:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 19:43:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:43:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:43:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 19:43:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 19:43:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 19:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 19:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:43:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:43:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:43:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:43:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 19:43:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 19:43:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 19:43:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 19:43:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:43:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-07 19:43:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-07 19:43:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 19:43:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 19:43:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:43:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:43:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:43:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 19:43:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:43:54 DEBUG     pycloudlib.instance:instance.py:200 deleting definite-monarch
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:43:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:43:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:43:54 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 19:43:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created integral-monkfish
+2021-09-07 19:43:55 DEBUG     pycloudlib.instance:instance.py:394 starting integral-monkfish
+2021-09-07 19:44:43 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:44:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:44:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:44:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:44:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:44:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:44:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:44:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:44:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:44:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=integral-monkfish)
+2021-09-07 19:44:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=integral-monkfish)
+2021-09-07 19:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:44:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:44:50 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 19:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 19:44:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 19:44:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 19:44:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 19:44:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:44:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:44:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 19:44:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 19:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:44:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:44:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:44:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 19:44:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 19:44:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 19:44:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 19:44:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-07 19:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-07 19:44:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 19:44:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 19:44:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:44:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:44:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:44:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 19:44:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:44:57 DEBUG     pycloudlib.instance:instance.py:200 deleting integral-monkfish
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:44:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:44:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-07 19:44:57 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 19:44:57 DEBUG     pycloudlib.cloud:cloud.py:275 Created proud-ghost
+2021-09-07 19:44:58 DEBUG     pycloudlib.instance:instance.py:394 starting proud-ghost
+2021-09-07 19:45:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:45:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:45:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:45:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:45:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:45:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:45:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:45:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:45:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:45:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=proud-ghost)
+2021-09-07 19:45:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=proud-ghost)
+2021-09-07 19:45:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:45:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:45:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:45:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 19:45:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 19:45:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 19:45:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 19:45:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 19:45:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 19:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 19:45:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 19:45:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 19:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 19:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 19:45:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 19:45:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 19:45:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 19:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-07 19:45:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:45:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 19:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:45:58 DEBUG     pycloudlib.instance:instance.py:200 deleting proud-ghost
+
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:45:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-07 19:45:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-07 19:45:59 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ntimezone: US/Aleutian\n', '--vm']
+2021-09-07 19:45:59 DEBUG     pycloudlib.cloud:cloud.py:275 Created curious-hamster
+2021-09-07 19:45:59 DEBUG     pycloudlib.instance:instance.py:394 starting curious-hamster
+2021-09-07 19:46:47 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:46:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:46:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:46:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:46:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:46:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:46:51 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:46:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:46:51 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=curious-hamster)
+2021-09-07 19:46:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=curious-hamster)
+2021-09-07 19:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:46:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:46:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:46:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:46:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+2021-09-07 19:46:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:46:52 DEBUG     pycloudlib.instance:instance.py:200 deleting curious-hamster
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:46:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:46:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:46:53 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:46:53 DEBUG     pycloudlib.cloud:cloud.py:275 Created square-skylark
+2021-09-07 19:46:53 DEBUG     pycloudlib.instance:instance.py:394 starting square-skylark
+2021-09-07 19:47:41 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:47:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:47:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:47:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:47:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:47:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:47:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:47:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:47:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=square-skylark)
+2021-09-07 19:47:45 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=square-skylark)
+2021-09-07 19:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:47:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:47:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:47:46 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmp2l51qou3 to /var/tmp/93cd2cda-b0c3-41b7-bdea-85234b8efa33.tmp
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmp2l51qou3 to /var/tmp/93cd2cda-b0c3-41b7-bdea-85234b8efa33.tmp
+2021-09-07 19:47:46 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/93cd2cda-b0c3-41b7-bdea-85234b8efa33.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/93cd2cda-b0c3-41b7-bdea-85234b8efa33.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 19:47:46 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:47:46 DEBUG     pycloudlib.instance:instance.py:296 restarting square-skylark
+2021-09-07 19:48:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:48:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:49:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:50:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:50:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:50:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:50:15 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:50:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:50:15 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:50:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:50:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:50:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:50:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:50:15 DEBUG     pycloudlib.instance:instance.py:200 deleting square-skylark
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:50:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-07 19:50:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-07 19:50:16 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nupdates:\n  network:\n    when: [boot]\n', '--vm']
+2021-09-07 19:50:16 DEBUG     pycloudlib.cloud:cloud.py:275 Created composed-owl
+2021-09-07 19:50:16 DEBUG     pycloudlib.instance:instance.py:394 starting composed-owl
+2021-09-07 19:51:03 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:51:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:51:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:51:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:51:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:51:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:51:07 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:51:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:51:07 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=composed-owl)
+2021-09-07 19:51:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=composed-owl)
+2021-09-07 19:51:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:51:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:51:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:51:09 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpcqoxrc92 to /var/tmp/eed0473e-09b9-4021-a6bc-b7e75038f04f.tmp
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpcqoxrc92 to /var/tmp/eed0473e-09b9-4021-a6bc-b7e75038f04f.tmp
+2021-09-07 19:51:09 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/eed0473e-09b9-4021-a6bc-b7e75038f04f.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/eed0473e-09b9-4021-a6bc-b7e75038f04f.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 19:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 19:51:09 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:51:09 DEBUG     pycloudlib.instance:instance.py:296 restarting composed-owl
+2021-09-07 19:51:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:51:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:51:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:51:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:51:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:51:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:51:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:51:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:51:39 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:51:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:51:39 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:51:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 19:51:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:51:39 DEBUG     pycloudlib.instance:instance.py:200 deleting composed-owl
+------------------------------ live log logreport ------------------------------
+2021-09-07 19:51:40 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:51:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-07 19:51:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-07 19:51:40 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-07 19:51:40 DEBUG     pycloudlib.cloud:cloud.py:275 Created distinct-teal
+2021-09-07 19:51:40 DEBUG     pycloudlib.instance:instance.py:394 starting distinct-teal
+2021-09-07 19:52:28 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:52:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:52:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:52:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:52:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:52:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:52:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:52:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:52:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:52:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:52:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:52:33 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:52:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:52:33 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=distinct-teal)
+2021-09-07 19:52:34 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=distinct-teal)
+2021-09-07 19:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:52:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:52:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:52:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:52:34 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+2021-09-07 19:52:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+2021-09-07 19:52:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+2021-09-07 19:52:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+2021-09-07 19:52:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+2021-09-07 19:52:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+2021-09-07 19:52:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:52:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+2021-09-07 19:52:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'groups root'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:52:35 DEBUG     pycloudlib.instance:instance.py:200 deleting distinct-teal
+
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-07 19:52:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-07 19:52:35 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-07 19:52:36 DEBUG     pycloudlib.cloud:cloud.py:275 Created clever-goose
+2021-09-07 19:52:36 DEBUG     pycloudlib.instance:instance.py:394 starting clever-goose
+2021-09-07 19:53:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:53:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:53:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:53:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:53:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:53:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:53:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:53:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:53:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:53:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:53:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:53:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:53:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:53:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=clever-goose)
+2021-09-07 19:53:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clever-goose)
+2021-09-07 19:53:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:53:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:53:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:53:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:53:30 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:53:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:53:30 DEBUG     pycloudlib.instance:instance.py:200 deleting clever-goose
+
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:53:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:53:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:53:30 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:53:30 DEBUG     pycloudlib.cloud:cloud.py:275 Created humane-vervet
+2021-09-07 19:53:31 DEBUG     pycloudlib.instance:instance.py:394 starting humane-vervet
+2021-09-07 19:54:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:54:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:54:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:54:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:54:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:54:21 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:54:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:54:21 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=humane-vervet)
+2021-09-07 19:54:23 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humane-vervet)
+2021-09-07 19:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:54:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:54:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:54:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:54:23 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:54:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 19:54:23 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:54:23 DEBUG     pycloudlib.instance:instance.py:296 restarting humane-vervet
+2021-09-07 19:54:49 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:54:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:54:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:54:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:54:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:54:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:54:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:54:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:54:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:54:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:54:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:54:54 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/b983bc25-1759-4539-8d14-b35cf3f6dadc.tmp
+2021-09-07 19:54:54 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/b983bc25-1759-4539-8d14-b35cf3f6dadc.tmp
+2021-09-07 19:54:54 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-07 19:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b983bc25-1759-4539-8d14-b35cf3f6dadc.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 19:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/b983bc25-1759-4539-8d14-b35cf3f6dadc.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-07 19:54:54 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:54:54 DEBUG     pycloudlib.instance:instance.py:296 restarting humane-vervet
+2021-09-07 19:55:20 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:55:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:55:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:55:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:55:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:55:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:55:24 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:55:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:55:24 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:55:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:55:25 DEBUG     pycloudlib.instance:instance.py:200 deleting humane-vervet
+------------------------------ live log logreport ------------------------------
+2021-09-07 19:55:26 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:55:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:55:26 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:55:26 DEBUG     pycloudlib.cloud:cloud.py:275 Created adapted-snapper
+2021-09-07 19:55:26 DEBUG     pycloudlib.instance:instance.py:394 starting adapted-snapper
+2021-09-07 19:56:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:56:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:56:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:56:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:56:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:56:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=adapted-snapper)
+2021-09-07 19:56:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=adapted-snapper)
+2021-09-07 19:56:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:56:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:56:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:56:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/4cc3feb5-a7ad-4dac-b19d-3102406cef0d.tmp
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/4cc3feb5-a7ad-4dac-b19d-3102406cef0d.tmp
+2021-09-07 19:56:19 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 19:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4cc3feb5-a7ad-4dac-b19d-3102406cef0d.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/4cc3feb5-a7ad-4dac-b19d-3102406cef0d.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 19:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-07 19:56:19 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:56:19 DEBUG     pycloudlib.instance:instance.py:296 restarting adapted-snapper
+2021-09-07 19:56:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:56:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:56:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:56:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:56:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:56:49 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:56:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:56:49 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:56:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:56:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:56:50 DEBUG     pycloudlib.instance:instance.py:200 deleting adapted-snapper
+------------------------------ live log logreport ------------------------------
+2021-09-07 19:56:50 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:56:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:56:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=None
+2021-09-07 19:56:51 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 19:56:51 DEBUG     pycloudlib.cloud:cloud.py:275 Created set-cat
+2021-09-07 19:56:51 DEBUG     pycloudlib.instance:instance.py:394 starting set-cat
+2021-09-07 19:57:39 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:57:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:57:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:57:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:57:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:57:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:57:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:57:42 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:57:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:57:42 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=set-cat)
+2021-09-07 19:57:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=set-cat)
+2021-09-07 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:57:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:57:43 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/343f0d76-fe6a-4f7a-82bc-cad4729f6c49.tmp
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/343f0d76-fe6a-4f7a-82bc-cad4729f6c49.tmp
+2021-09-07 19:57:43 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/343f0d76-fe6a-4f7a-82bc-cad4729f6c49.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/343f0d76-fe6a-4f7a-82bc-cad4729f6c49.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-07 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 19:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 19:57:44 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 19:57:44 DEBUG     pycloudlib.instance:instance.py:296 restarting set-cat
+2021-09-07 19:58:11 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:58:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:58:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:58:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:58:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:58:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:58:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:58:13 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:58:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:58:13 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 19:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 19:58:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:58:14 DEBUG     pycloudlib.instance:instance.py:200 deleting set-cat
+------------------------------ live log logreport ------------------------------
+2021-09-07 19:58:15 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:58:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-07 19:58:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:settling-crappie-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-07 19:58:15 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:settling-crappie-snapshot'
+['lxc', 'init', 'local:settling-crappie-snapshot', '--profile', 'pycloudlib-vm-bionic-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nwrite_files:\n-   encoding: b64\n    content: QVNDSUkgdGV4dA==\n    owner: root:root\n    path: /root/file_b64\n    permissions: \'0644\'\n-   content: |\n        # My new /root/file_text\n\n        SMBDOPTIONS="-D"\n    path: /root/file_text\n-   content: !!binary |\n        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK\n    path: /root/file_binary\n    permissions: \'0555\'\n-   encoding: gzip\n    content: !!binary |\n        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=\n    path: /root/file_gzip\n    permissions: \'0755\'\n', '--vm']
+2021-09-07 19:58:15 DEBUG     pycloudlib.cloud:cloud.py:275 Created outgoing-magpie
+2021-09-07 19:58:15 DEBUG     pycloudlib.instance:instance.py:394 starting outgoing-magpie
+2021-09-07 19:59:02 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 19:59:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:59:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:59:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:59:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:59:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 19:59:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 19:59:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-07 19:59:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 19:59:07 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 19:59:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 19:59:07 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=outgoing-magpie)
+2021-09-07 19:59:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=outgoing-magpie)
+2021-09-07 19:59:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 19:59:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:59:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-07 19:59:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 19:59:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 19:59:08 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:59:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+2021-09-07 19:59:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:59:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:59:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+2021-09-07 19:59:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:59:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:59:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+2021-09-07 19:59:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:59:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:59:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+2021-09-07 19:59:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 19:59:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-07 19:59:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+2021-09-07 19:59:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_text'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 19:59:09 DEBUG     pycloudlib.instance:instance.py:200 deleting outgoing-magpie
+Deleting snapshot image created for this testrun: local:settling-crappie-snapshot
+2021-09-07 19:59:09 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:settling-crappie-snapshot
+2021-09-07 19:59:09 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:settling-crappie-snapshot'
+2021-09-07 19:59:09 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:settling-crappie-snapshot
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 127 passed, 22 skipped, 2 warnings in 4471.02s (1:14:31) ===========

--- a/21.3-1/integration_tests/lxd_vm_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_vm_focal_integration_tests.txt
@@ -1,0 +1,5715 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:35:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:35:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:35:16 DEBUG     pycloudlib.cloud:cloud.py:338 finding released Ubuntu image for focal
+2021-09-07 21:35:16 DEBUG     pycloudlib.streams:streams.py:46 looking for image with the following config:
+2021-09-07 21:35:16 DEBUG     pycloudlib.streams:streams.py:47 {'filters': [datatype = image-downloads [none=], ftype = lxd.tar.xz [none=], arch = amd64 [none=], release = focal [none=]]}
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-07 21:35:22 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for lxd_vm
+2021-09-07 21:35:22 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_vm
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+2021-09-07 21:35:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+2021-09-07 21:35:23 DEBUG     pycloudlib.cloud:cloud.py:64 The profile named pycloudlib-vm-focal-v3 already exists
+The profile named pycloudlib-vm-focal-v3 already exists
+2021-09-07 21:35:24 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce'
+['lxc', 'init', 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:35:25 DEBUG     pycloudlib.cloud:cloud.py:275 Created big-mouse
+2021-09-07 21:35:25 DEBUG     pycloudlib.instance:instance.py:394 starting big-mouse
+2021-09-07 21:35:49 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:35:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:35:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:35:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:35:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:35:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:35:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:35:58 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:35:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:35:58 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=big-mouse)
+2021-09-07 21:36:02 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=big-mouse)
+2021-09-07 21:36:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:36:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:36:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:36:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:36:03 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-07 21:36:03 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-07 21:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:36:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:36:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:36:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:36:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-07 21:36:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:36:20 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:36:21 DEBUG     pycloudlib.instance:instance.py:331 shutting down big-mouse
+2021-09-07 21:36:23 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: big-mouse
+2021-09-07 21:36:23 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot big-mouse-snapshot
+Created new image: local:big-mouse-snapshot
+2021-09-07 21:37:57 INFO      integration_testing:instances.py:114 Created new image: local:big-mouse-snapshot
+2021-09-07 21:37:57 DEBUG     pycloudlib.instance:instance.py:200 deleting big-mouse
+Done with environment setup
+2021-09-07 21:37:58 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:37:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:37:58 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:39:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created saving-krill
+2021-09-07 21:39:21 DEBUG     pycloudlib.instance:instance.py:394 starting saving-krill
+2021-09-07 21:39:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:39:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:39:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:39:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:39:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:39:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:39:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:39:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:39:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=saving-krill)
+2021-09-07 21:39:54 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=saving-krill)
+2021-09-07 21:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:39:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:39:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:39:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:39:55 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-07 21:39:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-07 21:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+2021-09-07 21:39:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:39:55 DEBUG     pycloudlib.instance:instance.py:200 deleting saving-krill
+
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:39:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:39:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+2021-09-07 21:39:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+2021-09-07 21:39:56 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce'
+['lxc', 'init', 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nhostname: SRU-worked\n', '--vm']
+2021-09-07 21:39:57 DEBUG     pycloudlib.cloud:cloud.py:275 Created equipped-doe
+2021-09-07 21:39:57 DEBUG     pycloudlib.instance:instance.py:394 starting equipped-doe
+2021-09-07 21:40:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:40:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:40:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:40:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:40:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:40:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:40:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:40:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:40:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:40:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:40:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:40:30 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:40:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:40:30 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=equipped-doe)
+2021-09-07 21:40:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=equipped-doe)
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:40:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:40:35 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c cloud-id
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c systemd-analyze
+2021-09-07 21:40:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-07 21:40:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-07 21:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-07 21:40:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-07 21:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-07 21:40:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-07 21:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:40:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-07 21:40:36 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-07 21:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:40:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:40:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:40:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:40:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-07 21:40:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:40:53 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:40:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:40:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:40:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+2021-09-07 21:40:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-07 21:40:54 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:40:54 DEBUG     pycloudlib.instance:instance.py:296 restarting equipped-doe
+2021-09-07 21:41:07 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:41:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:41:11 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:41:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:41:11 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 21:41:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 21:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-07 21:41:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init init'
+2021-09-07 21:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 21:41:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 21:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-07 21:41:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c cloud-id
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c systemd-analyze
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-07 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-07 21:41:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-07 21:41:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:41:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 2.134s (kernel) + 14.261s (userspace) = 16.395s 
+graphical.target reached after 13.316s in userspace
+=== `systemd-analyze` after:
+Startup finished in 462ms (kernel) + 8.133s (userspace) = 8.596s 
+graphical.target reached after 7.311s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.155s snapd.seeded.service                          
+1.616s systemd-networkd-wait-online.service          
+1.523s snapd.service                                 
+1.515s cloud-init.service                            
+1.478s cloud-init-local.service                      
+1.418s snapd.apparmor.service                        
+1.293s pollinate.service                             
+1.146s e2scrub_reap.service                          
+ 789ms networkd-dispatcher.service                   
+ 776ms snap.lxd.activate.service                     
+=== `systemd-analyze blame` after (first 10 lines):
+3.181s snap.lxd.activate.service                     
+2.528s snapd.service                                 
+1.115s systemd-networkd-wait-online.service          
+ 978ms cloud-init-local.service                      
+ 851ms cloud-config.service                          
+ 751ms cloud-init.service                            
+ 687ms networkd-dispatcher.service                   
+ 655ms systemd-udev-settle.service                   
+ 591ms lvm2-monitor.service                          
+ 533ms dev-sda1.device                               
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.58800 seconds
+Finished stage: (init-network) 01.17400 seconds
+Finished stage: (modules-config) 00.25400 seconds
+Finished stage: (modules-final) 00.06700 seconds
+Total Time: 2.08300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.31200 seconds
+Finished stage: (init-network) 00.42200 seconds
+Finished stage: (modules-config) 00.24900 seconds
+Finished stage: (modules-final) 00.06400 seconds
+Total Time: 1.04700 seconds
+Finished stage: (init-network) 00.13900 seconds
+Total Time: 0.13900 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.39200s (init-network/config-growpart)
+     00.27200s (init-network/config-users-groups)
+     00.19800s (init-network/config-ssh)
+     00.17100s (modules-config/config-grub-dpkg)
+     00.12400s (init-network/config-resizefs)
+     00.07100s (init-local/search-NoCloud)
+     00.04300s (modules-config/config-apt-configure)
+     00.02800s (modules-final/config-keys-to-console)
+     00.01800s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.20000s (init-network/config-ssh)
+     00.16300s (modules-config/config-grub-dpkg)
+     00.04600s (modules-config/config-apt-configure)
+     00.04600s (init-local/search-NoCloud)
+     00.04400s (init-network/config-resizefs)
+     00.04200s (init-network/config-users-groups)
+     00.03000s (modules-final/config-keys-to-console)
+     00.03000s (init-network/config-growpart)
+     00.02000s (modules-config/config-locale)
+
+2021-09-07 21:41:16 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 2.134s (kernel) + 14.261s (userspace) = 16.395s 
+graphical.target reached after 13.316s in userspace
+=== `systemd-analyze` after:
+Startup finished in 462ms (kernel) + 8.133s (userspace) = 8.596s 
+graphical.target reached after 7.311s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+6.155s snapd.seeded.service                          
+1.616s systemd-networkd-wait-online.service          
+1.523s snapd.service                                 
+1.515s cloud-init.service                            
+1.478s cloud-init-local.service                      
+1.418s snapd.apparmor.service                        
+1.293s pollinate.service                             
+1.146s e2scrub_reap.service                          
+ 789ms networkd-dispatcher.service                   
+ 776ms snap.lxd.activate.service                     
+=== `systemd-analyze blame` after (first 10 lines):
+3.181s snap.lxd.activate.service                     
+2.528s snapd.service                                 
+1.115s systemd-networkd-wait-online.service          
+ 978ms cloud-init-local.service                      
+ 851ms cloud-config.service                          
+ 751ms cloud-init.service                            
+ 687ms networkd-dispatcher.service                   
+ 655ms systemd-udev-settle.service                   
+ 591ms lvm2-monitor.service                          
+ 533ms dev-sda1.device                               
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.58800 seconds
+Finished stage: (init-network) 01.17400 seconds
+Finished stage: (modules-config) 00.25400 seconds
+Finished stage: (modules-final) 00.06700 seconds
+Total Time: 2.08300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.31200 seconds
+Finished stage: (init-network) 00.42200 seconds
+Finished stage: (modules-config) 00.24900 seconds
+Finished stage: (modules-final) 00.06400 seconds
+Total Time: 1.04700 seconds
+Finished stage: (init-network) 00.13900 seconds
+Total Time: 0.13900 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.39200s (init-network/config-growpart)
+     00.27200s (init-network/config-users-groups)
+     00.19800s (init-network/config-ssh)
+     00.17100s (modules-config/config-grub-dpkg)
+     00.12400s (init-network/config-resizefs)
+     00.07100s (init-local/search-NoCloud)
+     00.04300s (modules-config/config-apt-configure)
+     00.02800s (modules-final/config-keys-to-console)
+     00.01800s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.20000s (init-network/config-ssh)
+     00.16300s (modules-config/config-grub-dpkg)
+     00.04600s (modules-config/config-apt-configure)
+     00.04600s (init-local/search-NoCloud)
+     00.04400s (init-network/config-resizefs)
+     00.04200s (init-network/config-users-groups)
+     00.03000s (modules-final/config-keys-to-console)
+     00.03000s (init-network/config-growpart)
+     00.02000s (modules-config/config-locale)
+
+2021-09-07 21:41:16 DEBUG     pycloudlib.instance:instance.py:200 deleting equipped-doe
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:41:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:41:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce
+2021-09-07 21:41:17 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce'
+['lxc', 'init', 'ubuntu:82b1aff50a20f04f7974c942c9d6a23e46111fd3fe4833d91433e6c45851e4ce', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:41:18 DEBUG     pycloudlib.cloud:cloud.py:275 Created valued-monster
+2021-09-07 21:41:18 DEBUG     pycloudlib.instance:instance.py:394 starting valued-monster
+2021-09-07 21:41:43 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:41:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:41:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:41:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:41:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:41:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:41:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=valued-monster)
+2021-09-07 21:41:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=valued-monster)
+2021-09-07 21:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:41:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-07 21:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:41:57 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-07 21:41:57 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-07 21:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-07 21:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-07 21:42:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:42:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-07 21:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-07 21:42:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:42:17 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-07 21:42:17 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:42:17 DEBUG     pycloudlib.instance:instance.py:296 restarting valued-monster
+2021-09-07 21:42:31 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:42:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:42:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:42:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:42:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:42:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:42:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:42:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:42:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:42:36 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:42:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:42:36 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 21:42:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-07 21:42:38 DEBUG     pycloudlib.instance:instance.py:200 deleting valued-monster
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:42:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:42:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:42:39 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:42:39 DEBUG     pycloudlib.cloud:cloud.py:275 Created stunning-pegasus
+2021-09-07 21:42:39 DEBUG     pycloudlib.instance:instance.py:394 starting stunning-pegasus
+2021-09-07 21:43:03 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:43:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:43:10 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:43:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:43:10 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=stunning-pegasus)
+2021-09-07 21:43:11 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=stunning-pegasus)
+2021-09-07 21:43:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:43:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:43:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:43:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:43:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:43:11 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:43:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-07 21:43:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-07 21:43:12 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpobm91nl3 to /var/tmp/32cff126-a78e-407e-b975-6ade38e41b86.tmp
+2021-09-07 21:43:12 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpobm91nl3 to /var/tmp/32cff126-a78e-407e-b975-6ade38e41b86.tmp
+2021-09-07 21:43:12 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-07 21:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/32cff126-a78e-407e-b975-6ade38e41b86.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-07 21:43:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/32cff126-a78e-407e-b975-6ade38e41b86.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-07 21:43:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 21:43:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 21:43:12 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:43:12 DEBUG     pycloudlib.instance:instance.py:296 restarting stunning-pegasus
+2021-09-07 21:43:25 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:43:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:43:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:43:30 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:43:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:43:30 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:43:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 21:43:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 21:43:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /var/tmp'
+2021-09-07 21:43:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:43:32 DEBUG     pycloudlib.instance:instance.py:200 deleting stunning-pegasus
+------------------------------ live log logreport ------------------------------
+2021-09-07 21:43:33 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:43:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:42:22:22\n', 'volatile.eth0.hwaddr': '02:00:00:42:22:22'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:43:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:42:22:22\n', 'volatile.eth0.hwaddr': '02:00:00:42:22:22'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:43:33 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:42:22:22\n', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:42:22:22', '--vm']
+2021-09-07 21:43:33 DEBUG     pycloudlib.cloud:cloud.py:275 Created lasting-shepherd
+2021-09-07 21:43:33 DEBUG     pycloudlib.instance:instance.py:394 starting lasting-shepherd
+2021-09-07 21:43:57 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:43:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:43:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:44:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:44:01 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:44:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:44:01 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=lasting-shepherd)
+2021-09-07 21:44:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=lasting-shepherd)
+2021-09-07 21:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:44:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:44:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:44:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:44:03 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:44:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 21:44:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:44:03 DEBUG     pycloudlib.instance:instance.py:200 deleting lasting-shepherd
+
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:44:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:44:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:44:04 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:44:04 DEBUG     pycloudlib.cloud:cloud.py:275 Created definite-shrew
+2021-09-07 21:44:04 DEBUG     pycloudlib.instance:instance.py:394 starting definite-shrew
+2021-09-07 21:44:29 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:44:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:44:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:44:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:44:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:44:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:44:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:44:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:44:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:44:33 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:44:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:44:33 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=definite-shrew)
+2021-09-07 21:44:35 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=definite-shrew)
+2021-09-07 21:44:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:44:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:44:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:44:36 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmp8hszmz3a to /var/tmp/5e23dfb7-64cd-459e-a64a-6223ff26560e.tmp
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmp8hszmz3a to /var/tmp/5e23dfb7-64cd-459e-a64a-6223ff26560e.tmp
+2021-09-07 21:44:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 21:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/5e23dfb7-64cd-459e-a64a-6223ff26560e.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/5e23dfb7-64cd-459e-a64a-6223ff26560e.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpm6ybklnx to /var/tmp/b78c5519-9666-41e4-bbe6-e1f07f70abcd.tmp
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpm6ybklnx to /var/tmp/b78c5519-9666-41e4-bbe6-e1f07f70abcd.tmp
+2021-09-07 21:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b78c5519-9666-41e4-bbe6-e1f07f70abcd.tmp /etc/cloud/ds-identify.cfg'
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/b78c5519-9666-41e4-bbe6-e1f07f70abcd.tmp /etc/cloud/ds-identify.cfg'
+2021-09-07 21:44:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 21:44:36 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:44:36 DEBUG     pycloudlib.instance:instance.py:296 restarting definite-shrew
+2021-09-07 21:44:49 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:44:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:44:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:44:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:44:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:44:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:44:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:44:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:44:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:44:55 DEBUG     pycloudlib.instance:instance.py:200 deleting definite-shrew
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:44:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:44:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+execute_via_ssh=False
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:d4:21:dc\n', 'volatile.eth0.hwaddr': '02:00:00:d4:21:dc'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:44:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+execute_via_ssh=False
+config_dict={'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:d4:21:dc\n', 'volatile.eth0.hwaddr': '02:00:00:d4:21:dc'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:44:56 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:d4:21:dc\n', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:d4:21:dc', '--vm']
+2021-09-07 21:44:56 DEBUG     pycloudlib.cloud:cloud.py:275 Created natural-tadpole
+2021-09-07 21:44:56 DEBUG     pycloudlib.instance:instance.py:394 starting natural-tadpole
+2021-09-07 21:45:20 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:45:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:45:20 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:45:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:45:20 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=natural-tadpole)
+2021-09-07 21:45:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=natural-tadpole)
+2021-09-07 21:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:45:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:45:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:45:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:45:26 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+2021-09-07 21:45:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:45:27 DEBUG     pycloudlib.instance:instance.py:200 deleting natural-tadpole
+
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:45:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:45:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:45:28 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-07 21:45:28 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nchef:\n  install_type: omnibus\n  chef_license: accept\n  server_url: https://chef.yourorg.invalid\n  validation_name: some-validator\n', '--vm']
+2021-09-07 21:45:28 DEBUG     pycloudlib.cloud:cloud.py:275 Created useful-condor
+2021-09-07 21:45:28 DEBUG     pycloudlib.instance:instance.py:394 starting useful-condor
+2021-09-07 21:45:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:45:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:45:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:45:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:45:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:45:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:45:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:45:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:45:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:45:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:45:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=useful-condor)
+2021-09-07 21:46:05 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=useful-condor)
+2021-09-07 21:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:46:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:46:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:46:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:46:05 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:46:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:46:05 DEBUG     pycloudlib.instance:instance.py:200 deleting useful-condor
+
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:46:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:46:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:46:06 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  sources:\n    cloudinit:\n      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'\n      keyserver: keyserver.ubuntu.com\n      keyid: E4D304DF\n", '--vm']
+2021-09-07 21:46:06 DEBUG     pycloudlib.cloud:cloud.py:275 Created grateful-eft
+2021-09-07 21:46:06 DEBUG     pycloudlib.instance:instance.py:394 starting grateful-eft
+2021-09-07 21:46:30 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:46:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:46:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:46:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:46:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:46:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:46:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:46:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:46:36 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:46:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:46:36 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=grateful-eft)
+2021-09-07 21:46:45 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=grateful-eft)
+2021-09-07 21:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:46:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:46:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:46:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:46:45 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:46:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:46:45 DEBUG     pycloudlib.instance:instance.py:200 deleting grateful-eft
+
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:46:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:46:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:46:47 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n- rm -f /etc/fstab\n', '--vm']
+2021-09-07 21:46:47 DEBUG     pycloudlib.cloud:cloud.py:275 Created famous-longhorn
+2021-09-07 21:46:47 DEBUG     pycloudlib.instance:instance.py:394 starting famous-longhorn
+2021-09-07 21:47:11 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:47:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:47:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:47:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:47:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=famous-longhorn)
+2021-09-07 21:47:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=famous-longhorn)
+2021-09-07 21:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:47:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:47:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:47:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:47:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:47:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:47:21 DEBUG     pycloudlib.instance:instance.py:200 deleting famous-longhorn
+
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:47:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:47:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:47:22 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n  - echo 'whoops' > /usr/bin/fallocate\nswap:\n  filename: /swap.img\n  size: 10000000\n  maxsize: 10000000\n", '--vm']
+2021-09-07 21:47:22 DEBUG     pycloudlib.cloud:cloud.py:275 Created fleet-mullet
+2021-09-07 21:47:22 DEBUG     pycloudlib.instance:instance.py:394 starting fleet-mullet
+2021-09-07 21:47:37 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:47:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:47:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:47:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:47:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:47:55 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:47:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:47:55 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fleet-mullet)
+2021-09-07 21:47:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fleet-mullet)
+2021-09-07 21:47:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:47:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:47:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:47:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:47:58 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:47:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-07 21:47:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-07 21:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+2021-09-07 21:47:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:47:58 DEBUG     pycloudlib.instance:instance.py:200 deleting fleet-mullet
+
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:47:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:47:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+execute_via_ssh=False
+config_dict={'user.network-config': 'bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:3b:52:e2\nversion: 2\n', 'volatile.eth0.hwaddr': '02:00:00:3b:52:e2'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:47:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+execute_via_ssh=False
+config_dict={'user.network-config': 'bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:3b:52:e2\nversion: 2\n', 'volatile.eth0.hwaddr': '02:00:00:3b:52:e2'}
+image_id=local:big-mouse-snapshot
+2021-09-07 21:47:58 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.network-config=bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:3b:52:e2\nversion: 2\n', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:3b:52:e2', '--vm']
+2021-09-07 21:47:58 DEBUG     pycloudlib.cloud:cloud.py:275 Created precise-meerkat
+2021-09-07 21:47:59 DEBUG     pycloudlib.instance:instance.py:394 starting precise-meerkat
+2021-09-07 21:48:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:48:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:48:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:48:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:48:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=precise-meerkat)
+2021-09-07 21:48:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=precise-meerkat)
+2021-09-07 21:48:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:48:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:48:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:48:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:48:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:48:28 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:48:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dhclient enp5s0'
+2021-09-07 21:48:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'dhclient enp5s0'
+2021-09-07 21:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt update -qqy'
+2021-09-07 21:48:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt update -qqy'
+2021-09-07 21:48:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qqy openvswitch-switch'
+2021-09-07 21:48:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qqy openvswitch-switch'
+2021-09-07 21:48:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 21:48:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 21:48:45 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:48:45 DEBUG     pycloudlib.instance:instance.py:296 restarting precise-meerkat
+2021-09-07 21:48:59 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:48:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:48:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:49:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:49:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:49:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:49:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:49:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr'
+2021-09-07 21:49:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip addr'
+2021-09-07 21:49:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip -4 route show default | awk '"'"'{ print $3 }'"'"''
+2021-09-07 21:49:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip -4 route show default | awk '"'"'{ print $3 }'"'"''
+2021-09-07 21:49:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ping -c 1 -W 1 -I ovs-br 10.85.130.1'
+2021-09-07 21:49:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ping -c 1 -W 1 -I ovs-br 10.85.130.1'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:49:07 DEBUG     pycloudlib.instance:instance.py:200 deleting precise-meerkat
+
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:49:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:49:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 21:49:08 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 21:49:08 DEBUG     pycloudlib.cloud:cloud.py:275 Created pumped-haddock
+2021-09-07 21:49:08 DEBUG     pycloudlib.instance:instance.py:394 starting pumped-haddock
+2021-09-07 21:49:32 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:49:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:49:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:49:37 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:49:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:49:37 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=pumped-haddock)
+2021-09-07 21:49:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pumped-haddock)
+2021-09-07 21:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:49:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:49:39 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 21:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-07 21:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 21:49:39 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 21:49:39 DEBUG     pycloudlib.instance:instance.py:296 restarting pumped-haddock
+2021-09-07 21:49:52 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:49:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:49:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:49:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:49:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:49:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:49:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 21:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 21:49:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-07 21:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-07 21:49:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:49:59 DEBUG     pycloudlib.instance:instance.py:200 deleting pumped-haddock
+
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:49:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:49:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:49:59 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n- openvswitch-switch\n', '--vm']
+2021-09-07 21:49:59 DEBUG     pycloudlib.cloud:cloud.py:275 Created easy-alpaca
+2021-09-07 21:50:00 DEBUG     pycloudlib.instance:instance.py:394 starting easy-alpaca
+2021-09-07 21:50:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:50:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:50:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:50:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:50:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:50:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:50:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:50:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:50:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:50:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=easy-alpaca)
+2021-09-07 21:50:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=easy-alpaca)
+2021-09-07 21:50:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:50:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:50:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:50:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:50:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:50:43 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-07 21:50:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-07 21:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-07 21:50:45 DEBUG     pycloudlib.instance:instance.py:331 shutting down easy-alpaca
+2021-09-07 21:50:46 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: easy-alpaca
+2021-09-07 21:50:47 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot easy-alpaca-snapshot
+Created new image: local:easy-alpaca-snapshot
+2021-09-07 21:52:47 INFO      integration_testing:instances.py:114 Created new image: local:easy-alpaca-snapshot
+2021-09-07 21:52:47 DEBUG     pycloudlib.instance:instance.py:200 deleting easy-alpaca
+Launching instance with launch_kwargs:
+user_data=None
+config_dict={'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:5d:62:7f\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:5d:62:7f\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:5d:62:7f\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', 'volatile.eth0.hwaddr': '02:00:00:5d:62:7f'}
+image_id=local:easy-alpaca-snapshot
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:52:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+config_dict={'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:5d:62:7f\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:5d:62:7f\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:5d:62:7f\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', 'volatile.eth0.hwaddr': '02:00:00:5d:62:7f'}
+image_id=local:easy-alpaca-snapshot
+2021-09-07 21:52:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:easy-alpaca-snapshot'
+['lxc', 'init', 'local:easy-alpaca-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.network-config=bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:5d:62:7f\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:5d:62:7f\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:5d:62:7f\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:5d:62:7f', '--vm']
+2021-09-07 21:54:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created fitting-stingray
+2021-09-07 21:54:20 DEBUG     pycloudlib.instance:instance.py:394 starting fitting-stingray
+2021-09-07 21:54:48 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:54:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:54:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:54:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:54:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:54:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:54:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:54:54 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:54:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:54:54 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fitting-stingray)
+2021-09-07 21:54:56 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fitting-stingray)
+2021-09-07 21:54:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:54:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:54:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:54:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:54:57 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-07 21:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-07 21:54:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-07 21:54:57 DEBUG     pycloudlib.instance:instance.py:200 deleting fitting-stingray
+PASSEDDeleting snapshot image created for this testrun: local:easy-alpaca-snapshot
+
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:54:58 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:easy-alpaca-snapshot
+2021-09-07 21:54:58 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:easy-alpaca-snapshot'
+2021-09-07 21:54:58 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:easy-alpaca-snapshot
+
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:54:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:54:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:54:58 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  conf: |\n    APT {\n        Get {\n            Assume-Yes "true";\n            Fix-Broken "true";\n        }\n    }\n  proxy: "http://proxy.internal:3128"\n  http_proxy: "http://squid.internal:3128"\n  ftp_proxy: "ftp://squid.internal:3128"\n  https_proxy: "https://squid.internal:3128"\n  primary:\n    - arches: [default]\n      uri: http://badarchive.ubuntu.com/ubuntu\n  security:\n    - arches: [default]\n      uri: http://badsecurity.ubuntu.com/ubuntu\n  sources_list: |\n    deb $MIRROR $RELEASE main restricted\n    deb-src $MIRROR $RELEASE main restricted\n    deb $PRIMARY $RELEASE universe restricted\n    deb-src $PRIMARY $RELEASE universe restricted\n    deb $SECURITY $RELEASE-security multiverse\n    deb-src $SECURITY $RELEASE-security multiverse\n  sources:\n    test_keyserver:\n        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937\n        keyserver: keyserver.ubuntu.com\n        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"\n    test_ppa:\n      keyid: 441614D8\n      keyserver: keyserver.ubuntu.com\n      source: "ppa:simplestreams-dev/trunk"\n    test_key:\n      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"\n      key: |\n        -----BEGIN PGP PUBLIC KEY BLOCK-----\n        Version: SKS 1.1.6\n        Comment: Hostname: keyserver.ubuntu.com\n\n        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI\n        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf\n        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq\n        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot\n        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX\n        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6\n        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6\n        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj\n        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l\n        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg\n        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG\n        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN\n        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH\n        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2\n        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj\n        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL\n        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq\n        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH\n        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ\n        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e\n        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf\n        pb0uBy+g0oxJQg15\n        =uy53\n        -----END PGP PUBLIC KEY BLOCK-----\napt_pipelining: os\n', '--vm']
+2021-09-07 21:54:58 DEBUG     pycloudlib.cloud:cloud.py:275 Created magical-spaniel
+2021-09-07 21:54:58 DEBUG     pycloudlib.instance:instance.py:394 starting magical-spaniel
+2021-09-07 21:55:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:55:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:55:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:55:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:55:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:55:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:55:30 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:55:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:55:30 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=magical-spaniel)
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=magical-spaniel)
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-07 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-07 21:55:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-07 21:55:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:55:40 DEBUG     pycloudlib.instance:instance.py:200 deleting magical-spaniel
+
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:55:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:55:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:55:40 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      \n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-07 21:55:41 DEBUG     pycloudlib.cloud:cloud.py:275 Created patient-cat
+2021-09-07 21:55:41 DEBUG     pycloudlib.instance:instance.py:394 starting patient-cat
+2021-09-07 21:56:06 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:56:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:56:10 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:56:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:56:10 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=patient-cat)
+2021-09-07 21:56:12 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=patient-cat)
+2021-09-07 21:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:56:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:56:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:56:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:56:12 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 21:56:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:56:12 DEBUG     pycloudlib.instance:instance.py:200 deleting patient-cat
+
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:56:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:56:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:56:13 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      uri: "http://something.random.invalid/ubuntu"\n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-07 21:56:13 DEBUG     pycloudlib.cloud:cloud.py:275 Created innocent-duckling
+2021-09-07 21:56:13 DEBUG     pycloudlib.instance:instance.py:394 starting innocent-duckling
+2021-09-07 21:56:36 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:56:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:56:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:56:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:56:41 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:56:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:56:41 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=innocent-duckling)
+2021-09-07 21:56:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=innocent-duckling)
+2021-09-07 21:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:56:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:56:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:56:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:56:43 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:56:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-07 21:56:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:56:43 DEBUG     pycloudlib.instance:instance.py:200 deleting innocent-duckling
+
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:56:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:56:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:56:44 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  disable_suites:\n  - $RELEASE\n  - $RELEASE-updates\n  - $RELEASE-backports\n  - $RELEASE-security\napt_pipelining: false\n', '--vm']
+2021-09-07 21:56:44 DEBUG     pycloudlib.cloud:cloud.py:275 Created clear-burro
+2021-09-07 21:56:44 DEBUG     pycloudlib.instance:instance.py:394 starting clear-burro
+2021-09-07 21:57:07 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:57:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:57:12 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:57:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:57:12 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=clear-burro)
+2021-09-07 21:57:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clear-burro)
+2021-09-07 21:57:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:57:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:57:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:57:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:57:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:57:15 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:57:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+2021-09-07 21:57:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:57:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:57:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-07 21:57:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:57:15 DEBUG     pycloudlib.instance:instance.py:200 deleting clear-burro
+
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:57:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:57:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:57:15 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nca-certs:\n  remove-defaults: true\n  trusted:\n    - |\n      -----BEGIN CERTIFICATE-----\n      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx\n      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP\n      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl\n      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW\n      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz\n      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93\n      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl\n      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG\n      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc\n      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ\n      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX\n      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6\n      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2\n      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S\n      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o\n      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4\n      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF\n      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1\n      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3\n      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT\n      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5\n      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3\n      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr\n      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf\n      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ\n      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM\n      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L\n      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT\n      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro\n      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586\n      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l\n      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i\n      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==\n      -----END CERTIFICATE-----\n', '--vm']
+2021-09-07 21:57:15 DEBUG     pycloudlib.cloud:cloud.py:275 Created right-swine
+2021-09-07 21:57:15 DEBUG     pycloudlib.instance:instance.py:394 starting right-swine
+2021-09-07 21:57:40 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:57:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:57:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:57:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:57:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:57:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:57:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=right-swine)
+2021-09-07 21:57:47 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=right-swine)
+2021-09-07 21:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:57:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:57:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:57:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:57:47 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-07 21:57:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-07 21:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-07 21:57:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-07 21:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-07 21:57:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-07 21:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+2021-09-07 21:57:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:57:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+2021-09-07 21:57:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:57:48 DEBUG     pycloudlib.instance:instance.py:200 deleting right-swine
+
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:57:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:57:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:57:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nruncmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-07 21:57:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created main-tiger
+2021-09-07 21:57:48 DEBUG     pycloudlib.instance:instance.py:394 starting main-tiger
+2021-09-07 21:58:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:58:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:58:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:58:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:58:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=main-tiger)
+2021-09-07 21:58:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=main-tiger)
+2021-09-07 21:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:58:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:58:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:58:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:58:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-07 21:58:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:58:21 DEBUG     pycloudlib.instance:instance.py:200 deleting main-tiger
+
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:58:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:58:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:58:22 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=runcmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-07 21:58:22 DEBUG     pycloudlib.cloud:cloud.py:275 Created organic-honeybee
+2021-09-07 21:58:22 DEBUG     pycloudlib.instance:instance.py:394 starting organic-honeybee
+2021-09-07 21:58:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:58:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:58:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:58:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:58:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:58:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:58:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=organic-honeybee)
+2021-09-07 21:58:53 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=organic-honeybee)
+2021-09-07 21:58:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:58:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:58:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:58:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:58:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:58:54 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:58:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-07 21:58:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:58:54 DEBUG     pycloudlib.instance:instance.py:200 deleting organic-honeybee
+
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:58:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:58:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:58:55 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  primary:\n    - arches: [default]\n      uri: http://us.archive.ubuntu.com/ubuntu/\nbyobu_by_default: enable\nfinal_message: |\n  This is my final message!\n  $version\n  $timestamp\n  $datasource\n  $uptime\nlocale: en_GB.UTF-8\nlocale_configfile: /etc/default/locale\nntp:\n  servers: ['ntp.ubuntu.com']\nruncmd:\n  - echo 'hello world' > /var/tmp/runcmd_output\n", '--vm']
+2021-09-07 21:58:55 DEBUG     pycloudlib.cloud:cloud.py:275 Created clever-mako
+2021-09-07 21:58:55 DEBUG     pycloudlib.instance:instance.py:394 starting clever-mako
+2021-09-07 21:59:19 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:59:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:59:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:59:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:59:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:59:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=clever-mako)
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clever-mako)
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-07 21:59:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'locale -a'
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:59:28 DEBUG     pycloudlib.instance:instance.py:200 deleting clever-mako
+
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:59:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:59:29 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\noutput: { all: "| tee -a /var/log/cloud-init-test-output" }\nfinal_message: "should be last line in cloud-init-test-output file"\n', '--vm']
+2021-09-07 21:59:29 DEBUG     pycloudlib.cloud:cloud.py:275 Created new-catfish
+2021-09-07 21:59:29 DEBUG     pycloudlib.instance:instance.py:394 starting new-catfish
+2021-09-07 21:59:52 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 21:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 21:59:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 21:59:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 21:59:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 21:59:56 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 21:59:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 21:59:56 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=new-catfish)
+2021-09-07 21:59:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=new-catfish)
+2021-09-07 21:59:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 21:59:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:59:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 21:59:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 21:59:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 21:59:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 21:59:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+2021-09-07 21:59:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 21:59:59 DEBUG     pycloudlib.instance:instance.py:200 deleting new-catfish
+
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 21:59:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:59:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 21:59:59 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndevice_aliases:\n  my_alias: /dev/sdb\ndisk_setup:\n  my_alias:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n- label: fs1\n  device: my_alias.1\n  filesystem: ext4\n- label: fs2\n  device: my_alias.2\n  filesystem: ext4\nmounts:\n- ["my_alias.1", "/mnt1"]\n- ["my_alias.2", "/mnt2"]\n', '--vm']
+2021-09-07 21:59:59 DEBUG     pycloudlib.cloud:cloud.py:275 Created super-polliwog
+Running callback specified by 'lxd_setup' mark
+2021-09-07 21:59:59 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-07 22:00:00 DEBUG     pycloudlib.instance:instance.py:394 starting super-polliwog
+2021-09-07 22:00:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:00:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:00:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:00:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:00:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:00:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=super-polliwog)
+2021-09-07 22:00:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=super-polliwog)
+2021-09-07 22:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:00:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:00:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:00:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:00:31 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:00:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 22:00:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:00:31 DEBUG     pycloudlib.instance:instance.py:200 deleting super-polliwog
+
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:00:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:00:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:00:32 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisk_setup:\n  /dev/sdb:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n  - label: test\n    device: /dev/sdb1\n    filesystem: ext4\n  - label: test2\n    device: /dev/sdb2\n    filesystem: ext4\nmounts:\n- ["/dev/sdb1", "/mnt1"]\n- ["/dev/sdb2", "/mnt2"]\n', '--vm']
+2021-09-07 22:00:32 DEBUG     pycloudlib.cloud:cloud.py:275 Created pumped-lobster
+Running callback specified by 'lxd_setup' mark
+2021-09-07 22:00:32 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-07 22:00:32 DEBUG     pycloudlib.instance:instance.py:394 starting pumped-lobster
+2021-09-07 22:00:55 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:00:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:00:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:01:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:01:01 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:01:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:01:01 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=pumped-lobster)
+2021-09-07 22:01:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pumped-lobster)
+2021-09-07 22:01:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:01:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:01:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:01:04 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpn0kidmwp to /var/tmp/4eda9a48-f0f6-41b5-a6c2-bf722a009e86.tmp
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpn0kidmwp to /var/tmp/4eda9a48-f0f6-41b5-a6c2-bf722a009e86.tmp
+2021-09-07 22:01:04 INFO      paramiko.transport.sftp:sftp.py:158 [chan 6] Opened sftp connection (server version 3)
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4eda9a48-f0f6-41b5-a6c2-bf722a009e86.tmp /var/lib/cloud/seed/nocloud-net/user-data'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/4eda9a48-f0f6-41b5-a6c2-bf722a009e86.tmp /var/lib/cloud/seed/nocloud-net/user-data'
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/write-files/write-files\n - mounts/'"'"' /etc/cloud/cloud.cfg'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sed -i '"'"'s/write-files/write-files\n - mounts/'"'"' /etc/cloud/cloud.cfg'
+2021-09-07 22:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 22:01:04 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:01:04 DEBUG     pycloudlib.instance:instance.py:296 restarting pumped-lobster
+2021-09-07 22:01:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:01:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:01:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:01:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:01:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 22:01:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:01:25 DEBUG     pycloudlib.instance:instance.py:200 deleting pumped-lobster
+
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:01:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:01:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:01:25 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisk_setup:\n  /dev/sdb:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n  - label: test\n    device: /dev/sdb1\n    filesystem: ext4\n  - label: test2\n    device: /dev/sdb2\n    filesystem: ext4\nmounts:\n- ["/dev/sdb1", "/mnt1"]\n- ["/dev/sdb2", "/mnt2"]\n', '--vm']
+2021-09-07 22:01:26 DEBUG     pycloudlib.cloud:cloud.py:275 Created creative-anchovy
+Running callback specified by 'lxd_setup' mark
+2021-09-07 22:01:26 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-07 22:01:26 DEBUG     pycloudlib.instance:instance.py:394 starting creative-anchovy
+2021-09-07 22:01:50 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:01:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:01:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:01:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:01:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:01:55 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:01:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:01:55 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:01:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 6] sftp session closed.
+Launched instance: LXDInstance(name=creative-anchovy)
+2021-09-07 22:01:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=creative-anchovy)
+2021-09-07 22:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:01:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:01:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:01:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:01:57 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-07 22:01:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-07 22:01:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-07 22:01:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-07 22:01:57 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:01:57 DEBUG     pycloudlib.instance:instance.py:296 restarting creative-anchovy
+2021-09-07 22:02:10 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:02:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:02:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:02:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:02:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:02:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:02:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-07 22:02:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:02:18 DEBUG     pycloudlib.instance:instance.py:200 deleting creative-anchovy
+
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:02:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:02:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:02:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=## template: jinja\n#cloud-config\nruncmd:\n  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output\n  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output\n', '--vm']
+2021-09-07 22:02:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created worthy-cod
+2021-09-07 22:02:19 DEBUG     pycloudlib.instance:instance.py:394 starting worthy-cod
+2021-09-07 22:02:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:02:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:02:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:02:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:02:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:02:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:02:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:02:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=worthy-cod)
+2021-09-07 22:02:53 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=worthy-cod)
+2021-09-07 22:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:02:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:02:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:02:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:02:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 22:02:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 22:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-07 22:02:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:02:53 DEBUG     pycloudlib.instance:instance.py:200 deleting worthy-cod
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:02:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:02:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:02:54 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\nssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-07 22:02:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created engaged-chigger
+2021-09-07 22:02:54 DEBUG     pycloudlib.instance:instance.py:394 starting engaged-chigger
+2021-09-07 22:03:07 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:03:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:03:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:03:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:03:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:03:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=engaged-chigger)
+2021-09-07 22:03:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=engaged-chigger)
+2021-09-07 22:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:03:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:03:26 DEBUG     pycloudlib.instance:instance.py:200 deleting engaged-chigger
+
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:03:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:03:26 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-07 22:03:27 DEBUG     pycloudlib.cloud:cloud.py:275 Created good-elf
+2021-09-07 22:03:27 DEBUG     pycloudlib.instance:instance.py:394 starting good-elf
+2021-09-07 22:03:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:03:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:03:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:03:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:03:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:03:56 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:03:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:03:56 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=good-elf)
+2021-09-07 22:03:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=good-elf)
+2021-09-07 22:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:03:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:03:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:03:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:03:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:03:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:03:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:03:59 DEBUG     pycloudlib.instance:instance.py:200 deleting good-elf
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:04:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:04:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh:\n  emit_keys_to_console: false\n', '--vm']
+2021-09-07 22:04:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created wanted-polecat
+2021-09-07 22:04:00 DEBUG     pycloudlib.instance:instance.py:394 starting wanted-polecat
+2021-09-07 22:04:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:04:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:04:28 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:04:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:04:28 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=wanted-polecat)
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wanted-polecat)
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:04:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:04:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:04:31 DEBUG     pycloudlib.instance:instance.py:200 deleting wanted-polecat
+
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:04:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:04:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:04:31 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nlxd:\n  init:\n    storage_backend: dir\n  bridge:\n    mode: new\n    name: lxdbr0\n    ipv4_address: 10.100.100.1\n    ipv4_netmask: 24\n    ipv4_dhcp_first: 10.100.100.100\n    ipv4_dhcp_last: 10.100.100.200\n    ipv4_nat: true\n    domain: lxd\n', '--vm']
+2021-09-07 22:04:31 DEBUG     pycloudlib.cloud:cloud.py:275 Created uncommon-walleye
+2021-09-07 22:04:31 DEBUG     pycloudlib.instance:instance.py:394 starting uncommon-walleye
+2021-09-07 22:04:55 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:04:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:04:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:04:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:04:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:05:01 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:05:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:05:01 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=uncommon-walleye)
+2021-09-07 22:05:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=uncommon-walleye)
+2021-09-07 22:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:05:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:05:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:05:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:05:14 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+2021-09-07 22:05:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+2021-09-07 22:05:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:05:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-07 22:05:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-07 22:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+2021-09-07 22:05:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:05:15 DEBUG     pycloudlib.instance:instance.py:200 deleting uncommon-walleye
+
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:05:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:05:15 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  servers:\n      - 172.16.15.14\n      - 172.16.17.18\n  pools:\n      - 0.cloud-init.mypool\n      - 1.cloud-init.mypool\n      - 172.16.15.15\n', '--vm']
+2021-09-07 22:05:16 DEBUG     pycloudlib.cloud:cloud.py:275 Created desired-lemur
+2021-09-07 22:05:16 DEBUG     pycloudlib.instance:instance.py:394 starting desired-lemur
+2021-09-07 22:05:39 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:05:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:05:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:05:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:05:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:05:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:05:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:05:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:05:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:05:44 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:05:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:05:44 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=desired-lemur)
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=desired-lemur)
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:05:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+2021-09-07 22:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:06:00 DEBUG     pycloudlib.instance:instance.py:200 deleting desired-lemur
+
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:06:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:06:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:06:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: chrony\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-07 22:06:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created flexible-bluegill
+2021-09-07 22:06:01 DEBUG     pycloudlib.instance:instance.py:394 starting flexible-bluegill
+2021-09-07 22:06:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:06:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:06:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:06:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:06:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:06:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:06:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:06:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:06:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:06:30 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:06:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:06:30 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=flexible-bluegill)
+2021-09-07 22:06:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=flexible-bluegill)
+2021-09-07 22:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:06:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:06:46 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-07 22:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-07 22:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+2021-09-07 22:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:06:46 DEBUG     pycloudlib.instance:instance.py:200 deleting flexible-bluegill
+
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:06:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:06:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:06:47 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: systemd-timesyncd\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-07 22:06:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created game-chigger
+2021-09-07 22:06:48 DEBUG     pycloudlib.instance:instance.py:394 starting game-chigger
+2021-09-07 22:07:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:07:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:07:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:07:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:07:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=game-chigger)
+2021-09-07 22:07:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=game-chigger)
+2021-09-07 22:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:07:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:07:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:07:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:07:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+2021-09-07 22:07:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:07:19 DEBUG     pycloudlib.instance:instance.py:200 deleting game-chigger
+
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:07:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:07:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:07:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  pools: []\n  servers: []\n', '--vm']
+2021-09-07 22:07:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created adapted-ocelot
+2021-09-07 22:07:20 DEBUG     pycloudlib.instance:instance.py:394 starting adapted-ocelot
+2021-09-07 22:07:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:07:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:07:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:07:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:07:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:07:54 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:07:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:07:54 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=adapted-ocelot)
+2021-09-07 22:08:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=adapted-ocelot)
+2021-09-07 22:08:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:08:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:08:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:08:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:08:11 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 22:08:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+2021-09-07 22:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-07 22:08:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-07 22:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+2021-09-07 22:08:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:08:11 DEBUG     pycloudlib.instance:instance.py:200 deleting adapted-ocelot
+
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:08:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:08:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:08:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n  - sl\n  - tree\npackage_update: true\npackage_upgrade: true\n', '--vm']
+2021-09-07 22:08:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created tough-cricket
+2021-09-07 22:08:12 DEBUG     pycloudlib.instance:instance.py:394 starting tough-cricket
+2021-09-07 22:08:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:08:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:08:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:08:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:08:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:08:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:08:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:08:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:08:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:08:39 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:08:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:08:39 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=tough-cricket)
+2021-09-07 22:09:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=tough-cricket)
+2021-09-07 22:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:09:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:09:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:09:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:09:20 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:09:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+2021-09-07 22:09:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:09:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+2021-09-07 22:09:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:09:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:09:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 22:09:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:09:21 DEBUG     pycloudlib.instance:instance.py:200 deleting tough-cricket
+
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:09:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:09:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:09:21 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nrandom_seed:\n  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'\n  encoding: raw\n  file: /root/seed\n", '--vm']
+2021-09-07 22:09:22 DEBUG     pycloudlib.cloud:cloud.py:275 Created main-stork
+2021-09-07 22:09:22 DEBUG     pycloudlib.instance:instance.py:394 starting main-stork
+2021-09-07 22:09:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:09:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:09:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:09:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:09:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:09:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:09:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:09:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:09:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:09:49 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:09:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:09:49 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=main-stork)
+2021-09-07 22:09:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=main-stork)
+2021-09-07 22:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:09:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:09:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:09:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:09:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:09:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+2021-09-07 22:09:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:09:51 DEBUG     pycloudlib.instance:instance.py:200 deleting main-stork
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:09:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:09:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:09:52 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nhostname: cloudinit2\n', '--vm']
+2021-09-07 22:09:52 DEBUG     pycloudlib.cloud:cloud.py:275 Created alive-ghoul
+2021-09-07 22:09:52 DEBUG     pycloudlib.instance:instance.py:394 starting alive-ghoul
+2021-09-07 22:10:16 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:10:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:10:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:10:20 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:10:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:10:20 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=alive-ghoul)
+2021-09-07 22:10:22 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=alive-ghoul)
+2021-09-07 22:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:10:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:10:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:10:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:10:22 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 22:10:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:10:22 DEBUG     pycloudlib.instance:instance.py:200 deleting alive-ghoul
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:10:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:10:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:10:23 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: True\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-07 22:10:23 DEBUG     pycloudlib.cloud:cloud.py:275 Created premium-jackass
+2021-09-07 22:10:23 DEBUG     pycloudlib.instance:instance.py:394 starting premium-jackass
+2021-09-07 22:10:45 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:10:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:10:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:10:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:10:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:10:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:10:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=premium-jackass)
+2021-09-07 22:10:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=premium-jackass)
+2021-09-07 22:10:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:10:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:10:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:10:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:10:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:10:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:10:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 22:10:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:10:53 DEBUG     pycloudlib.instance:instance.py:200 deleting premium-jackass
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:10:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:10:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:10:53 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: False\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-07 22:10:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created liberal-flounder
+2021-09-07 22:10:54 DEBUG     pycloudlib.instance:instance.py:394 starting liberal-flounder
+2021-09-07 22:11:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:11:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:11:21 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:11:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:11:21 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=liberal-flounder)
+2021-09-07 22:11:23 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=liberal-flounder)
+2021-09-07 22:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:11:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:11:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:11:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:11:23 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 22:11:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:11:23 DEBUG     pycloudlib.instance:instance.py:200 deleting liberal-flounder
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:11:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:11:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:11:24 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nmanage_etc_hosts: true\nhostname: cloudinit1\nfqdn: cloudinit2.i9n.cloud-init.io\n', '--vm']
+2021-09-07 22:11:24 DEBUG     pycloudlib.cloud:cloud.py:275 Created enormous-grouper
+2021-09-07 22:11:24 DEBUG     pycloudlib.instance:instance.py:394 starting enormous-grouper
+2021-09-07 22:11:48 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:11:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:11:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:11:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:11:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:11:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:11:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=enormous-grouper)
+2021-09-07 22:11:54 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=enormous-grouper)
+2021-09-07 22:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:11:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:11:54 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-07 22:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-07 22:11:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:11:54 DEBUG     pycloudlib.instance:instance.py:200 deleting enormous-grouper
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:11:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:11:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:11:55 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n  list:\n    - tom:mypassword123!\n    - dick:RANDOM\n    - harry:RANDOM\n    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-07 22:11:55 DEBUG     pycloudlib.cloud:cloud.py:275 Created charmed-haddock
+2021-09-07 22:11:55 DEBUG     pycloudlib.instance:instance.py:394 starting charmed-haddock
+2021-09-07 22:12:18 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:12:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:12:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:12:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:12:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=charmed-haddock)
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=charmed-haddock)
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:179 getting console log for charmed-haddock
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:12:26 DEBUG     pycloudlib.instance:instance.py:200 deleting charmed-haddock
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:12:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:12:26 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n    list: |\n      tom:mypassword123!\n      dick:RANDOM\n      harry:RANDOM\n      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-07 22:12:27 DEBUG     pycloudlib.cloud:cloud.py:275 Created arriving-javelin
+2021-09-07 22:12:27 DEBUG     pycloudlib.instance:instance.py:394 starting arriving-javelin
+2021-09-07 22:12:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:12:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:12:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:12:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:12:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:12:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:12:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=arriving-javelin)
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=arriving-javelin)
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 getting console log for arriving-javelin
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:12:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:12:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 22:12:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:13:00 DEBUG     pycloudlib.instance:instance.py:200 deleting arriving-javelin
+
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:13:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:13:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:13:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackage_update: true\nsnap:\n  squashfuse_in_container: true\n  commands:\n    - snap install hello-world\n', '--vm']
+2021-09-07 22:13:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created concise-sunbeam
+2021-09-07 22:13:00 DEBUG     pycloudlib.instance:instance.py:394 starting concise-sunbeam
+2021-09-07 22:13:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:13:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:13:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:13:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:13:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:13:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:13:28 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:13:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:13:28 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=concise-sunbeam)
+2021-09-07 22:13:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=concise-sunbeam)
+2021-09-07 22:13:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:13:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:13:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:13:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:13:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:13:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:13:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+2021-09-07 22:13:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'snap list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:13:49 DEBUG     pycloudlib.instance:instance.py:200 deleting concise-sunbeam
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:13:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:13:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:13:50 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nno_ssh_fingerprints: true\n', '--vm']
+2021-09-07 22:13:50 DEBUG     pycloudlib.cloud:cloud.py:275 Created moved-cod
+2021-09-07 22:13:50 DEBUG     pycloudlib.instance:instance.py:394 starting moved-cod
+2021-09-07 22:14:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:14:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:14:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:14:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:14:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:14:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=moved-cod)
+2021-09-07 22:14:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=moved-cod)
+2021-09-07 22:14:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:14:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:14:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:14:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:14:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:14:19 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:14:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:14:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:14:19 DEBUG     pycloudlib.instance:instance.py:200 deleting moved-cod
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:14:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:14:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:14:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\n', '--vm']
+2021-09-07 22:14:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created free-rat
+2021-09-07 22:14:20 DEBUG     pycloudlib.instance:instance.py:394 starting free-rat
+2021-09-07 22:14:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:14:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:14:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:14:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:14:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:14:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:14:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=free-rat)
+2021-09-07 22:14:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=free-rat)
+2021-09-07 22:14:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:14:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:14:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:14:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:14:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:14:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:14:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-07 22:14:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:14:49 DEBUG     pycloudlib.instance:instance.py:200 deleting free-rat
+
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:14:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:14:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:14:50 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nauthkey_hash: sha512\n', '--vm']
+2021-09-07 22:14:50 DEBUG     pycloudlib.cloud:cloud.py:275 Created singular-panther
+2021-09-07 22:14:50 DEBUG     pycloudlib.instance:instance.py:394 starting singular-panther
+2021-09-07 22:15:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:15:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:15:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:15:18 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:15:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:15:18 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=singular-panther)
+2021-09-07 22:15:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=singular-panther)
+2021-09-07 22:15:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:15:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:15:20 DEBUG     pycloudlib.instance:instance.py:200 deleting singular-panther
+
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:15:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:15:21 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_import_id:\n  - gh:powersj\n  - lp:smoser\n', '--vm']
+2021-09-07 22:15:21 DEBUG     pycloudlib.cloud:cloud.py:275 Created amused-terrier
+2021-09-07 22:15:21 DEBUG     pycloudlib.instance:instance.py:394 starting amused-terrier
+2021-09-07 22:15:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:15:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:15:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:15:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:15:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:15:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:15:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:15:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=amused-terrier)
+2021-09-07 22:15:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=amused-terrier)
+2021-09-07 22:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:15:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:15:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:15:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:15:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 22:15:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:15:51 DEBUG     pycloudlib.instance:instance.py:200 deleting amused-terrier
+
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:15:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:15:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:15:52 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisable_root: false\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\nssh_keys:\n  rsa_private: |\n    -----BEGIN RSA PRIVATE KEY-----\n    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj\n    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9\n    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y\n    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu\n    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c\n    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5\n    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw\n    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm\n    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl\n    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA\n    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ\n    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu\n    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP\n    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN\n    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW\n    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N\n    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr\n    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN\n    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO\n    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR\n    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A\n    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW\n    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2\n    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+\n    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE\n    -----END RSA PRIVATE KEY-----\n  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd\n  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd\n  dsa_private: |\n    -----BEGIN DSA PRIVATE KEY-----\n    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP\n    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d\n    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i\n    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE\n    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI\n    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED\n    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf\n    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E\n    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW\n    nCPOXEQsayANi8+Cb7BH\n    -----END DSA PRIVATE KEY-----\n  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd\n  ed25519_private: |\n    -----BEGIN OPENSSH PRIVATE KEY-----\n    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp\n    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q\n    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg\n    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==\n    -----END OPENSSH PRIVATE KEY-----\n  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd\n  ecdsa_private: |\n    -----BEGIN EC PRIVATE KEY-----\n    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49\n    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb\n    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==\n    -----END EC PRIVATE KEY-----\n  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd\n', '--vm']
+2021-09-07 22:15:52 DEBUG     pycloudlib.cloud:cloud.py:275 Created precious-lemur
+2021-09-07 22:15:52 DEBUG     pycloudlib.instance:instance.py:394 starting precious-lemur
+2021-09-07 22:16:15 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:16:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:16:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:16:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=precious-lemur)
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=precious-lemur)
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+2021-09-07 22:16:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:16:22 DEBUG     pycloudlib.instance:instance.py:200 deleting precious-lemur
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:16:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:16:23 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n - ""\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n', '--vm']
+2021-09-07 22:16:23 DEBUG     pycloudlib.cloud:cloud.py:275 Created clever-bedbug
+2021-09-07 22:16:23 DEBUG     pycloudlib.instance:instance.py:394 starting clever-bedbug
+2021-09-07 22:16:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:16:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:16:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:16:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:16:51 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:16:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:16:51 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=clever-bedbug)
+2021-09-07 22:16:53 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=clever-bedbug)
+2021-09-07 22:16:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:16:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:16:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:16:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:16:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:16:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:16:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-07 22:16:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:16:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:16:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:16:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:16:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:16:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-07 22:16:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 22:16:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-07 22:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 22:16:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:16:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:16:58 DEBUG     pycloudlib.instance:instance.py:200 deleting clever-bedbug
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:16:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:16:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:16:59 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 22:16:59 DEBUG     pycloudlib.cloud:cloud.py:275 Created native-caiman
+2021-09-07 22:16:59 DEBUG     pycloudlib.instance:instance.py:394 starting native-caiman
+2021-09-07 22:17:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:17:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:17:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:17:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:17:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:17:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:17:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:17:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:17:27 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:17:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:17:27 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=native-caiman)
+2021-09-07 22:17:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=native-caiman)
+2021-09-07 22:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:17:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:17:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:17:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:17:29 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 22:17:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 22:17:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 22:17:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 22:17:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 22:17:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 22:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-07 22:17:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:17:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:17:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:17:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:17:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:17:34 DEBUG     pycloudlib.instance:instance.py:200 deleting native-caiman
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:17:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:17:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:17:34 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 22:17:35 DEBUG     pycloudlib.cloud:cloud.py:275 Created secure-krill
+2021-09-07 22:17:35 DEBUG     pycloudlib.instance:instance.py:394 starting secure-krill
+2021-09-07 22:17:58 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:17:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:17:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:18:04 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:18:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:18:04 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=secure-krill)
+2021-09-07 22:18:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=secure-krill)
+2021-09-07 22:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:18:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:18:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:18:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:18:06 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 22:18:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 22:18:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 22:18:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 22:18:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 22:18:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-07 22:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 22:18:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 22:18:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:18:11 DEBUG     pycloudlib.instance:instance.py:200 deleting secure-krill
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:18:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:18:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:18:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-07 22:18:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created viable-monitor
+2021-09-07 22:18:12 DEBUG     pycloudlib.instance:instance.py:394 starting viable-monitor
+2021-09-07 22:18:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:18:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:18:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:18:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:18:41 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:18:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:18:41 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=viable-monitor)
+2021-09-07 22:18:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=viable-monitor)
+2021-09-07 22:18:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:18:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:18:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:18:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:18:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:18:43 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:18:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 22:18:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 22:18:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-07 22:18:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-07 22:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 22:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-07 22:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 22:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-07 22:18:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-07 22:18:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-07 22:18:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-07 22:18:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:18:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-07 22:18:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:18:47 DEBUG     pycloudlib.instance:instance.py:200 deleting viable-monitor
+
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:18:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:18:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:18:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ntimezone: US/Aleutian\n', '--vm']
+2021-09-07 22:18:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created liked-hound
+2021-09-07 22:18:48 DEBUG     pycloudlib.instance:instance.py:394 starting liked-hound
+2021-09-07 22:19:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:19:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:19:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:19:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:19:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:19:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=liked-hound)
+2021-09-07 22:19:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=liked-hound)
+2021-09-07 22:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:19:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:19:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:19:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:19:18 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+2021-09-07 22:19:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:19:18 DEBUG     pycloudlib.instance:instance.py:200 deleting liked-hound
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:19:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:19:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:19:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 22:19:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created awaited-panda
+2021-09-07 22:19:19 DEBUG     pycloudlib.instance:instance.py:394 starting awaited-panda
+2021-09-07 22:19:42 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:19:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:19:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:19:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:19:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:19:47 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:19:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:19:47 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=awaited-panda)
+2021-09-07 22:19:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=awaited-panda)
+2021-09-07 22:19:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:19:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:19:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:19:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpqes1b7xx to /var/tmp/67a66d9a-cb90-45a2-817c-3b46519f32ab.tmp
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpqes1b7xx to /var/tmp/67a66d9a-cb90-45a2-817c-3b46519f32ab.tmp
+2021-09-07 22:19:49 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/67a66d9a-cb90-45a2-817c-3b46519f32ab.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/67a66d9a-cb90-45a2-817c-3b46519f32ab.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 22:19:49 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:19:49 DEBUG     pycloudlib.instance:instance.py:296 restarting awaited-panda
+2021-09-07 22:20:27 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:20:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:20:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:20:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:20:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:20:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:20:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:20:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:20:31 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:20:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:20:31 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:20:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:20:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:20:33 DEBUG     pycloudlib.instance:instance.py:200 deleting awaited-panda
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:20:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:20:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:20:34 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nupdates:\n  network:\n    when: [boot]\n', '--vm']
+2021-09-07 22:20:34 DEBUG     pycloudlib.cloud:cloud.py:275 Created sought-firefly
+2021-09-07 22:20:34 DEBUG     pycloudlib.instance:instance.py:394 starting sought-firefly
+2021-09-07 22:20:57 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:20:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:20:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:20:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:20:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:21:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:21:01 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-07 22:21:01 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:21:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:21:01 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sought-firefly)
+2021-09-07 22:21:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sought-firefly)
+2021-09-07 22:21:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:21:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:21:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:21:04 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpuae5pva_ to /var/tmp/d82a1183-b65a-47c2-a708-38e505fbbf1a.tmp
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpuae5pva_ to /var/tmp/d82a1183-b65a-47c2-a708-38e505fbbf1a.tmp
+2021-09-07 22:21:04 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/d82a1183-b65a-47c2-a708-38e505fbbf1a.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/d82a1183-b65a-47c2-a708-38e505fbbf1a.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-07 22:21:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 22:21:04 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:21:04 DEBUG     pycloudlib.instance:instance.py:296 restarting sought-firefly
+2021-09-07 22:21:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:21:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:21:22 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:21:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:21:22 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:21:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-07 22:21:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:21:23 DEBUG     pycloudlib.instance:instance.py:200 deleting sought-firefly
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:21:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:21:24 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-07 22:21:24 DEBUG     pycloudlib.cloud:cloud.py:275 Created wondrous-platypus
+2021-09-07 22:21:24 DEBUG     pycloudlib.instance:instance.py:394 starting wondrous-platypus
+2021-09-07 22:21:47 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:21:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:21:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:21:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:21:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:21:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:21:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+Launched instance: LXDInstance(name=wondrous-platypus)
+2021-09-07 22:21:54 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wondrous-platypus)
+2021-09-07 22:21:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:21:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'groups root'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:21:55 DEBUG     pycloudlib.instance:instance.py:200 deleting wondrous-platypus
+
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:21:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:21:55 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-07 22:21:56 DEBUG     pycloudlib.cloud:cloud.py:275 Created current-slug
+2021-09-07 22:21:56 DEBUG     pycloudlib.instance:instance.py:394 starting current-slug
+2021-09-07 22:22:19 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:22:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:22:24 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:22:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:22:24 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=current-slug)
+2021-09-07 22:22:26 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=current-slug)
+2021-09-07 22:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:22:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:22:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:22:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:22:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:22:27 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:22:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:22:27 DEBUG     pycloudlib.instance:instance.py:200 deleting current-slug
+
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:22:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:22:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:22:27 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 22:22:27 DEBUG     pycloudlib.cloud:cloud.py:275 Created willing-minnow
+2021-09-07 22:22:27 DEBUG     pycloudlib.instance:instance.py:394 starting willing-minnow
+2021-09-07 22:22:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:22:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:22:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:22:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:22:56 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:22:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:22:56 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=willing-minnow)
+2021-09-07 22:22:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=willing-minnow)
+2021-09-07 22:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:22:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:22:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:22:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:22:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:22:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 22:22:59 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:22:59 DEBUG     pycloudlib.instance:instance.py:296 restarting willing-minnow
+2021-09-07 22:23:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:23:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:23:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:23:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:23:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:23:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:23:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:23:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:23:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:23:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:23:18 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/774f2cc0-0578-4f99-97d7-dc0eb552b82c.tmp
+2021-09-07 22:23:18 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/774f2cc0-0578-4f99-97d7-dc0eb552b82c.tmp
+2021-09-07 22:23:18 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-07 22:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/774f2cc0-0578-4f99-97d7-dc0eb552b82c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 22:23:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/774f2cc0-0578-4f99-97d7-dc0eb552b82c.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-07 22:23:18 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:23:18 DEBUG     pycloudlib.instance:instance.py:296 restarting willing-minnow
+2021-09-07 22:23:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:23:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:23:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:23:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:23:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:23:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:23:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:23:38 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:23:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:23:38 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:23:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:23:39 DEBUG     pycloudlib.instance:instance.py:200 deleting willing-minnow
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:23:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:23:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:23:40 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 22:23:40 DEBUG     pycloudlib.cloud:cloud.py:275 Created united-zebra
+2021-09-07 22:23:40 DEBUG     pycloudlib.instance:instance.py:394 starting united-zebra
+2021-09-07 22:24:04 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:24:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:24:08 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:24:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:24:08 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=united-zebra)
+2021-09-07 22:24:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=united-zebra)
+2021-09-07 22:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:24:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:24:10 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/92fe3291-11e8-4cc4-a9c7-d6c46ec35fb5.tmp
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/92fe3291-11e8-4cc4-a9c7-d6c46ec35fb5.tmp
+2021-09-07 22:24:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 22:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/92fe3291-11e8-4cc4-a9c7-d6c46ec35fb5.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/92fe3291-11e8-4cc4-a9c7-d6c46ec35fb5.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 22:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-07 22:24:10 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:24:10 DEBUG     pycloudlib.instance:instance.py:296 restarting united-zebra
+2021-09-07 22:24:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:24:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:26 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+2021-09-07 22:24:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:24:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:24:27 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:24:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:24:27 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:24:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:24:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:24:29 DEBUG     pycloudlib.instance:instance.py:200 deleting united-zebra
+------------------------------ live log logreport ------------------------------
+2021-09-07 22:24:29 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:24:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:24:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=local:big-mouse-snapshot
+2021-09-07 22:24:29 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-07 22:24:30 DEBUG     pycloudlib.cloud:cloud.py:275 Created mint-dodo
+2021-09-07 22:24:30 DEBUG     pycloudlib.instance:instance.py:394 starting mint-dodo
+2021-09-07 22:24:53 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:24:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:24:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:24:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:24:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:24:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:24:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=mint-dodo)
+2021-09-07 22:24:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=mint-dodo)
+2021-09-07 22:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:24:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:24:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/7b8b86bf-adee-4ad8-b5c9-dd91ce751241.tmp
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/7b8b86bf-adee-4ad8-b5c9-dd91ce751241.tmp
+2021-09-07 22:24:59 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-07 22:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/7b8b86bf-adee-4ad8-b5c9-dd91ce751241.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/7b8b86bf-adee-4ad8-b5c9-dd91ce751241.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-07 22:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-07 22:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-07 22:24:59 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-07 22:24:59 DEBUG     pycloudlib.instance:instance.py:296 restarting mint-dodo
+2021-09-07 22:25:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:25:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:25:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:25:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:25:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:25:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-07 22:25:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-07 22:25:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:25:18 DEBUG     pycloudlib.instance:instance.py:200 deleting mint-dodo
+------------------------------ live log logreport ------------------------------
+2021-09-07 22:25:18 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:25:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:25:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=local:big-mouse-snapshot
+2021-09-07 22:25:18 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:big-mouse-snapshot'
+['lxc', 'init', 'local:big-mouse-snapshot', '--profile', 'pycloudlib-vm-focal-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nwrite_files:\n-   encoding: b64\n    content: QVNDSUkgdGV4dA==\n    owner: root:root\n    path: /root/file_b64\n    permissions: \'0644\'\n-   content: |\n        # My new /root/file_text\n\n        SMBDOPTIONS="-D"\n    path: /root/file_text\n-   content: !!binary |\n        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK\n    path: /root/file_binary\n    permissions: \'0555\'\n-   encoding: gzip\n    content: !!binary |\n        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=\n    path: /root/file_gzip\n    permissions: \'0755\'\n', '--vm']
+2021-09-07 22:25:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created advanced-coral
+2021-09-07 22:25:19 DEBUG     pycloudlib.instance:instance.py:394 starting advanced-coral
+2021-09-07 22:25:42 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-07 22:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-07 22:25:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-07 22:25:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-07 22:25:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-07 22:25:46 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-07 22:25:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-07 22:25:46 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=advanced-coral)
+2021-09-07 22:25:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=advanced-coral)
+2021-09-07 22:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-07 22:25:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-07 22:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-07 22:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_text'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-07 22:25:49 DEBUG     pycloudlib.instance:instance.py:200 deleting advanced-coral
+Deleting snapshot image created for this testrun: local:big-mouse-snapshot
+2021-09-07 22:25:50 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:big-mouse-snapshot
+2021-09-07 22:25:50 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:big-mouse-snapshot'
+2021-09-07 22:25:50 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:big-mouse-snapshot
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 130 passed, 19 skipped, 2 warnings in 3034.02s (0:50:34) ===========

--- a/21.3-1/integration_tests/lxd_vm_hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/lxd_vm_hirsute_integration_tests.txt
@@ -1,0 +1,5658 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 00:46:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 00:46:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 00:46:28 DEBUG     pycloudlib.cloud:cloud.py:338 finding released Ubuntu image for hirsute
+2021-09-08 00:46:28 DEBUG     pycloudlib.streams:streams.py:46 looking for image with the following config:
+2021-09-08 00:46:28 DEBUG     pycloudlib.streams:streams.py:47 {'filters': [datatype = image-downloads [none=], ftype = lxd.tar.xz [none=], arch = amd64 [none=], release = hirsute [none=]]}
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-08 00:46:38 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=hirsute
+PLATFORM=lxd_vm
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for lxd_vm
+2021-09-08 00:46:38 INFO      integration_testing:conftest.py:156 Setting up environment for lxd_vm
+Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=None
+2021-09-08 00:46:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=None
+2021-09-08 00:46:40 DEBUG     pycloudlib.cloud:cloud.py:64 The profile named pycloudlib-vm-hirsute-v3 already exists
+The profile named pycloudlib-vm-hirsute-v3 already exists
+2021-09-08 00:46:41 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a'
+['lxc', 'init', 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 00:46:43 DEBUG     pycloudlib.cloud:cloud.py:275 Created subtle-ghoul
+2021-09-08 00:46:43 DEBUG     pycloudlib.instance:instance.py:394 starting subtle-ghoul
+2021-09-08 00:47:18 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:47:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:47:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:47:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:47:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:47:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:47:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:47:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:47:34 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:47:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:47:34 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=subtle-ghoul)
+2021-09-08 00:47:39 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=subtle-ghoul)
+2021-09-08 00:47:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 00:47:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:47:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 00:47:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 00:47:40 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Installing proposed image
+2021-09-08 00:47:40 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-08 00:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:47:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:47:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:47:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:47:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-08 00:48:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:48:04 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:48:06 DEBUG     pycloudlib.instance:instance.py:331 shutting down subtle-ghoul
+2021-09-08 00:48:09 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: subtle-ghoul
+2021-09-08 00:48:09 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot subtle-ghoul-snapshot
+Created new image: local:subtle-ghoul-snapshot
+2021-09-08 00:50:34 INFO      integration_testing:instances.py:114 Created new image: local:subtle-ghoul-snapshot
+2021-09-08 00:50:34 DEBUG     pycloudlib.instance:instance.py:200 deleting subtle-ghoul
+Done with environment setup
+2021-09-08 00:50:36 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 00:50:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 00:50:36 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 00:52:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created stable-skink
+2021-09-08 00:52:55 DEBUG     pycloudlib.instance:instance.py:394 starting stable-skink
+2021-09-08 00:53:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:53:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:53:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:53:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:53:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:53:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:53:37 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:53:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:53:37 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=stable-skink)
+2021-09-08 00:53:45 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=stable-skink)
+2021-09-08 00:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 00:53:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:53:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 00:53:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 00:53:46 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 00:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-08 00:53:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-08 00:53:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+2021-09-08 00:53:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 00:53:46 DEBUG     pycloudlib.instance:instance.py:200 deleting stable-skink
+
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 00:53:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 00:53:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-08 00:53:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-08 00:53:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a'
+['lxc', 'init', 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nhostname: SRU-worked\n', '--vm']
+2021-09-08 00:53:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created capital-flounder
+2021-09-08 00:53:49 DEBUG     pycloudlib.instance:instance.py:394 starting capital-flounder
+2021-09-08 00:54:22 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:54:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:54:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:54:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:54:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:54:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:54:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:54:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:54:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:54:39 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:54:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:54:39 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=capital-flounder)
+2021-09-08 00:54:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=capital-flounder)
+2021-09-08 00:54:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 00:54:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:54:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 00:54:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 00:54:53 INFO      integration_testing:clouds.py:183 image serial: 20210817
+2021-09-08 00:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 00:54:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-08 00:54:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-08 00:54:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c cloud-id
+2021-09-08 00:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 00:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 00:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 00:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 00:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-08 00:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c systemd-analyze
+2021-09-08 00:54:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-08 00:54:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-08 00:54:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-08 00:54:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-08 00:54:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-08 00:54:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-08 00:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 00:54:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-08 00:54:57 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-08 00:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:54:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:54:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:55:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-08 00:55:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:55:30 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:55:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 00:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:55:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 00:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+2021-09-08 00:55:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-08 00:55:30 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 00:55:30 DEBUG     pycloudlib.instance:instance.py:296 restarting capital-flounder
+2021-09-08 00:55:48 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:55:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:55:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:55:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:55:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:55:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:55:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:55:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:55:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:55:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 00:56:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-08 00:56:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-08 00:56:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-08 00:56:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init init'
+2021-09-08 00:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 00:56:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-08 00:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-08 00:56:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c cloud-id
+2021-09-08 00:56:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 00:56:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 00:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 00:56:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 00:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-08 00:56:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c systemd-analyze
+2021-09-08 00:56:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-08 00:56:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-08 00:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-08 00:56:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-08 00:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-08 00:56:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-08 00:56:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 00:56:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 2.850s (kernel) + 33.543s (userspace) = 36.393s 
+graphical.target reached after 30.950s in userspace
+=== `systemd-analyze` after:
+Startup finished in 850ms (kernel) + 18.261s (userspace) = 19.112s 
+graphical.target reached after 16.886s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+14.748s snapd.seeded.service
+ 6.426s snapd.apparmor.service
+ 4.877s cloud-init-local.service
+ 4.716s snapd.service
+ 3.681s e2scrub_reap.service
+ 3.059s cloud-init.service
+ 2.371s pollinate.service
+ 1.820s secureboot-db.service
+ 1.642s networkd-dispatcher.service
+ 1.633s rsyslog.service
+=== `systemd-analyze blame` after (first 10 lines):
+10.704s snap.lxd.activate.service
+ 9.876s snapd.service
+ 2.148s cloud-init-local.service
+ 1.705s cloud-init.service
+ 1.595s networkd-dispatcher.service
+ 1.298s cloud-config.service
+ 1.173s udisks2.service
+  972ms lvm2-monitor.service
+  957ms systemd-logind.service
+  929ms dev-sda1.device
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 02.15300 seconds
+Finished stage: (init-network) 01.94400 seconds
+Finished stage: (modules-config) 00.73900 seconds
+Finished stage: (modules-final) 00.21400 seconds
+Total Time: 5.05000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.85100 seconds
+Finished stage: (init-network) 01.01200 seconds
+Finished stage: (modules-config) 00.44500 seconds
+Finished stage: (modules-final) 00.12300 seconds
+Total Time: 2.43100 seconds
+Finished stage: (init-network) 00.28600 seconds
+Total Time: 0.28600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.56500s (init-network/config-growpart)
+     00.49100s (init-network/config-ssh)
+     00.41700s (modules-config/config-grub-dpkg)
+     00.31900s (init-network/config-users-groups)
+     00.16900s (modules-config/config-apt-configure)
+     00.16400s (init-network/config-resizefs)
+     00.13500s (init-local/search-NoCloud)
+     00.10400s (modules-final/config-keys-to-console)
+     00.07500s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.45500s (init-network/config-ssh)
+     00.27700s (modules-config/config-grub-dpkg)
+     00.13400s (init-network/config-resizefs)
+     00.09300s (modules-config/config-apt-configure)
+     00.09000s (init-network/config-growpart)
+     00.07900s (init-network/config-users-groups)
+     00.07600s (init-local/search-NoCloud)
+     00.06200s (modules-final/config-keys-to-console)
+     00.03600s (modules-config/config-locale)
+
+2021-09-08 00:56:08 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 2.850s (kernel) + 33.543s (userspace) = 36.393s 
+graphical.target reached after 30.950s in userspace
+=== `systemd-analyze` after:
+Startup finished in 850ms (kernel) + 18.261s (userspace) = 19.112s 
+graphical.target reached after 16.886s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+14.748s snapd.seeded.service
+ 6.426s snapd.apparmor.service
+ 4.877s cloud-init-local.service
+ 4.716s snapd.service
+ 3.681s e2scrub_reap.service
+ 3.059s cloud-init.service
+ 2.371s pollinate.service
+ 1.820s secureboot-db.service
+ 1.642s networkd-dispatcher.service
+ 1.633s rsyslog.service
+=== `systemd-analyze blame` after (first 10 lines):
+10.704s snap.lxd.activate.service
+ 9.876s snapd.service
+ 2.148s cloud-init-local.service
+ 1.705s cloud-init.service
+ 1.595s networkd-dispatcher.service
+ 1.298s cloud-config.service
+ 1.173s udisks2.service
+  972ms lvm2-monitor.service
+  957ms systemd-logind.service
+  929ms dev-sda1.device
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 02.15300 seconds
+Finished stage: (init-network) 01.94400 seconds
+Finished stage: (modules-config) 00.73900 seconds
+Finished stage: (modules-final) 00.21400 seconds
+Total Time: 5.05000 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.85100 seconds
+Finished stage: (init-network) 01.01200 seconds
+Finished stage: (modules-config) 00.44500 seconds
+Finished stage: (modules-final) 00.12300 seconds
+Total Time: 2.43100 seconds
+Finished stage: (init-network) 00.28600 seconds
+Total Time: 0.28600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.56500s (init-network/config-growpart)
+     00.49100s (init-network/config-ssh)
+     00.41700s (modules-config/config-grub-dpkg)
+     00.31900s (init-network/config-users-groups)
+     00.16900s (modules-config/config-apt-configure)
+     00.16400s (init-network/config-resizefs)
+     00.13500s (init-local/search-NoCloud)
+     00.10400s (modules-final/config-keys-to-console)
+     00.07500s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.45500s (init-network/config-ssh)
+     00.27700s (modules-config/config-grub-dpkg)
+     00.13400s (init-network/config-resizefs)
+     00.09300s (modules-config/config-apt-configure)
+     00.09000s (init-network/config-growpart)
+     00.07900s (init-network/config-users-groups)
+     00.07600s (init-local/search-NoCloud)
+     00.06200s (modules-final/config-keys-to-console)
+     00.03600s (modules-config/config-locale)
+
+2021-09-08 00:56:08 DEBUG     pycloudlib.instance:instance.py:200 deleting capital-flounder
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 00:56:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-08 00:56:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a
+user_data=None
+2021-09-08 00:56:10 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a'
+['lxc', 'init', 'ubuntu:840aec22d910cbdba6f88cfb1008397517576d526671634a0eaec8793a0da78a', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 00:56:11 DEBUG     pycloudlib.cloud:cloud.py:275 Created absolute-mongoose
+2021-09-08 00:56:11 DEBUG     pycloudlib.instance:instance.py:394 starting absolute-mongoose
+2021-09-08 00:56:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:56:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:56:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:56:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:56:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:56:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:56:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:56:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:56:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:56:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:57:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:57:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:57:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=absolute-mongoose)
+2021-09-08 00:57:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=absolute-mongoose)
+2021-09-08 00:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 00:57:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:57:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-08 00:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 00:57:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 00:57:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Installing proposed image
+2021-09-08 00:57:07 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-08 00:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:57:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-08 00:57:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:57:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-08 00:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:57:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-08 00:57:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+2021-09-08 00:57:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:57:36 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+Restarting instance and waiting for boot
+2021-09-08 00:57:36 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 00:57:36 DEBUG     pycloudlib.instance:instance.py:296 restarting absolute-mongoose
+2021-09-08 00:58:00 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:58:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:58:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:58:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:58:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:58:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:58:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:58:10 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:58:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:58:10 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 00:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-08 00:58:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-08 00:58:17 DEBUG     pycloudlib.instance:instance.py:200 deleting absolute-mongoose
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 00:58:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 00:58:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 00:58:18 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 00:58:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created apparent-salmon
+2021-09-08 00:58:19 DEBUG     pycloudlib.instance:instance.py:394 starting apparent-salmon
+2021-09-08 00:58:50 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:58:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:58:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:58:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:58:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:58:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:58:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:58:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:58:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:58:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=apparent-salmon)
+2021-09-08 00:59:05 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=apparent-salmon)
+2021-09-08 00:59:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 00:59:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:59:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 00:59:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 00:59:06 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 00:59:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /var/tmp/test_seed_dir && touch /var/tmp/test_seed_dir/user-data && touch /var/tmp/test_seed_dir/meta-data && echo '"'"'seedfrom: /var/tmp/test_seed_dir/'"'"' > /var/lib/cloud/seed/nocloud-net/meta-data'
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpc4ibcbb1 to /var/tmp/bd821f51-3989-4eef-869f-38caabaf687b.tmp
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpc4ibcbb1 to /var/tmp/bd821f51-3989-4eef-869f-38caabaf687b.tmp
+2021-09-08 00:59:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] Opened sftp connection (server version 3)
+2021-09-08 00:59:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/bd821f51-3989-4eef-869f-38caabaf687b.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/bd821f51-3989-4eef-869f-38caabaf687b.tmp /var/tmp/test_seed_dir/vendor-data'
+2021-09-08 00:59:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-08 00:59:06 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 00:59:06 DEBUG     pycloudlib.instance:instance.py:296 restarting apparent-salmon
+2021-09-08 00:59:23 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 00:59:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:59:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:59:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:59:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 00:59:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 00:59:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 00:59:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 00:59:33 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 00:59:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 00:59:33 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 00:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-08 00:59:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-08 00:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /var/tmp'
+2021-09-08 00:59:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /var/tmp'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 00:59:54 DEBUG     pycloudlib.instance:instance.py:200 deleting apparent-salmon
+------------------------------ live log logreport ------------------------------
+2021-09-08 00:59:56 INFO      paramiko.transport.sftp:sftp.py:158 [chan 5] sftp session closed.
+
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 00:59:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+config_dict={'volatile.eth0.hwaddr': '02:00:00:21:4a:13', 'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:21:4a:13\n'}
+2021-09-08 00:59:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+config_dict={'volatile.eth0.hwaddr': '02:00:00:21:4a:13', 'user.network-config': 'version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:21:4a:13\n'}
+2021-09-08 00:59:56 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:21:4a:13', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    dhcp4: true\n    wakeonlan: true\n    match:\n      macaddress: 02:00:00:21:4a:13\n', '--vm']
+2021-09-08 00:59:56 DEBUG     pycloudlib.cloud:cloud.py:275 Created loved-roughy
+2021-09-08 00:59:57 DEBUG     pycloudlib.instance:instance.py:394 starting loved-roughy
+2021-09-08 01:00:19 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:00:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:00:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:00:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:00:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:00:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:00:44 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:00:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:00:44 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=loved-roughy)
+2021-09-08 01:00:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=loved-roughy)
+2021-09-08 01:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:00:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:00:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:00:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:00:53 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:00:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:00:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:00:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:00:53 DEBUG     pycloudlib.instance:instance.py:200 deleting loved-roughy
+
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:00:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:00:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:00:54 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:00:54 DEBUG     pycloudlib.cloud:cloud.py:275 Created diverse-yak
+2021-09-08 01:00:54 DEBUG     pycloudlib.instance:instance.py:394 starting diverse-yak
+2021-09-08 01:01:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:01:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:01:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:01:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:01:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:01:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:01:32 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:01:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:01:32 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=diverse-yak)
+2021-09-08 01:01:38 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=diverse-yak)
+2021-09-08 01:01:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:01:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:01:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:01:38 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpmx_qgrjf to /var/tmp/d31f6649-380c-485b-9304-eb108f906f25.tmp
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpmx_qgrjf to /var/tmp/d31f6649-380c-485b-9304-eb108f906f25.tmp
+2021-09-08 01:01:38 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-08 01:01:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/d31f6649-380c-485b-9304-eb108f906f25.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/d31f6649-380c-485b-9304-eb108f906f25.tmp /etc/cloud/cloud.cfg.d/90_dpkg.cfg'
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpi2ey1301 to /var/tmp/7cdb7809-62e4-43a7-9299-736ac350ff8c.tmp
+2021-09-08 01:01:38 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpi2ey1301 to /var/tmp/7cdb7809-62e4-43a7-9299-736ac350ff8c.tmp
+2021-09-08 01:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/7cdb7809-62e4-43a7-9299-736ac350ff8c.tmp /etc/cloud/ds-identify.cfg'
+2021-09-08 01:01:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/7cdb7809-62e4-43a7-9299-736ac350ff8c.tmp /etc/cloud/ds-identify.cfg'
+2021-09-08 01:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-08 01:01:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-08 01:01:39 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:01:39 DEBUG     pycloudlib.instance:instance.py:296 restarting diverse-yak
+2021-09-08 01:01:55 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:01:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:01:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:01:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:01:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:01:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:01:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:02:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:02:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:02:04 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:02:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:02:04 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:02:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:02:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:02:17 DEBUG     pycloudlib.instance:instance.py:200 deleting diverse-yak
+
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:02:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:02:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+execute_via_ssh=False
+config_dict={'volatile.eth0.hwaddr': '02:00:00:c7:0a:be', 'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:c7:0a:be\n'}
+2021-09-08 01:02:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+execute_via_ssh=False
+config_dict={'volatile.eth0.hwaddr': '02:00:00:c7:0a:be', 'user.network-config': 'version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:c7:0a:be\n'}
+2021-09-08 01:02:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:c7:0a:be', '--config', 'user.network-config=version: 2\nethernets:\n  eth0:\n    addresses: [10.0.0.10/8]\n    dhcp4: false\n    routes:\n    - to: 172.16.0.10/32\n      via: 10.0.0.100\n    match:\n      macaddress: 02:00:00:c7:0a:be\n', '--vm']
+2021-09-08 01:02:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created choice-bird
+2021-09-08 01:02:19 DEBUG     pycloudlib.instance:instance.py:394 starting choice-bird
+2021-09-08 01:02:52 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:02:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:02:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:02:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:02:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=choice-bird)
+2021-09-08 01:03:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=choice-bird)
+2021-09-08 01:03:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:03:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:03:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:03:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:03:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:03:13 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:03:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+2021-09-08 01:03:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip route | grep 172.16.0.10'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:03:14 DEBUG     pycloudlib.instance:instance.py:200 deleting choice-bird
+
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:03:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-08 01:03:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-08 01:03:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-08 01:03:14 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nchef:\n  install_type: omnibus\n  chef_license: accept\n  server_url: https://chef.yourorg.invalid\n  validation_name: some-validator\n', '--vm']
+2021-09-08 01:03:15 DEBUG     pycloudlib.cloud:cloud.py:275 Created enjoyed-maggot
+2021-09-08 01:03:15 DEBUG     pycloudlib.instance:instance.py:394 starting enjoyed-maggot
+2021-09-08 01:03:31 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:03:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:03:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:03:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:03:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:03:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:03:52 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:03:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:03:52 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=enjoyed-maggot)
+2021-09-08 01:04:09 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=enjoyed-maggot)
+2021-09-08 01:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:04:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:04:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:04:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:04:10 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:04:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:04:10 DEBUG     pycloudlib.instance:instance.py:200 deleting enjoyed-maggot
+
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:04:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-08 01:04:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-08 01:04:11 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  sources:\n    cloudinit:\n      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'\n      keyserver: keyserver.ubuntu.com\n      keyid: E4D304DF\n", '--vm']
+2021-09-08 01:04:11 DEBUG     pycloudlib.cloud:cloud.py:275 Created active-sturgeon
+2021-09-08 01:04:11 DEBUG     pycloudlib.instance:instance.py:394 starting active-sturgeon
+2021-09-08 01:04:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:04:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:04:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:04:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:04:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:04:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:04:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:04:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:04:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=active-sturgeon)
+2021-09-08 01:05:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=active-sturgeon)
+2021-09-08 01:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:05:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:05:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:05:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:05:08 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:05:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:05:08 DEBUG     pycloudlib.instance:instance.py:200 deleting active-sturgeon
+
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:05:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-08 01:05:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-08 01:05:09 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n- rm -f /etc/fstab\n', '--vm']
+2021-09-08 01:05:09 DEBUG     pycloudlib.cloud:cloud.py:275 Created factual-aardvark
+2021-09-08 01:05:09 DEBUG     pycloudlib.instance:instance.py:394 starting factual-aardvark
+2021-09-08 01:05:40 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:05:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:05:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:05:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:05:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:05:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:05:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:05:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:05:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:05:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:05:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:05:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=factual-aardvark)
+2021-09-08 01:05:58 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=factual-aardvark)
+2021-09-08 01:05:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:05:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:05:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:05:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:05:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:05:59 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:05:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:05:59 DEBUG     pycloudlib.instance:instance.py:200 deleting factual-aardvark
+
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:06:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-08 01:06:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-08 01:06:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n  - echo 'whoops' > /usr/bin/fallocate\nswap:\n  filename: /swap.img\n  size: 10000000\n  maxsize: 10000000\n", '--vm']
+2021-09-08 01:06:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created eternal-shark
+2021-09-08 01:06:00 DEBUG     pycloudlib.instance:instance.py:394 starting eternal-shark
+2021-09-08 01:06:31 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:06:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:06:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:06:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:06:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:06:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:06:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:06:38 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:06:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:06:38 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=eternal-shark)
+2021-09-08 01:06:46 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=eternal-shark)
+2021-09-08 01:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:06:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:06:46 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:06:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:06:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-08 01:06:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-08 01:06:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+2021-09-08 01:06:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:06:47 DEBUG     pycloudlib.instance:instance.py:200 deleting eternal-shark
+
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:06:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:06:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+execute_via_ssh=False
+config_dict={'volatile.eth0.hwaddr': '02:00:00:41:75:94', 'user.network-config': 'bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:41:75:94\nversion: 2\n'}
+2021-09-08 01:06:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+execute_via_ssh=False
+config_dict={'volatile.eth0.hwaddr': '02:00:00:41:75:94', 'user.network-config': 'bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:41:75:94\nversion: 2\n'}
+2021-09-08 01:06:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:41:75:94', '--config', 'user.network-config=bridges:\n        ovs-br:\n            dhcp4: true\n            interfaces:\n            - enp5s0\n            macaddress: 52:54:00:d9:08:1c\n            mtu: 1500\n            openvswitch: {}\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:41:75:94\nversion: 2\n', '--vm']
+2021-09-08 01:06:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created evolved-sawfish
+2021-09-08 01:06:48 DEBUG     pycloudlib.instance:instance.py:394 starting evolved-sawfish
+2021-09-08 01:07:16 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:07:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:07:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:07:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:07:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=evolved-sawfish)
+2021-09-08 01:07:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=evolved-sawfish)
+2021-09-08 01:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:07:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:07:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:07:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:07:27 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dhclient enp5s0'
+2021-09-08 01:07:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'dhclient enp5s0'
+2021-09-08 01:07:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt update -qqy'
+2021-09-08 01:07:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt update -qqy'
+2021-09-08 01:07:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qqy openvswitch-switch'
+2021-09-08 01:07:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-get install -qqy openvswitch-switch'
+2021-09-08 01:08:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-08 01:08:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-08 01:08:03 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:08:03 DEBUG     pycloudlib.instance:instance.py:296 restarting evolved-sawfish
+2021-09-08 01:08:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:08:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:08:28 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:08:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:08:28 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:08:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:08:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:08:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr'
+2021-09-08 01:08:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip addr'
+2021-09-08 01:08:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip -4 route show default | awk '"'"'{ print $3 }'"'"''
+2021-09-08 01:08:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip -4 route show default | awk '"'"'{ print $3 }'"'"''
+2021-09-08 01:08:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ping -c 1 -W 1 -I ovs-br 10.85.130.1'
+2021-09-08 01:08:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ping -c 1 -W 1 -I ovs-br 10.85.130.1'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:08:47 DEBUG     pycloudlib.instance:instance.py:200 deleting evolved-sawfish
+
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:08:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:08:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:08:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:08:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created supreme-pup
+2021-09-08 01:08:48 DEBUG     pycloudlib.instance:instance.py:394 starting supreme-pup
+2021-09-08 01:09:17 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:09:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:09:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:09:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:09:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:09:22 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:09:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:09:22 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=supreme-pup)
+2021-09-08 01:09:26 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=supreme-pup)
+2021-09-08 01:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:09:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:09:26 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-08 01:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-08 01:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-08 01:09:26 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:09:26 DEBUG     pycloudlib.instance:instance.py:296 restarting supreme-pup
+2021-09-08 01:09:41 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:09:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:09:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:09:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:09:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:09:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:09:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:09:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:09:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:09:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:09:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-08 01:09:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init status'
+2021-09-08 01:09:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-08 01:09:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:09:49 DEBUG     pycloudlib.instance:instance.py:200 deleting supreme-pup
+
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:09:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+2021-09-08 01:09:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+packages:
+- openvswitch-switch
+
+2021-09-08 01:09:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n- openvswitch-switch\n', '--vm']
+2021-09-08 01:09:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created fancy-porpoise
+2021-09-08 01:09:49 DEBUG     pycloudlib.instance:instance.py:394 starting fancy-porpoise
+2021-09-08 01:10:14 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:10:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:10:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:10:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:10:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:10:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:10:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:10:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:10:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:10:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fancy-porpoise)
+2021-09-08 01:10:37 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fancy-porpoise)
+2021-09-08 01:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:10:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:10:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:10:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:10:37 INFO      integration_testing:clouds.py:183 image serial: 20210817
+2021-09-08 01:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:10:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:10:38 DEBUG     pycloudlib.instance:instance.py:331 shutting down fancy-porpoise
+2021-09-08 01:10:40 DEBUG     pycloudlib.instance:instance.py:414 waiting for STOPPED: fancy-porpoise
+2021-09-08 01:10:40 DEBUG     pycloudlib.instance:instance.py:381 Publishing snapshot fancy-porpoise-snapshot
+Created new image: local:fancy-porpoise-snapshot
+2021-09-08 01:12:18 INFO      integration_testing:instances.py:114 Created new image: local:fancy-porpoise-snapshot
+2021-09-08 01:12:18 DEBUG     pycloudlib.instance:instance.py:200 deleting fancy-porpoise
+Launching instance with launch_kwargs:
+image_id=local:fancy-porpoise-snapshot
+user_data=None
+config_dict={'volatile.eth0.hwaddr': '02:00:00:f1:6b:86', 'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:f1:6b:86\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:f1:6b:86\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:f1:6b:86\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n'}
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:12:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:fancy-porpoise-snapshot
+user_data=None
+config_dict={'volatile.eth0.hwaddr': '02:00:00:f1:6b:86', 'user.network-config': 'bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:f1:6b:86\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:f1:6b:86\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:f1:6b:86\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n'}
+2021-09-08 01:12:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:fancy-porpoise-snapshot'
+['lxc', 'init', 'local:fancy-porpoise-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'volatile.eth0.hwaddr=02:00:00:f1:6b:86', '--config', 'user.network-config=bonds:\n    bond0:\n        interfaces:\n            - enp5s0\n        macaddress: 02:00:00:f1:6b:86\n        mtu: 1500\nbridges:\n        ovs-br:\n            interfaces:\n            - bond0\n            macaddress: 02:00:00:f1:6b:86\n            mtu: 1500\n            openvswitch: {}\n            dhcp4: true\nethernets:\n    enp5s0:\n      mtu: 1500\n      set-name: enp5s0\n      match:\n          macaddress: 02:00:00:f1:6b:86\nversion: 2\nvlans:\n  ovs-br.100:\n    id: 100\n    link: ovs-br\n    mtu: 1500\n  ovs-br.200:\n    id: 200\n    link: ovs-br\n    mtu: 1500\n', '--vm']
+2021-09-08 01:13:36 DEBUG     pycloudlib.cloud:cloud.py:275 Created fine-garfish
+2021-09-08 01:13:37 DEBUG     pycloudlib.instance:instance.py:394 starting fine-garfish
+2021-09-08 01:14:03 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:14:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:14:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:14:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:14:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:14:10 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:14:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:14:10 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fine-garfish)
+2021-09-08 01:14:12 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fine-garfish)
+2021-09-08 01:14:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:14:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:14:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:14:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:14:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:14:12 INFO      integration_testing:clouds.py:183 image serial: 20210817
+2021-09-08 01:14:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-08 01:14:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'python3 -c'"'"'from cloudinit.net import get_interfaces_by_mac;get_interfaces_by_mac()'"'"''
+2021-09-08 01:14:12 DEBUG     pycloudlib.instance:instance.py:200 deleting fine-garfish
+PASSEDDeleting snapshot image created for this testrun: local:fancy-porpoise-snapshot
+
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:14:13 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:fancy-porpoise-snapshot
+2021-09-08 01:14:13 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:fancy-porpoise-snapshot'
+2021-09-08 01:14:13 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:fancy-porpoise-snapshot
+
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-08 01:14:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-08 01:14:13 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  conf: |\n    APT {\n        Get {\n            Assume-Yes "true";\n            Fix-Broken "true";\n        }\n    }\n  proxy: "http://proxy.internal:3128"\n  http_proxy: "http://squid.internal:3128"\n  ftp_proxy: "ftp://squid.internal:3128"\n  https_proxy: "https://squid.internal:3128"\n  primary:\n    - arches: [default]\n      uri: http://badarchive.ubuntu.com/ubuntu\n  security:\n    - arches: [default]\n      uri: http://badsecurity.ubuntu.com/ubuntu\n  sources_list: |\n    deb $MIRROR $RELEASE main restricted\n    deb-src $MIRROR $RELEASE main restricted\n    deb $PRIMARY $RELEASE universe restricted\n    deb-src $PRIMARY $RELEASE universe restricted\n    deb $SECURITY $RELEASE-security multiverse\n    deb-src $SECURITY $RELEASE-security multiverse\n  sources:\n    test_keyserver:\n        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937\n        keyserver: keyserver.ubuntu.com\n        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"\n    test_ppa:\n      keyid: 441614D8\n      keyserver: keyserver.ubuntu.com\n      source: "ppa:simplestreams-dev/trunk"\n    test_key:\n      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"\n      key: |\n        -----BEGIN PGP PUBLIC KEY BLOCK-----\n        Version: SKS 1.1.6\n        Comment: Hostname: keyserver.ubuntu.com\n\n        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI\n        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf\n        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq\n        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot\n        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX\n        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6\n        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6\n        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj\n        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l\n        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg\n        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG\n        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN\n        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH\n        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2\n        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj\n        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL\n        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq\n        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH\n        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ\n        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e\n        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf\n        pb0uBy+g0oxJQg15\n        =uy53\n        -----END PGP PUBLIC KEY BLOCK-----\napt_pipelining: os\n', '--vm']
+2021-09-08 01:14:13 DEBUG     pycloudlib.cloud:cloud.py:275 Created sterling-mammal
+2021-09-08 01:14:13 DEBUG     pycloudlib.instance:instance.py:394 starting sterling-mammal
+2021-09-08 01:14:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:14:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:14:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:14:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:14:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:14:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:14:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:14:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:14:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:14:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=sterling-mammal)
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=sterling-mammal)
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-08 01:14:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-08 01:14:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-08 01:14:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-08 01:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+2021-09-08 01:14:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:14:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-08 01:14:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:14:56 DEBUG     pycloudlib.instance:instance.py:200 deleting sterling-mammal
+
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:14:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-08 01:14:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-08 01:14:56 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      \n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-08 01:14:56 DEBUG     pycloudlib.cloud:cloud.py:275 Created apt-barnacle
+2021-09-08 01:14:57 DEBUG     pycloudlib.instance:instance.py:394 starting apt-barnacle
+2021-09-08 01:15:20 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:15:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:15:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:15:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:15:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:15:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:15:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:15:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:15:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:15:26 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:15:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:15:26 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=apt-barnacle)
+2021-09-08 01:15:29 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=apt-barnacle)
+2021-09-08 01:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:15:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:15:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:15:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:15:29 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-08 01:15:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:15:29 DEBUG     pycloudlib.instance:instance.py:200 deleting apt-barnacle
+
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:15:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-08 01:15:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-08 01:15:30 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  primary:\n    - arches:\n      - default\n      uri: "http://something.random.invalid/ubuntu"\n  security:\n    - arches:\n      - default\n', '--vm']
+2021-09-08 01:15:30 DEBUG     pycloudlib.cloud:cloud.py:275 Created legal-gopher
+2021-09-08 01:15:30 DEBUG     pycloudlib.instance:instance.py:394 starting legal-gopher
+2021-09-08 01:15:42 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:15:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:15:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:15:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:15:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:15:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:15:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:15:56 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:15:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:15:56 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=legal-gopher)
+2021-09-08 01:16:00 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=legal-gopher)
+2021-09-08 01:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:16:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:16:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:16:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:16:00 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+2021-09-08 01:16:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:16:00 DEBUG     pycloudlib.instance:instance.py:200 deleting legal-gopher
+
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:16:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-08 01:16:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-08 01:16:01 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\napt:\n  disable_suites:\n  - $RELEASE\n  - $RELEASE-updates\n  - $RELEASE-backports\n  - $RELEASE-security\napt_pipelining: false\n', '--vm']
+2021-09-08 01:16:01 DEBUG     pycloudlib.cloud:cloud.py:275 Created flowing-turtle
+2021-09-08 01:16:01 DEBUG     pycloudlib.instance:instance.py:394 starting flowing-turtle
+2021-09-08 01:16:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:16:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:16:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:16:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:16:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:16:27 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:16:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:16:27 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=flowing-turtle)
+2021-09-08 01:16:30 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=flowing-turtle)
+2021-09-08 01:16:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:16:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:16:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:16:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:16:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:16:31 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:16:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+2021-09-08 01:16:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:16:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:16:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+2021-09-08 01:16:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:16:31 DEBUG     pycloudlib.instance:instance.py:200 deleting flowing-turtle
+
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:16:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-08 01:16:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-08 01:16:31 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nca-certs:\n  remove-defaults: true\n  trusted:\n    - |\n      -----BEGIN CERTIFICATE-----\n      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx\n      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP\n      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl\n      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW\n      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz\n      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93\n      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl\n      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG\n      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc\n      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ\n      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX\n      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6\n      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2\n      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S\n      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o\n      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4\n      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF\n      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1\n      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3\n      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT\n      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5\n      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3\n      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr\n      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf\n      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ\n      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM\n      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L\n      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT\n      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro\n      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586\n      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l\n      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i\n      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==\n      -----END CERTIFICATE-----\n', '--vm']
+2021-09-08 01:16:32 DEBUG     pycloudlib.cloud:cloud.py:275 Created known-frog
+2021-09-08 01:16:32 DEBUG     pycloudlib.instance:instance.py:394 starting known-frog
+2021-09-08 01:16:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:16:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:16:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:16:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:16:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:17:00 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:17:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:17:00 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=known-frog)
+2021-09-08 01:17:03 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=known-frog)
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:17:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:17:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:17:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:17:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+2021-09-08 01:17:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:17:04 DEBUG     pycloudlib.instance:instance.py:200 deleting known-frog
+
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:17:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-08 01:17:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-08 01:17:04 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nruncmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-08 01:17:04 DEBUG     pycloudlib.cloud:cloud.py:275 Created oriented-serval
+2021-09-08 01:17:04 DEBUG     pycloudlib.instance:instance.py:394 starting oriented-serval
+2021-09-08 01:17:29 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:17:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:17:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:17:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:17:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:17:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:17:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:17:34 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:17:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:17:34 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=oriented-serval)
+2021-09-08 01:17:36 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=oriented-serval)
+2021-09-08 01:17:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:17:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:17:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:17:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:17:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:17:37 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:17:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-08 01:17:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:17:37 DEBUG     pycloudlib.instance:instance.py:200 deleting oriented-serval
+
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:17:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-08 01:17:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-08 01:17:38 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=runcmd:\n  - echo 'hi' > /var/tmp/test\n", '--vm']
+2021-09-08 01:17:38 DEBUG     pycloudlib.cloud:cloud.py:275 Created driven-kitten
+2021-09-08 01:17:38 DEBUG     pycloudlib.instance:instance.py:394 starting driven-kitten
+2021-09-08 01:17:50 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:17:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:17:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:18:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:18:07 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:18:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:18:07 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=driven-kitten)
+2021-09-08 01:18:10 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=driven-kitten)
+2021-09-08 01:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:18:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:18:10 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+2021-09-08 01:18:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:18:10 DEBUG     pycloudlib.instance:instance.py:200 deleting driven-kitten
+
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-08 01:18:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-08 01:18:11 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\napt:\n  primary:\n    - arches: [default]\n      uri: http://us.archive.ubuntu.com/ubuntu/\nbyobu_by_default: enable\nfinal_message: |\n  This is my final message!\n  $version\n  $timestamp\n  $datasource\n  $uptime\nlocale: en_GB.UTF-8\nlocale_configfile: /etc/default/locale\nntp:\n  servers: ['ntp.ubuntu.com']\nruncmd:\n  - echo 'hello world' > /var/tmp/runcmd_output\n", '--vm']
+2021-09-08 01:18:11 DEBUG     pycloudlib.cloud:cloud.py:275 Created honest-glider
+2021-09-08 01:18:11 DEBUG     pycloudlib.instance:instance.py:394 starting honest-glider
+2021-09-08 01:18:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:18:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:18:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:18:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:18:40 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:18:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:18:40 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=honest-glider)
+2021-09-08 01:18:44 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=honest-glider)
+2021-09-08 01:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:18:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:18:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:18:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'locale -a'
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:18:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /run/cloud-init/instance-data.json'
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:18:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:18:45 DEBUG     pycloudlib.instance:instance.py:200 deleting honest-glider
+
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:18:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-08 01:18:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-08 01:18:46 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\noutput: { all: "| tee -a /var/log/cloud-init-test-output" }\nfinal_message: "should be last line in cloud-init-test-output file"\n', '--vm']
+2021-09-08 01:18:46 DEBUG     pycloudlib.cloud:cloud.py:275 Created game-chimp
+2021-09-08 01:18:46 DEBUG     pycloudlib.instance:instance.py:394 starting game-chimp
+2021-09-08 01:18:58 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:18:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:18:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:19:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:19:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:19:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:19:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:19:14 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:19:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:19:14 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=game-chimp)
+2021-09-08 01:19:16 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=game-chimp)
+2021-09-08 01:19:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:19:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:19:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:19:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:19:17 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+2021-09-08 01:19:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:19:17 DEBUG     pycloudlib.instance:instance.py:200 deleting game-chimp
+
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:19:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+2021-09-08 01:19:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+device_aliases:
+  my_alias: /dev/sdb
+disk_setup:
+  my_alias:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+- label: fs1
+  device: my_alias.1
+  filesystem: ext4
+- label: fs2
+  device: my_alias.2
+  filesystem: ext4
+mounts:
+- ["my_alias.1", "/mnt1"]
+- ["my_alias.2", "/mnt2"]
+
+2021-09-08 01:19:17 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndevice_aliases:\n  my_alias: /dev/sdb\ndisk_setup:\n  my_alias:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n- label: fs1\n  device: my_alias.1\n  filesystem: ext4\n- label: fs2\n  device: my_alias.2\n  filesystem: ext4\nmounts:\n- ["my_alias.1", "/mnt1"]\n- ["my_alias.2", "/mnt2"]\n', '--vm']
+2021-09-08 01:19:18 DEBUG     pycloudlib.cloud:cloud.py:275 Created ethical-trout
+Running callback specified by 'lxd_setup' mark
+2021-09-08 01:19:18 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-08 01:19:18 DEBUG     pycloudlib.instance:instance.py:394 starting ethical-trout
+2021-09-08 01:19:41 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:19:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:19:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:19:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:19:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:19:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:19:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:19:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:19:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:19:47 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:19:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:19:47 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=ethical-trout)
+2021-09-08 01:19:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ethical-trout)
+2021-09-08 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:19:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:19:49 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:19:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-08 01:19:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:19:49 DEBUG     pycloudlib.instance:instance.py:200 deleting ethical-trout
+
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:19:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-08 01:19:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-08 01:19:50 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisk_setup:\n  /dev/sdb:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n  - label: test\n    device: /dev/sdb1\n    filesystem: ext4\n  - label: test2\n    device: /dev/sdb2\n    filesystem: ext4\nmounts:\n- ["/dev/sdb1", "/mnt1"]\n- ["/dev/sdb2", "/mnt2"]\n', '--vm']
+2021-09-08 01:19:50 DEBUG     pycloudlib.cloud:cloud.py:275 Created glowing-chow
+Running callback specified by 'lxd_setup' mark
+2021-09-08 01:19:50 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-08 01:19:50 DEBUG     pycloudlib.instance:instance.py:394 starting glowing-chow
+2021-09-08 01:20:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:20:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:20:22 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:20:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:20:22 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=glowing-chow)
+2021-09-08 01:20:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=glowing-chow)
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:20:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:20:24 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmp3r517_8i to /var/tmp/5cb12b28-d75a-4960-be40-e302af137b04.tmp
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmp3r517_8i to /var/tmp/5cb12b28-d75a-4960-be40-e302af137b04.tmp
+2021-09-08 01:20:24 INFO      paramiko.transport.sftp:sftp.py:158 [chan 6] Opened sftp connection (server version 3)
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/5cb12b28-d75a-4960-be40-e302af137b04.tmp /var/lib/cloud/seed/nocloud-net/user-data'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/5cb12b28-d75a-4960-be40-e302af137b04.tmp /var/lib/cloud/seed/nocloud-net/user-data'
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/write-files/write-files\n - mounts/'"'"' /etc/cloud/cloud.cfg'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sed -i '"'"'s/write-files/write-files\n - mounts/'"'"' /etc/cloud/cloud.cfg'
+2021-09-08 01:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-08 01:20:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-08 01:20:25 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:20:25 DEBUG     pycloudlib.instance:instance.py:296 restarting glowing-chow
+2021-09-08 01:20:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:20:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:40 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:20:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:20:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:20:42 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:20:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:20:42 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:20:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-08 01:20:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:20:44 DEBUG     pycloudlib.instance:instance.py:200 deleting glowing-chow
+------------------------------ live log logreport ------------------------------
+2021-09-08 01:20:45 INFO      paramiko.transport.sftp:sftp.py:158 [chan 6] sftp session closed.
+
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:20:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-08 01:20:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disk_setup:
+  /dev/sdb:
+    table_type: mbr
+    layout: [50, 50]
+    overwrite: True
+fs_setup:
+  - label: test
+    device: /dev/sdb1
+    filesystem: ext4
+  - label: test2
+    device: /dev/sdb2
+    filesystem: ext4
+mounts:
+- ["/dev/sdb1", "/mnt1"]
+- ["/dev/sdb2", "/mnt2"]
+
+2021-09-08 01:20:45 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisk_setup:\n  /dev/sdb:\n    table_type: mbr\n    layout: [50, 50]\n    overwrite: True\nfs_setup:\n  - label: test\n    device: /dev/sdb1\n    filesystem: ext4\n  - label: test2\n    device: /dev/sdb2\n    filesystem: ext4\nmounts:\n- ["/dev/sdb1", "/mnt1"]\n- ["/dev/sdb2", "/mnt2"]\n', '--vm']
+2021-09-08 01:20:45 DEBUG     pycloudlib.cloud:cloud.py:275 Created blessed-ocelot
+Running callback specified by 'lxd_setup' mark
+2021-09-08 01:20:45 INFO      integration_testing:clouds.py:321 Running callback specified by 'lxd_setup' mark
+2021-09-08 01:20:45 DEBUG     pycloudlib.instance:instance.py:394 starting blessed-ocelot
+2021-09-08 01:20:58 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:20:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:20:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:21:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:21:15 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:21:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:21:15 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=blessed-ocelot)
+2021-09-08 01:21:17 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=blessed-ocelot)
+2021-09-08 01:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:21:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:21:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:21:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:21:17 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-08 01:21:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm $(which partprobe)'
+2021-09-08 01:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init clean --logs'
+2021-09-08 01:21:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init clean --logs'
+Restarting instance and waiting for boot
+2021-09-08 01:21:17 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:21:17 DEBUG     pycloudlib.instance:instance.py:296 restarting blessed-ocelot
+2021-09-08 01:21:30 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:21:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:21:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:21:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:21:36 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:21:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:21:36 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:21:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lsblk --json'
+2021-09-08 01:21:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lsblk --json'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:21:38 DEBUG     pycloudlib.instance:instance.py:200 deleting blessed-ocelot
+
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:21:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-08 01:21:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-08 01:21:39 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=## template: jinja\n#cloud-config\nruncmd:\n  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output\n  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output\n', '--vm']
+2021-09-08 01:21:39 DEBUG     pycloudlib.cloud:cloud.py:275 Created climbing-koala
+2021-09-08 01:21:39 DEBUG     pycloudlib.instance:instance.py:394 starting climbing-koala
+2021-09-08 01:21:51 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:21:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:22:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:22:05 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:22:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:22:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:22:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:22:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:22:08 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:22:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:22:08 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=climbing-koala)
+2021-09-08 01:22:11 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=climbing-koala)
+2021-09-08 01:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:22:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:22:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:22:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:22:11 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 01:22:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-08 01:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+2021-09-08 01:22:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:22:11 DEBUG     pycloudlib.instance:instance.py:200 deleting climbing-koala
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:22:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-08 01:22:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-08 01:22:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\nssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-08 01:22:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created knowing-locust
+2021-09-08 01:22:12 DEBUG     pycloudlib.instance:instance.py:394 starting knowing-locust
+2021-09-08 01:22:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:22:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:22:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:22:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:22:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:22:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:22:38 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:22:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:22:38 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=knowing-locust)
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=knowing-locust)
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:22:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:22:41 DEBUG     pycloudlib.instance:instance.py:200 deleting knowing-locust
+
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:22:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-08 01:22:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-08 01:22:42 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]\n', '--vm']
+2021-09-08 01:22:42 DEBUG     pycloudlib.cloud:cloud.py:275 Created striking-lemming
+2021-09-08 01:22:42 DEBUG     pycloudlib.instance:instance.py:394 starting striking-lemming
+2021-09-08 01:22:54 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:22:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:22:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:23:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:23:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:23:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:23:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:23:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:23:11 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:23:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:23:11 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=striking-lemming)
+2021-09-08 01:23:13 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=striking-lemming)
+2021-09-08 01:23:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:23:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:23:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:23:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:23:14 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:23:14 DEBUG     pycloudlib.instance:instance.py:200 deleting striking-lemming
+
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-08 01:23:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-08 01:23:14 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh:\n  emit_keys_to_console: false\n', '--vm']
+2021-09-08 01:23:14 DEBUG     pycloudlib.cloud:cloud.py:275 Created amused-yak
+2021-09-08 01:23:15 DEBUG     pycloudlib.instance:instance.py:394 starting amused-yak
+2021-09-08 01:23:27 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:23:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:23:27 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:23:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:23:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:23:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:23:40 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:23:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:23:40 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=amused-yak)
+2021-09-08 01:23:43 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=amused-yak)
+2021-09-08 01:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:23:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:23:44 DEBUG     pycloudlib.instance:instance.py:200 deleting amused-yak
+
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:23:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-08 01:23:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-08 01:23:45 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nlxd:\n  init:\n    storage_backend: dir\n  bridge:\n    mode: new\n    name: lxdbr0\n    ipv4_address: 10.100.100.1\n    ipv4_netmask: 24\n    ipv4_dhcp_first: 10.100.100.100\n    ipv4_dhcp_last: 10.100.100.200\n    ipv4_nat: true\n    domain: lxd\n', '--vm']
+2021-09-08 01:23:45 DEBUG     pycloudlib.cloud:cloud.py:275 Created real-bengal
+2021-09-08 01:23:45 DEBUG     pycloudlib.instance:instance.py:394 starting real-bengal
+2021-09-08 01:24:08 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:24:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:24:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:24:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:24:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:24:12 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:24:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:24:12 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=real-bengal)
+2021-09-08 01:24:24 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=real-bengal)
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:24:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:24:24 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:24:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:24:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-08 01:24:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+2021-09-08 01:24:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:24:25 DEBUG     pycloudlib.instance:instance.py:200 deleting real-bengal
+
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:24:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-08 01:24:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-08 01:24:25 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  servers:\n      - 172.16.15.14\n      - 172.16.17.18\n  pools:\n      - 0.cloud-init.mypool\n      - 1.cloud-init.mypool\n      - 172.16.15.15\n', '--vm']
+2021-09-08 01:24:25 DEBUG     pycloudlib.cloud:cloud.py:275 Created harmless-ram
+2021-09-08 01:24:25 DEBUG     pycloudlib.instance:instance.py:394 starting harmless-ram
+2021-09-08 01:24:38 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:24:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:24:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:24:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:24:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:24:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:24:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:24:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:24:54 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:24:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:24:54 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=harmless-ram)
+2021-09-08 01:25:06 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=harmless-ram)
+2021-09-08 01:25:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:25:06 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:25:07 DEBUG     pycloudlib.instance:instance.py:200 deleting harmless-ram
+
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-08 01:25:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-08 01:25:08 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: chrony\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-08 01:25:08 DEBUG     pycloudlib.cloud:cloud.py:275 Created faithful-swan
+2021-09-08 01:25:08 DEBUG     pycloudlib.instance:instance.py:394 starting faithful-swan
+2021-09-08 01:25:20 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:25:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:25:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:25:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:25:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:25:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:25:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:25:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:25:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:25:37 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:25:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:25:37 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=faithful-swan)
+2021-09-08 01:25:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=faithful-swan)
+2021-09-08 01:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:25:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:25:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:25:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:25:48 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-08 01:25:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-08 01:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+2021-09-08 01:25:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:25:48 DEBUG     pycloudlib.instance:instance.py:200 deleting faithful-swan
+
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:25:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-08 01:25:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-08 01:25:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  enabled: true\n  ntp_client: systemd-timesyncd\n  servers:\n      - 172.16.15.14\n', '--vm']
+2021-09-08 01:25:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created ethical-barnacle
+2021-09-08 01:25:49 DEBUG     pycloudlib.instance:instance.py:394 starting ethical-barnacle
+2021-09-08 01:26:02 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:26:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:26:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:26:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:26:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:26:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:26:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:26:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:26:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=ethical-barnacle)
+2021-09-08 01:26:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ethical-barnacle)
+2021-09-08 01:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:26:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:26:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:26:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:26:20 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+2021-09-08 01:26:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:26:20 DEBUG     pycloudlib.instance:instance.py:200 deleting ethical-barnacle
+
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:26:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-08 01:26:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-08 01:26:21 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nntp:\n  ntp_client: ntp\n  pools: []\n  servers: []\n', '--vm']
+2021-09-08 01:26:21 DEBUG     pycloudlib.cloud:cloud.py:275 Created rational-bluegill
+2021-09-08 01:26:21 DEBUG     pycloudlib.instance:instance.py:394 starting rational-bluegill
+2021-09-08 01:26:33 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:26:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:26:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:26:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:26:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:26:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:26:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:26:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:26:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:26:50 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:26:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:26:50 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=rational-bluegill)
+2021-09-08 01:27:02 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=rational-bluegill)
+2021-09-08 01:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:27:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:27:02 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ntpd --version'
+2021-09-08 01:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-08 01:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:27:02 DEBUG     pycloudlib.instance:instance.py:200 deleting rational-bluegill
+
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:27:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-08 01:27:03 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-08 01:27:03 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackages:\n  - sl\n  - tree\npackage_update: true\npackage_upgrade: true\n', '--vm']
+2021-09-08 01:27:03 DEBUG     pycloudlib.cloud:cloud.py:275 Created ample-polecat
+2021-09-08 01:27:03 DEBUG     pycloudlib.instance:instance.py:394 starting ample-polecat
+2021-09-08 01:27:15 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:27:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:27:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:27:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:27:29 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:27:30 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:27:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:27:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:27:32 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:27:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:27:32 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=ample-polecat)
+2021-09-08 01:28:14 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=ample-polecat)
+2021-09-08 01:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:28:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:28:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:28:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:28:15 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+2021-09-08 01:28:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+2021-09-08 01:28:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-08 01:28:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:28:15 DEBUG     pycloudlib.instance:instance.py:200 deleting ample-polecat
+
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-08 01:28:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-08 01:28:16 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nrandom_seed:\n  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'\n  encoding: raw\n  file: /root/seed\n", '--vm']
+2021-09-08 01:28:16 DEBUG     pycloudlib.cloud:cloud.py:275 Created fun-spider
+2021-09-08 01:28:16 DEBUG     pycloudlib.instance:instance.py:394 starting fun-spider
+2021-09-08 01:28:39 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:28:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:28:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:28:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:28:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:28:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:28:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:28:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:28:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fun-spider)
+2021-09-08 01:28:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fun-spider)
+2021-09-08 01:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:28:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:28:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:28:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:28:48 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+2021-09-08 01:28:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:28:48 DEBUG     pycloudlib.instance:instance.py:200 deleting fun-spider
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:28:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-08 01:28:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-08 01:28:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nhostname: cloudinit2\n', '--vm']
+2021-09-08 01:28:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created evident-chipmunk
+2021-09-08 01:28:49 DEBUG     pycloudlib.instance:instance.py:394 starting evident-chipmunk
+2021-09-08 01:29:01 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:29:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:29:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:29:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:29:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:29:15 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:29:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:29:15 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=evident-chipmunk)
+2021-09-08 01:29:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=evident-chipmunk)
+2021-09-08 01:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:29:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:29:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:29:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:29:18 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 01:29:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:29:18 DEBUG     pycloudlib.instance:instance.py:200 deleting evident-chipmunk
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:29:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-08 01:29:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-08 01:29:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: True\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-08 01:29:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created communal-beagle
+2021-09-08 01:29:19 DEBUG     pycloudlib.instance:instance.py:394 starting communal-beagle
+2021-09-08 01:29:31 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:29:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:29:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:29:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:29:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:29:45 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:29:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:29:45 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=communal-beagle)
+2021-09-08 01:29:48 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=communal-beagle)
+2021-09-08 01:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:29:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:29:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:29:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:29:48 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 01:29:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:29:49 DEBUG     pycloudlib.instance:instance.py:200 deleting communal-beagle
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:29:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-08 01:29:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-08 01:29:49 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nprefer_fqdn_over_hostname: False\nhostname: cloudinit1\nfqdn: cloudinit2.test.io\n', '--vm']
+2021-09-08 01:29:49 DEBUG     pycloudlib.cloud:cloud.py:275 Created caring-spaniel
+2021-09-08 01:29:49 DEBUG     pycloudlib.instance:instance.py:394 starting caring-spaniel
+2021-09-08 01:30:02 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:30:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:30:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:30:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:30:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:30:15 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:30:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:30:15 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=caring-spaniel)
+2021-09-08 01:30:18 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=caring-spaniel)
+2021-09-08 01:30:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:30:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:30:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:30:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:30:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:30:19 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:30:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 01:30:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:30:19 DEBUG     pycloudlib.instance:instance.py:200 deleting caring-spaniel
+
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:30:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-08 01:30:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-08 01:30:19 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nmanage_etc_hosts: true\nhostname: cloudinit1\nfqdn: cloudinit2.i9n.cloud-init.io\n', '--vm']
+2021-09-08 01:30:19 DEBUG     pycloudlib.cloud:cloud.py:275 Created pet-stag
+2021-09-08 01:30:20 DEBUG     pycloudlib.instance:instance.py:394 starting pet-stag
+2021-09-08 01:30:32 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:30:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:30:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:30:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:30:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:30:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:30:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:30:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:30:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=pet-stag)
+2021-09-08 01:30:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=pet-stag)
+2021-09-08 01:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:30:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:30:50 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c hostname
+2021-09-08 01:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-08 01:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:30:50 DEBUG     pycloudlib.instance:instance.py:200 deleting pet-stag
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:30:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-08 01:30:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-08 01:30:51 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n  list:\n    - tom:mypassword123!\n    - dick:RANDOM\n    - harry:RANDOM\n    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-08 01:30:51 DEBUG     pycloudlib.cloud:cloud.py:275 Created humble-adder
+2021-09-08 01:30:51 DEBUG     pycloudlib.instance:instance.py:394 starting humble-adder
+2021-09-08 01:31:03 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:31:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:31:23 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:31:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:31:23 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=humble-adder)
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humble-adder)
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 getting console log for humble-adder
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-08 01:31:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:31:26 DEBUG     pycloudlib.instance:instance.py:200 deleting humble-adder
+
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-08 01:31:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-08 01:31:26 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_pwauth: yes\nusers:\n  - default\n  - name: tom\n    # md5 gotomgo\n    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"\n    lock_passwd: false\n  - name: dick\n    # md5 gocubsgo\n    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"\n    lock_passwd: false\n  - name: harry\n    # sha512 goharrygo\n    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"\n    lock_passwd: false\n  - name: jane\n    # sha256 gojanego\n    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."\n    lock_passwd: false\n  - name: "mikey"\n    lock_passwd: false\n\nchpasswd:\n    list: |\n      tom:mypassword123!\n      dick:RANDOM\n      harry:RANDOM\n      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89\n', '--vm']
+2021-09-08 01:31:26 DEBUG     pycloudlib.cloud:cloud.py:275 Created gorgeous-parakeet
+2021-09-08 01:31:26 DEBUG     pycloudlib.instance:instance.py:394 starting gorgeous-parakeet
+2021-09-08 01:31:39 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:31:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:39 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:31:54 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:31:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:31:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:31:57 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:31:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:31:57 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=gorgeous-parakeet)
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=gorgeous-parakeet)
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:31:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:31:59 DEBUG     pycloudlib.instance:instance.py:179 getting console log for gorgeous-parakeet
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:32:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:32:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:32:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+2021-09-08 01:32:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:32:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-08 01:32:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:32:00 DEBUG     pycloudlib.instance:instance.py:200 deleting gorgeous-parakeet
+
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:32:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-08 01:32:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-08 01:32:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\npackage_update: true\nsnap:\n  squashfuse_in_container: true\n  commands:\n    - snap install hello-world\n', '--vm']
+2021-09-08 01:32:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created resolved-heron
+2021-09-08 01:32:01 DEBUG     pycloudlib.instance:instance.py:394 starting resolved-heron
+2021-09-08 01:32:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:32:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:32:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:32:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:32:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:32:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:32:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:32:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:32:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=resolved-heron)
+2021-09-08 01:32:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=resolved-heron)
+2021-09-08 01:32:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:32:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:32:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:32:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:32:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:32:49 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:32:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+2021-09-08 01:32:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'snap list'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:32:49 DEBUG     pycloudlib.instance:instance.py:200 deleting resolved-heron
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:32:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-08 01:32:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-08 01:32:50 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nno_ssh_fingerprints: true\n', '--vm']
+2021-09-08 01:32:50 DEBUG     pycloudlib.cloud:cloud.py:275 Created wired-tapir
+2021-09-08 01:32:50 DEBUG     pycloudlib.instance:instance.py:394 starting wired-tapir
+2021-09-08 01:33:13 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:33:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:33:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:33:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:33:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:33:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:33:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:33:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:33:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:33:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=wired-tapir)
+2021-09-08 01:33:20 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=wired-tapir)
+2021-09-08 01:33:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:33:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:33:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:33:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:33:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:33:20 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:33:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:33:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:33:20 DEBUG     pycloudlib.instance:instance.py:200 deleting wired-tapir
+
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:33:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-08 01:33:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-08 01:33:21 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\n', '--vm']
+2021-09-08 01:33:21 DEBUG     pycloudlib.cloud:cloud.py:275 Created current-krill
+2021-09-08 01:33:21 DEBUG     pycloudlib.instance:instance.py:394 starting current-krill
+2021-09-08 01:33:44 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:33:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:33:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:33:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:33:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:33:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:33:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:33:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=current-krill)
+2021-09-08 01:33:50 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=current-krill)
+2021-09-08 01:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:33:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:33:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:33:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:33:50 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+2021-09-08 01:33:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:33:50 DEBUG     pycloudlib.instance:instance.py:200 deleting current-krill
+
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:33:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-08 01:33:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-08 01:33:51 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_genkeytypes:\n  - ecdsa\n  - ed25519\nauthkey_hash: sha512\n', '--vm']
+2021-09-08 01:33:51 DEBUG     pycloudlib.cloud:cloud.py:275 Created fit-ostrich
+2021-09-08 01:33:51 DEBUG     pycloudlib.instance:instance.py:394 starting fit-ostrich
+2021-09-08 01:34:03 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:34:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:34:03 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:34:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:34:15 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:34:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:34:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:34:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:34:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:34:19 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:34:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:34:19 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=fit-ostrich)
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=fit-ostrich)
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-08 01:34:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-08 01:34:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-08 01:34:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:34:22 DEBUG     pycloudlib.instance:instance.py:200 deleting fit-ostrich
+
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-08 01:34:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-08 01:34:22 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nssh_import_id:\n  - gh:powersj\n  - lp:smoser\n', '--vm']
+2021-09-08 01:34:22 DEBUG     pycloudlib.cloud:cloud.py:275 Created equipped-cowbird
+2021-09-08 01:34:22 DEBUG     pycloudlib.instance:instance.py:394 starting equipped-cowbird
+2021-09-08 01:34:35 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:34:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:34:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:34:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:34:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:34:48 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:34:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:34:48 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=equipped-cowbird)
+2021-09-08 01:34:52 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=equipped-cowbird)
+2021-09-08 01:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:34:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:34:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:34:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:34:52 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-08 01:34:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:34:52 DEBUG     pycloudlib.instance:instance.py:200 deleting equipped-cowbird
+
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:34:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-08 01:34:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-08 01:34:53 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ndisable_root: false\nssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==\nssh_keys:\n  rsa_private: |\n    -----BEGIN RSA PRIVATE KEY-----\n    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj\n    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9\n    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y\n    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu\n    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c\n    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5\n    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw\n    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm\n    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl\n    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA\n    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ\n    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu\n    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP\n    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN\n    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW\n    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N\n    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr\n    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN\n    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO\n    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR\n    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A\n    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW\n    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2\n    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+\n    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE\n    -----END RSA PRIVATE KEY-----\n  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd\n  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd\n  dsa_private: |\n    -----BEGIN DSA PRIVATE KEY-----\n    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP\n    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d\n    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i\n    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE\n    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI\n    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED\n    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf\n    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E\n    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW\n    nCPOXEQsayANi8+Cb7BH\n    -----END DSA PRIVATE KEY-----\n  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd\n  ed25519_private: |\n    -----BEGIN OPENSSH PRIVATE KEY-----\n    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp\n    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q\n    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg\n    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==\n    -----END OPENSSH PRIVATE KEY-----\n  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd\n  ecdsa_private: |\n    -----BEGIN EC PRIVATE KEY-----\n    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49\n    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb\n    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==\n    -----END EC PRIVATE KEY-----\n  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd\n', '--vm']
+2021-09-08 01:34:53 DEBUG     pycloudlib.cloud:cloud.py:275 Created happy-pheasant
+2021-09-08 01:34:53 DEBUG     pycloudlib.instance:instance.py:394 starting happy-pheasant
+2021-09-08 01:35:16 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:18 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:35:20 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:35:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:35:20 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=happy-pheasant)
+2021-09-08 01:35:22 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=happy-pheasant)
+2021-09-08 01:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:35:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:35:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:35:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:35:23 DEBUG     pycloudlib.instance:instance.py:200 deleting happy-pheasant
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:35:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:35:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:35:24 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nbootcmd:\n - ""\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n', '--vm']
+2021-09-08 01:35:24 DEBUG     pycloudlib.cloud:cloud.py:275 Created uncommon-lark
+2021-09-08 01:35:24 DEBUG     pycloudlib.instance:instance.py:394 starting uncommon-lark
+2021-09-08 01:35:47 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:48 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:35:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:35:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:35:53 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:35:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:35:53 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=uncommon-lark)
+2021-09-08 01:35:55 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=uncommon-lark)
+2021-09-08 01:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:35:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:35:55 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-08 01:35:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-08 01:35:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-08 01:35:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-08 01:35:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-08 01:35:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:35:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-08 01:35:56 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-08 01:35:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:35:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:58 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:35:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-08 01:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:35:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:36:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:36:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-08 01:36:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:36:00 DEBUG     pycloudlib.instance:instance.py:200 deleting uncommon-lark
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:36:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:36:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:36:00 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-08 01:36:00 DEBUG     pycloudlib.cloud:cloud.py:275 Created useful-haddock
+2021-09-08 01:36:01 DEBUG     pycloudlib.instance:instance.py:394 starting useful-haddock
+2021-09-08 01:36:24 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:36:24 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:36:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:36:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:36:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:36:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:36:29 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:36:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:36:29 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=useful-haddock)
+2021-09-08 01:36:31 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=useful-haddock)
+2021-09-08 01:36:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:36:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:36:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:36:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:36:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:36:31 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:36:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-08 01:36:31 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-08 01:36:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-08 01:36:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-08 01:36:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-08 01:36:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-08 01:36:34 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:36:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-08 01:36:35 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:36:36 DEBUG     pycloudlib.instance:instance.py:200 deleting useful-haddock
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:36:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:36:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:36:36 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-08 01:36:36 DEBUG     pycloudlib.cloud:cloud.py:275 Created upward-worm
+2021-09-08 01:36:36 DEBUG     pycloudlib.instance:instance.py:394 starting upward-worm
+2021-09-08 01:37:00 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:00 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:37:04 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:37:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:37:04 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=upward-worm)
+2021-09-08 01:37:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=upward-worm)
+2021-09-08 01:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:37:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:37:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:37:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:37:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:37:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-08 01:37:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-08 01:37:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-08 01:37:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-08 01:37:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-08 01:37:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:37:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-08 01:37:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-08 01:37:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-08 01:37:09 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:37:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-08 01:37:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:37:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:37:11 DEBUG     pycloudlib.instance:instance.py:200 deleting upward-worm
+
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:37:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:37:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-08 01:37:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', "user.user-data=#cloud-config\nbootcmd:\n - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host\n\nusers:\n- default\n- name: test_user1\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host\n\n- name: test_user2\n  ssh_authorized_keys:\n    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host\n\n", '--vm']
+2021-09-08 01:37:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created driving-dinosaur
+2021-09-08 01:37:12 DEBUG     pycloudlib.instance:instance.py:394 starting driving-dinosaur
+2021-09-08 01:37:36 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:37:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:37:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:37:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:37:40 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:37:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:37:40 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=driving-dinosaur)
+2021-09-08 01:37:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=driving-dinosaur)
+2021-09-08 01:37:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:37:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:37:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:37:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:37:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:37:43 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:37:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-08 01:37:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-08 01:37:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-08 01:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-08 01:37:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-08 01:37:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-08 01:37:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-08 01:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-08 01:37:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-08 01:37:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-08 01:37:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-08 01:37:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-08 01:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-08 01:37:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:37:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-08 01:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+2021-09-08 01:37:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:37:48 DEBUG     pycloudlib.instance:instance.py:200 deleting driving-dinosaur
+
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:37:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-08 01:37:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-08 01:37:48 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\ntimezone: US/Aleutian\n', '--vm']
+2021-09-08 01:37:48 DEBUG     pycloudlib.cloud:cloud.py:275 Created primary-haddock
+2021-09-08 01:37:48 DEBUG     pycloudlib.instance:instance.py:394 starting primary-haddock
+2021-09-08 01:38:12 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:38:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:14 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:38:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:38:17 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:38:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:38:17 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=primary-haddock)
+2021-09-08 01:38:19 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=primary-haddock)
+2021-09-08 01:38:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:38:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:38:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:38:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:38:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:38:19 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:38:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+2021-09-08 01:38:19 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:38:19 DEBUG     pycloudlib.instance:instance.py:200 deleting primary-haddock
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:38:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:38:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:38:20 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:38:20 DEBUG     pycloudlib.cloud:cloud.py:275 Created integral-titmouse
+2021-09-08 01:38:20 DEBUG     pycloudlib.instance:instance.py:394 starting integral-titmouse
+2021-09-08 01:38:32 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:38:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:38:47 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:38:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:38:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:38:49 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:38:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:38:49 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=integral-titmouse)
+2021-09-08 01:38:51 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=integral-titmouse)
+2021-09-08 01:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:38:51 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:38:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:38:52 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmp7pwid1af to /var/tmp/6a16fd90-05a6-4169-be57-9039ff2b12ef.tmp
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmp7pwid1af to /var/tmp/6a16fd90-05a6-4169-be57-9039ff2b12ef.tmp
+2021-09-08 01:38:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/6a16fd90-05a6-4169-be57-9039ff2b12ef.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/6a16fd90-05a6-4169-be57-9039ff2b12ef.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-08 01:38:52 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:38:52 DEBUG     pycloudlib.instance:instance.py:296 restarting integral-titmouse
+2021-09-08 01:39:04 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:39:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:39:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:39:09 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:39:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:39:09 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:39:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:39:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:39:11 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:39:11 DEBUG     pycloudlib.instance:instance.py:200 deleting integral-titmouse
+------------------------------ live log logreport ------------------------------
+2021-09-08 01:39:12 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:39:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-08 01:39:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-08 01:39:12 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nupdates:\n  network:\n    when: [boot]\n', '--vm']
+2021-09-08 01:39:12 DEBUG     pycloudlib.cloud:cloud.py:275 Created secure-monarch
+2021-09-08 01:39:12 DEBUG     pycloudlib.instance:instance.py:394 starting secure-monarch
+2021-09-08 01:39:25 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:39:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:36 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:38 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:39:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:39:40 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:39:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:39:40 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=secure-monarch)
+2021-09-08 01:39:42 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=secure-monarch)
+2021-09-08 01:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:39:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:39:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:39:43 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:270 pushing file /tmp/tmpssdwsvju to /var/tmp/53009da2-8477-43aa-a1bc-22a6efe0a79c.tmp
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:227 pushing file /tmp/tmpssdwsvju to /var/tmp/53009da2-8477-43aa-a1bc-22a6efe0a79c.tmp
+2021-09-08 01:39:43 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/53009da2-8477-43aa-a1bc-22a6efe0a79c.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/53009da2-8477-43aa-a1bc-22a6efe0a79c.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-08 01:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-08 01:39:43 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:39:43 DEBUG     pycloudlib.instance:instance.py:296 restarting secure-monarch
+2021-09-08 01:39:55 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:39:55 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:39:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:39:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:39:59 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:39:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:39:59 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:40:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-08 01:40:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:40:01 DEBUG     pycloudlib.instance:instance.py:200 deleting secure-monarch
+------------------------------ live log logreport ------------------------------
+2021-09-08 01:40:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-08 01:40:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-08 01:40:02 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-08 01:40:02 DEBUG     pycloudlib.cloud:cloud.py:275 Created decent-bonefish
+2021-09-08 01:40:02 DEBUG     pycloudlib.instance:instance.py:394 starting decent-bonefish
+2021-09-08 01:40:25 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:40:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:40:25 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:40:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:40:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:40:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:40:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:40:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:40:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:40:30 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:40:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:40:30 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=decent-bonefish)
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=decent-bonefish)
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'groups root'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:40:33 DEBUG     pycloudlib.instance:instance.py:200 deleting decent-bonefish
+
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:40:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-08 01:40:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-08 01:40:34 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\n# Add groups to the system\ngroups:\n  - secret: [root]\n  - cloud-users\n\n# Add users to the system. Users are added after groups are added.\nusers:\n  - default\n  - name: foobar\n    gecos: Foo B. Bar\n    primary_group: foobar\n    groups: users\n    expiredate: 2038-01-19\n    lock_passwd: false\n    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/\n  - name: barfoo\n    gecos: Bar B. Foo\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: [cloud-users, secret]\n    lock_passwd: true\n  - name: cloudy\n    gecos: Magic Cloud App Daemon User\n    inactive: true\n    system: true\n', '--vm']
+2021-09-08 01:40:34 DEBUG     pycloudlib.cloud:cloud.py:275 Created eternal-wahoo
+2021-09-08 01:40:34 DEBUG     pycloudlib.instance:instance.py:394 starting eternal-wahoo
+2021-09-08 01:40:46 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:40:46 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:40:59 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:41:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:41:04 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:41:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:41:04 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=eternal-wahoo)
+2021-09-08 01:41:07 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=eternal-wahoo)
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:41:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:41:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:41:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-08 01:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Restarting instance and waiting for boot
+2021-09-08 01:41:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:41:07 DEBUG     pycloudlib.instance:instance.py:296 restarting eternal-wahoo
+2021-09-08 01:41:20 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:41:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:20 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:22 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:23 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:41:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:41:26 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:41:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:41:26 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:41:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-08 01:41:28 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:41:28 DEBUG     pycloudlib.instance:instance.py:200 deleting eternal-wahoo
+
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:41:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:41:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:41:28 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:41:28 DEBUG     pycloudlib.cloud:cloud.py:275 Created direct-bull
+2021-09-08 01:41:28 DEBUG     pycloudlib.instance:instance.py:394 starting direct-bull
+2021-09-08 01:41:52 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:41:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:52 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:41:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:41:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:41:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:41:54 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:41:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:41:54 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=direct-bull)
+2021-09-08 01:41:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=direct-bull)
+2021-09-08 01:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:41:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:41:57 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:41:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-08 01:41:57 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:41:57 DEBUG     pycloudlib.instance:instance.py:296 restarting direct-bull
+2021-09-08 01:42:10 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:42:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:42:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:42:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:42:14 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:42:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:42:14 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:42:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:42:16 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/4ecfe12d-f51e-45ab-9600-e05e15431b0a.tmp
+2021-09-08 01:42:16 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/4ecfe12d-f51e-45ab-9600-e05e15431b0a.tmp
+2021-09-08 01:42:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-08 01:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4ecfe12d-f51e-45ab-9600-e05e15431b0a.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-08 01:42:16 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/4ecfe12d-f51e-45ab-9600-e05e15431b0a.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-08 01:42:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:42:16 DEBUG     pycloudlib.instance:instance.py:296 restarting direct-bull
+2021-09-08 01:42:32 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:42:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:42:32 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:42:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:42:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:42:34 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:42:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:42:34 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:42:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:42:37 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:42:37 DEBUG     pycloudlib.instance:instance.py:200 deleting direct-bull
+------------------------------ live log logreport ------------------------------
+2021-09-08 01:42:38 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:42:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:42:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:42:38 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:42:38 DEBUG     pycloudlib.cloud:cloud.py:275 Created giving-airedale
+2021-09-08 01:42:38 DEBUG     pycloudlib.instance:instance.py:394 starting giving-airedale
+2021-09-08 01:43:01 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:43:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:01 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:02 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:04 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:43:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:43:06 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:43:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:43:06 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=giving-airedale)
+2021-09-08 01:43:08 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=giving-airedale)
+2021-09-08 01:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:43:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:43:08 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/5b13e224-2116-48c1-a851-506477d69aef.tmp
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/5b13e224-2116-48c1-a851-506477d69aef.tmp
+2021-09-08 01:43:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-08 01:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/5b13e224-2116-48c1-a851-506477d69aef.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/5b13e224-2116-48c1-a851-506477d69aef.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-08 01:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-08 01:43:08 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:43:08 DEBUG     pycloudlib.instance:instance.py:296 restarting giving-airedale
+2021-09-08 01:43:21 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:43:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:21 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:43:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:43:24 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:43:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:43:24 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:43:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:43:26 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:43:26 DEBUG     pycloudlib.instance:instance.py:200 deleting giving-airedale
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:43:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:43:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=None
+2021-09-08 01:43:27 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-08 01:43:27 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--vm']
+2021-09-08 01:43:27 DEBUG     pycloudlib.cloud:cloud.py:275 Created loved-asp
+2021-09-08 01:43:27 DEBUG     pycloudlib.instance:instance.py:394 starting loved-asp
+2021-09-08 01:43:50 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:43:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:43:53 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:43:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:43:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:43:55 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:43:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:43:55 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=loved-asp)
+2021-09-08 01:43:57 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=loved-asp)
+2021-09-08 01:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:43:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:43:57 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:270 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/8eed2487-7310-4736-9284-53c49ae71cbf.tmp
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:227 pushing file tests/integration_tests/assets/test_version_change.pkl to /var/tmp/8eed2487-7310-4736-9284-53c49ae71cbf.tmp
+2021-09-08 01:43:57 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-08 01:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/8eed2487-7310-4736-9284-53c49ae71cbf.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'mv /var/tmp/8eed2487-7310-4736-9284-53c49ae71cbf.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-08 01:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-08 01:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-08 01:43:57 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-08 01:43:57 DEBUG     pycloudlib.instance:instance.py:296 restarting loved-asp
+2021-09-08 01:44:10 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:44:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:10 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:12 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:13 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:44:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:44:16 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:44:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:44:16 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+2021-09-08 01:44:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-08 01:44:17 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:44:17 DEBUG     pycloudlib.instance:instance.py:200 deleting loved-asp
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:44:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-08 01:44:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=local:subtle-ghoul-snapshot
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-08 01:44:18 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-08 01:44:18 DEBUG     pycloudlib.cloud:cloud.py:181 Full image ID to launch: 'local:subtle-ghoul-snapshot'
+['lxc', 'init', 'local:subtle-ghoul-snapshot', '--profile', 'pycloudlib-vm-hirsute-v3', '--config', 'user.meta-data=public-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMS8gdKw0kA1PDwAVkURrxgjbAgWVeiBq+VSOI1jFLafONDwkc0ZVriZofmCZ1BVjixCA6kqVQsmA88Av7eeI3jGvy4fwX+TKhDQk28rRC9mNz8nBLfB+gp3wfcgFJrVeekhjV+fgxiyq1wJC4WcJZfXKdXvsNTBzhd2RNZAsyKyRKBRahv57/KJjXozS94p83l0qq/gi6pYYBTTkLz65SiyVCUpkddgXDPfxEXqjsx6ha3VCdoKBdRgh3p2toADzcYafyqxDMPtfLJE+BofSA4Gi9YQAMhshdk4tzI+KYcq07cd8AtreXpVyZLC3r7cfe4m2IK7UvVSbTItYoUItN255P1M09eLQNlbbrJwnxuX3IUwxBkYZhVUIaEOQreWTnc+tg20ZK3olUzNWcJBurpeT5i6Hg/QoRrQSanVLFx8hff4l1V9Yxb23txlv9e2Pzh0i/0YVmrVlQxuen/5YyWNm553D1EfH8fEon3xVAqrbC8NS63GaP0QhGo7rlYs= james@newt\n', '--config', 'user.user-data=#cloud-config\nwrite_files:\n-   encoding: b64\n    content: QVNDSUkgdGV4dA==\n    owner: root:root\n    path: /root/file_b64\n    permissions: \'0644\'\n-   content: |\n        # My new /root/file_text\n\n        SMBDOPTIONS="-D"\n    path: /root/file_text\n-   content: !!binary |\n        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK\n    path: /root/file_binary\n    permissions: \'0555\'\n-   encoding: gzip\n    content: !!binary |\n        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=\n    path: /root/file_gzip\n    permissions: \'0755\'\n', '--vm']
+2021-09-08 01:44:18 DEBUG     pycloudlib.cloud:cloud.py:275 Created humane-spider
+2021-09-08 01:44:18 DEBUG     pycloudlib.instance:instance.py:394 starting humane-spider
+2021-09-08 01:44:41 DEBUG     pycloudlib.instance:instance.py:373 _wait_for_execute to complete
+2021-09-08 01:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:41 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:42 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:44 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-08 01:44:45 DEBUG     pycloudlib.instance:instance.py:179 executing: sh -c whoami
+2021-09-08 01:44:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-08 01:44:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-08 01:44:47 DEBUG     pycloudlib.instance:instance.py:398 _wait_for_cloudinit to complete
+2021-09-08 01:44:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-08 01:44:47 DEBUG     pycloudlib.instance:instance.py:177 waiting for start
+Launched instance: LXDInstance(name=humane-spider)
+2021-09-08 01:44:49 INFO      integration_testing:clouds.py:173 Launched instance: LXDInstance(name=humane-spider)
+2021-09-08 01:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-08 01:44:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:44:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-08 01:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-08 01:44:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-08 01:44:49 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+2021-09-08 01:44:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:44:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+2021-09-08 01:44:49 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:44:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+2021-09-08 01:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:44:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+2021-09-08 01:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=hirsute os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-08 01:44:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=hirsute os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-08 01:44:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+2021-09-08 01:44:50 DEBUG     pycloudlib.instance:instance.py:179 executing: sudo -- sh -c 'file /root/file_text'
+PASSED
+------------------------------ live log teardown -------------------------------
+2021-09-08 01:44:50 DEBUG     pycloudlib.instance:instance.py:200 deleting humane-spider
+Deleting snapshot image created for this testrun: local:subtle-ghoul-snapshot
+2021-09-08 01:44:50 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: local:subtle-ghoul-snapshot
+2021-09-08 01:44:50 DEBUG     pycloudlib.cloud:cloud.py:455 Deleting image: 'local:subtle-ghoul-snapshot'
+2021-09-08 01:44:50 DEBUG     pycloudlib.cloud:cloud.py:458 Deleted local:subtle-ghoul-snapshot
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    self.prefix, path)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 131 passed, 18 skipped, 2 warnings in 3502.64s (0:58:22) ===========

--- a/21.3-1/integration_tests/oci_bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/oci_bionic_integration_tests.txt
@@ -1,0 +1,3918 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:27:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 09:27:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=oci
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 09:27:25 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=bionic
+PLATFORM=oci
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for oci
+2021-09-05 09:27:25 INFO      integration_testing:conftest.py:156 Setting up environment for oci
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+2021-09-05 09:27:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+2021-09-05 09:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:28:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:28:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:28:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycalwbem6jsiwqzcbiqfufygo2mjtrphhjktsf5xgmj36q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:28:46 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycalwbem6jsiwqzcbiqfufygo2mjtrphhjktsf5xgmj36q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:28:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:28:47 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:28:47 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-05 09:28:47 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 09:28:49 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:28:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:28:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 09:28:52 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:28:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:28:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 09:29:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 09:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:29:08 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 09:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 09:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 09:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:31:50 INFO      integration_testing:instances.py:114 Created new image: ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+Done with environment setup
+2021-09-05 09:33:29 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:33:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:34:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:34:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:34:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:34:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczksee2kgkyok5f44hg63cl6ys3jyln3juiuajfvisbmq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:34:43 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczksee2kgkyok5f44hg63cl6ys3jyln3juiuajfvisbmq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:34:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:34:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:34:44 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:34:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 09:34:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:36:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:36:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+2021-09-05 09:36:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+2021-09-05 09:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:37:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:37:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:37:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc27xnldwkq5sfqufvgknekqym5rwd2na4chb4qnupdfuq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:37:48 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc27xnldwkq5sfqufvgknekqym5rwd2na4chb4qnupdfuq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:37:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:37:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+2021-09-05 09:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 09:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 09:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 09:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 09:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 09:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 09:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 09:37:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 09:37:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 09:37:54 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:37:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:37:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 09:38:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 09:38:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:38:10 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 09:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 09:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 09:38:11 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 09:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 09:38:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:38:44 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 09:38:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:38:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:38:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:38:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:38:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 09:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 09:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 09:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 09:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 09:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 09:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 09:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 09:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 09:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 09:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 09:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 7.554s (kernel) + 29.964s (userspace) = 37.519s
+graphical.target reached after 26.760s in userspace
+=== `systemd-analyze` after:
+Startup finished in 5.688s (kernel) + 18.476s (userspace) = 24.165s
+graphical.target reached after 14.891s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         14.482s snapd.seeded.service
+          7.000s cloud-init.service
+          1.731s cloud-final.service
+          1.465s cloud-config.service
+          1.399s dev-sda1.device
+          1.281s pollinate.service
+          1.145s apparmor.service
+          1.133s cloud-init-local.service
+          1.001s snapd.service
+           699ms networkd-dispatcher.service
+=== `systemd-analyze blame` after (first 10 lines):
+          6.688s cloud-init.service
+          3.147s snapd.service
+          2.237s dev-sda1.device
+          2.227s cloud-config.service
+          1.380s cloud-final.service
+          1.219s cloud-init-local.service
+           938ms networkd-dispatcher.service
+           743ms grub-common.service
+           589ms accounts-daemon.service
+           572ms systemd-logind.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.11300 seconds
+Finished stage: (init-network) 06.26800 seconds
+Finished stage: (modules-config) 00.53400 seconds
+Finished stage: (modules-final) 00.55600 seconds
+Total Time: 7.47100 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.12700 seconds
+Finished stage: (init-network) 06.02000 seconds
+Finished stage: (modules-config) 00.58900 seconds
+Finished stage: (modules-final) 00.43800 seconds
+Total Time: 7.17400 seconds
+Finished stage: (init-network) 00.32600 seconds
+Total Time: 0.32600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     05.12300s (init-network/search-OpenStack)
+     00.33800s (init-network/config-resizefs)
+     00.32800s (modules-config/config-grub-dpkg)
+     00.25200s (modules-final/config-keys-to-console)
+     00.24000s (init-network/config-ssh)
+     00.15400s (modules-config/config-apt-configure)
+     00.13400s (init-network/config-growpart)
+     00.11300s (init-network/config-users-groups)
+     00.10700s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     05.09700s (init-network/search-OpenStack)
+     00.43000s (init-network/config-ssh)
+     00.35700s (modules-config/config-grub-dpkg)
+     00.22600s (modules-final/config-ssh-authkey-fingerprints)
+     00.16300s (modules-config/config-apt-configure)
+     00.13500s (modules-final/config-keys-to-console)
+     00.07400s (init-local/search-OpenStackLocal)
+     00.06000s (init-network/config-growpart)
+     00.03300s (init-network/config-users-groups)
+
+2021-09-05 09:39:01 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 7.554s (kernel) + 29.964s (userspace) = 37.519s
+graphical.target reached after 26.760s in userspace
+=== `systemd-analyze` after:
+Startup finished in 5.688s (kernel) + 18.476s (userspace) = 24.165s
+graphical.target reached after 14.891s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+         14.482s snapd.seeded.service
+          7.000s cloud-init.service
+          1.731s cloud-final.service
+          1.465s cloud-config.service
+          1.399s dev-sda1.device
+          1.281s pollinate.service
+          1.145s apparmor.service
+          1.133s cloud-init-local.service
+          1.001s snapd.service
+           699ms networkd-dispatcher.service
+=== `systemd-analyze blame` after (first 10 lines):
+          6.688s cloud-init.service
+          3.147s snapd.service
+          2.237s dev-sda1.device
+          2.227s cloud-config.service
+          1.380s cloud-final.service
+          1.219s cloud-init-local.service
+           938ms networkd-dispatcher.service
+           743ms grub-common.service
+           589ms accounts-daemon.service
+           572ms systemd-logind.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.11300 seconds
+Finished stage: (init-network) 06.26800 seconds
+Finished stage: (modules-config) 00.53400 seconds
+Finished stage: (modules-final) 00.55600 seconds
+Total Time: 7.47100 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.12700 seconds
+Finished stage: (init-network) 06.02000 seconds
+Finished stage: (modules-config) 00.58900 seconds
+Finished stage: (modules-final) 00.43800 seconds
+Total Time: 7.17400 seconds
+Finished stage: (init-network) 00.32600 seconds
+Total Time: 0.32600 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     05.12300s (init-network/search-OpenStack)
+     00.33800s (init-network/config-resizefs)
+     00.32800s (modules-config/config-grub-dpkg)
+     00.25200s (modules-final/config-keys-to-console)
+     00.24000s (init-network/config-ssh)
+     00.15400s (modules-config/config-apt-configure)
+     00.13400s (init-network/config-growpart)
+     00.11300s (init-network/config-users-groups)
+     00.10700s (modules-final/config-ssh-authkey-fingerprints)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     05.09700s (init-network/search-OpenStack)
+     00.43000s (init-network/config-ssh)
+     00.35700s (modules-config/config-grub-dpkg)
+     00.22600s (modules-final/config-ssh-authkey-fingerprints)
+     00.16300s (modules-config/config-apt-configure)
+     00.13500s (modules-final/config-keys-to-console)
+     00.07400s (init-local/search-OpenStackLocal)
+     00.06000s (init-network/config-growpart)
+     00.03300s (init-network/config-users-groups)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:40:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:40:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaavaly2nuycxgpgffwfakvqf3djoi4h2xul4hmqxivdetzvejttl3q
+2021-09-05 09:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:41:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:41:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:41:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycfgc5bqxukpihejl3koxfbpbrgljoqqd7cvjzdpw7dpoa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:41:52 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycfgc5bqxukpihejl3koxfbpbrgljoqqd7cvjzdpw7dpoa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:41:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:41:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 09:41:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:41:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Installing proposed image
+2021-09-05 09:41:53 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:41:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:41:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 09:41:55 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:41:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:41:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 09:41:58 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 09:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 09:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 09:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 09:42:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:42:14 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-05 09:42:14 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 09:42:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 09:42:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:42:43 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 09:42:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:42:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:42:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:42:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 09:42:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:44:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:44:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:45:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:45:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:45:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:45:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:45:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:45:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:45:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syca6x4ogqbyhlqtnnlpx75oblw4caijixbmaafvoycue6a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:45:45 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syca6x4ogqbyhlqtnnlpx75oblw4caijixbmaafvoycue6a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:45:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:45:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:45:46 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:45:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:47:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:47:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:48:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:48:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:48:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgokgyj6v4ooil7akqqyldgynnqvw3dfvhfcej2taelaa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:48:36 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgokgyj6v4ooil7akqqyldgynnqvw3dfvhfcej2taelaa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:48:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:48:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:48:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:48:37 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:48:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:50:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:50:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:50:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:50:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:51:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:51:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:51:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdyag7xr2t3cz5dxaz2is6efmamxzqjw3mdktq5sfmkzq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:51:07 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdyag7xr2t3cz5dxaz2is6efmamxzqjw3mdktq5sfmkzq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:51:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:51:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:51:08 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:51:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:52:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:52:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:53:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:53:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:53:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:53:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycogrzoqzb3pw2hlebf3gr4xsorvkza4oxwwsyechsgfsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:53:51 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycogrzoqzb3pw2hlebf3gr4xsorvkza4oxwwsyechsgfsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:53:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:53:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 09:53:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 09:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:55:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:55:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:55:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:56:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:56:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycx6jncuh4bajivb6bxc3pllvbdqkt4o6kufijx4y4tutq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:56:26 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycx6jncuh4bajivb6bxc3pllvbdqkt4o6kufijx4y4tutq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:56:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:56:27 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 09:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 09:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 09:56:28 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 09:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 09:56:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:56 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 09:56:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:56:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:57:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:57:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 09:57:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 09:57:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:58:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:58:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 09:59:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:59:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 09:59:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 09:59:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 09:59:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct55ml5s26i5s4ia5y47ew76txhxpnyrhkehlbia3quqq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:59:51 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct55ml5s26i5s4ia5y47ew76txhxpnyrhkehlbia3quqq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 09:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:59:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 09:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 09:59:52 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 09:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-05 09:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 09:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 09:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 09:59:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 09:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:01:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:01:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:02:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:02:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:02:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:02:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:03:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:03:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:03:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:03:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycn6infwzs3atzmxpchfubzdzwwmt4x2lfiygexguxt5tq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:03:06 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycn6infwzs3atzmxpchfubzdzwwmt4x2lfiygexguxt5tq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:03:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:03:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:03:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:03:08 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:03:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:04:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:04:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:05:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:05:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:05:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:05:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:05:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:05:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycpyy2ixpa3ce7ngse6ipbyja7nm4zhrvnv7pfet5hkn4a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:05:36 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycpyy2ixpa3ce7ngse6ipbyja7nm4zhrvnv7pfet5hkn4a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:05:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:05:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:05:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:05:37 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:05:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:07:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:07:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:07:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:07:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:07:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:08:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:08:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:08:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:08:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc42yfdwxrj4jeqh4mrkngao3wcsiuqcshrjfnhenrsz6q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:08:08 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc42yfdwxrj4jeqh4mrkngao3wcsiuqcshrjfnhenrsz6q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:08:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:08:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:08:09 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:08:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:09:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:09:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:10:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:10:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:10:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycz5uzumww4doi6r25e5k6slnrduztgbhymwyzdz2ddgeq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:10:43 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycz5uzumww4doi6r25e5k6slnrduztgbhymwyzdz2ddgeq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:10:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:10:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:10:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:10:44 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:10:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 10:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 10:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 10:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:10:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:10:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:12:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:12:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:12:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:13:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:13:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:13:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2okflwjns3ulksygzvkpouz27odtdjyu7de5z3csgraa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:13:24 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2okflwjns3ulksygzvkpouz27odtdjyu7de5z3csgraa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:13:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:13:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:14:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:14:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:15:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:15:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:15:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycddx2vpxhmel5vktjsubalangschxqsr5menhhugagkpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:16:01 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycddx2vpxhmel5vktjsubalangschxqsr5menhhugagkpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:16:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:16:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:16:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:16:03 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:16:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:17:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:17:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:18:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:18:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:18:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:18:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwuiwe7lb627k6cltkdp3abva4r2l233jjmmb4jtvvjba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:18:51 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwuiwe7lb627k6cltkdp3abva4r2l233jjmmb4jtvvjba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:18:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:18:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:18:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 10:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:18:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:18:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:18:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 10:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 10:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:18:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:18:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:18:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 10:18:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 10:18:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:20:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:20:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:20:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:21:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:21:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:21:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:21:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:21:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:21:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syck24jddf6xwl2hqswwug23g3afspopht6rkt6m4qgr5ta, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:21:24 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syck24jddf6xwl2hqswwug23g3afspopht6rkt6m4qgr5ta, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:21:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:21:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:23:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:23:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:23:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:23:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:23:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:24:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycxginoppz5sw4vrmotb5v3luznbu7e2jc42a2qzr2e35q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:24:04 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycxginoppz5sw4vrmotb5v3luznbu7e2jc42a2qzr2e35q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:24:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:24:05 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 10:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:25:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:25:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:26:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:26:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:26:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:26:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:26:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:26:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:26:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:26:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct5ba6dep2hbtk5x2lrsqnqskd7xxzrmfdja7idprfhsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:27:03 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct5ba6dep2hbtk5x2lrsqnqskd7xxzrmfdja7idprfhsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:27:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:27:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:27:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:27:04 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:27:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:27:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:27:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:27:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:28:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:28:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:29:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:29:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:29:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycvpymjbsvyqodu6tget7wc657baxqfx6fjohfmwtjhfdq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:29:54 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycvpymjbsvyqodu6tget7wc657baxqfx6fjohfmwtjhfdq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:29:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:29:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:29:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:29:55 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:29:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:29:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:32:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:32:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:33:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:33:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:33:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycejet5tyrxcvzqdatxcub3p3uypnldue7mxsiea6hkssa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:33:58 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycejet5tyrxcvzqdatxcub3p3uypnldue7mxsiea6hkssa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:33:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:33:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:33:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:33:59 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:33:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:34:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:35:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:35:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:36:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:36:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:36:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:36:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:36:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:36:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:36:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycf34bwho3m6mkfzaow5rjbgmz4psswitzmoa4kxvj4rka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:37:02 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycf34bwho3m6mkfzaow5rjbgmz4psswitzmoa4kxvj4rka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:37:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:37:03 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:37:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:37:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 10:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 10:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:38:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:38:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:39:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:39:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:39:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbeqlxfv4ymp77p6xdagftpemoxfdt4dfvihcbogf7inq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:39:43 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbeqlxfv4ymp77p6xdagftpemoxfdt4dfvihcbogf7inq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:39:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:39:44 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:39:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:39:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:39:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:41:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:41:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:41:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:42:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:42:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:42:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:42:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:42:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:42:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:42:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sychurtvvghxdozsm2aihfvofxuu6ber6ndbriht7xlmbpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:42:38 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sychurtvvghxdozsm2aihfvofxuu6ber6ndbriht7xlmbpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:42:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:42:39 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 10:42:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:44:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:44:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:45:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:45:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:45:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct64kdx2wftghgjwcruyf2zwwue2nvfufgquwof2eoufa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:45:15 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syct64kdx2wftghgjwcruyf2zwwue2nvfufgquwof2eoufa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:45:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:45:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:45:16 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:46:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:46:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:47:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:47:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:47:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycekautu734avrmjftyfx6ql2dfh7k6r6avyvxbgjxwyca, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:47:55 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycekautu734avrmjftyfx6ql2dfh7k6r6avyvxbgjxwyca, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:47:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:47:56 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 10:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 10:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:49:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:49:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:50:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:50:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:50:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:50:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:50:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycepcpzqzraczpw4feptexmcrnbmae2dudaotxajzreqrq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:52:10 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycepcpzqzraczpw4feptexmcrnbmae2dudaotxajzreqrq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:52:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:52:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:52:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:52:11 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:52:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:52:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:54:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:54:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:54:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:54:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:54:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:54:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:55:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:55:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczjmeowynfuxhxudl6wv62rru3rkadrhxjckk2j7utjyq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:55:06 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczjmeowynfuxhxudl6wv62rru3rkadrhxjckk2j7utjyq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:55:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:55:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:55:07 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:56:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:56:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:57:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:57:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:57:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:57:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:57:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 10:57:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 10:57:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 10:57:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwyqjbnxxr2xguffdigb5qtzrqqv64ep7c74kkqz4jjuq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:57:55 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwyqjbnxxr2xguffdigb5qtzrqqv64ep7c74kkqz4jjuq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 10:57:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:57:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 10:57:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 10:57:57 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 10:57:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 10:59:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 10:59:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:00:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:00:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:00:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:00:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycztz4qkenu5lyjx57cw5dwzlcdjceeveduf4qyihrtdhq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:00:41 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycztz4qkenu5lyjx57cw5dwzlcdjceeveduf4qyihrtdhq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:00:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:00:42 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:02:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:02:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:03:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:03:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:03:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:03:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4gio4ea3wt2rqrkkxw7hhdk3tnbpd2qxxqhyswjgn2la, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:03:29 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4gio4ea3wt2rqrkkxw7hhdk3tnbpd2qxxqhyswjgn2la, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:03:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:03:30 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:03:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:05:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:05:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:05:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:05:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:05:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:06:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsh2w4tk6d6vbfmcotlo2vmefj4azo62aeuwxcyxfu6ja, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:06:05 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsh2w4tk6d6vbfmcotlo2vmefj4azo62aeuwxcyxfu6ja, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:06:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:06:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:06:06 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 11:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 11:06:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:07:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:07:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:08:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:08:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:08:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:08:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:08:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:08:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:08:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4fyvibjejpe4hopenjl3ieucn7bj6hsdqsl5jycd6vtq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:08:50 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4fyvibjejpe4hopenjl3ieucn7bj6hsdqsl5jycd6vtq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:08:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:08:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:08:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:08:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:08:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:10:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:10:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:11:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:11:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:11:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:11:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:11:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:11:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:11:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:11:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjsdhh6ap2b7qzavrwttov5juvvi7tqyzpymffvs46bkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:11:50 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjsdhh6ap2b7qzavrwttov5juvvi7tqyzpymffvs46bkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:11:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:11:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:11:51 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:11:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:11:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:13:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:13:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:14:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:14:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:14:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:14:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:14:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:14:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:14:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syccu3opokgarj5od2qlrtdhopfnh6pfewnurzul3xylyba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:15:08 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syccu3opokgarj5od2qlrtdhopfnh6pfewnurzul3xylyba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:15:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:15:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:15:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:15:09 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:15:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:16:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:16:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:17:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:17:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:17:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:17:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2xwi43dml2esvcife6ekvguk3vsyrlxmv2oj22ts2d5q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:17:59 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2xwi43dml2esvcife6ekvguk3vsyrlxmv2oj22ts2d5q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:18:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:18:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:18:00 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:18:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:19:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:19:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:20:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:20:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:20:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:20:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:20:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczqr6mnotzfcf3ht2tvm3suk3pe6lc5rxsfrzwizo4zca, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:20:33 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczqr6mnotzfcf3ht2tvm3suk3pe6lc5rxsfrzwizo4zca, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:20:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:20:34 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:22:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:22:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:22:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:22:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:22:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:22:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:23:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjerqxo5nn5n6aqakek2xd3nflnzi5vzeq43mckdglrpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:23:05 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjerqxo5nn5n6aqakek2xd3nflnzi5vzeq43mckdglrpq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:23:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:23:06 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:23:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:23:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:24:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:24:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:25:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:25:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:25:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:25:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:25:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:25:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:25:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:25:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdwlxyv4yg3drc32jzn7ylf3mhp4beqbqc2eeztrvwjmq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:25:48 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdwlxyv4yg3drc32jzn7ylf3mhp4beqbqc2eeztrvwjmq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:25:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:25:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:27:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:27:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:27:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:28:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:28:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:28:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycah5rfqj7ikq756xohv6ygtisvyvumxxrreelyjtcvyqq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:28:13 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycah5rfqj7ikq756xohv6ygtisvyvumxxrreelyjtcvyqq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:28:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:28:14 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:28:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:29:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:29:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:30:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:30:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:30:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:30:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:30:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:30:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:30:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgcexeutuaafyytczrjskkhhrlxakdccttpbmm6kbjkla, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:30:59 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgcexeutuaafyytczrjskkhhrlxakdccttpbmm6kbjkla, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:31:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:31:00 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:31:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 11:31:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 11:31:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 11:31:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 11:31:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 11:31:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 11:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 11:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 11:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 11:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:31:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 11:31:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 11:31:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 11:31:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 11:31:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 11:31:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 11:31:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 11:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 11:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 11:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 11:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 11:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 11:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 11:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 11:31:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 11:31:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 11:31:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 11:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 11:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 11:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 11:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 11:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:31:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 11:31:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 11:31:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 11:31:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 11:31:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 11:31:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:31:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 11:31:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 11:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 11:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 11:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 11:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 11:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 11:31:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:32:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:32:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:33:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:33:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:33:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:33:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:33:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:33:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:33:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:33:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycue2h3uq4gbkvqwur7pl5ntokfjxtlvd2fbplgsryaeva, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:33:56 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycue2h3uq4gbkvqwur7pl5ntokfjxtlvd2fbplgsryaeva, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:33:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:33:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:33:57 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:33:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 11:33:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:33:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 11:33:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:33:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 11:33:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:33:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 11:34:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 11:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 11:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 11:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 11:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 11:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 11:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 11:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 11:34:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 11:34:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 11:34:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 11:34:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 11:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 11:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 11:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 11:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 11:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:34:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 11:34:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 11:34:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 11:34:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 11:34:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 11:34:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 11:34:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 11:34:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 11:34:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 11:34:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 11:34:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:34:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 11:34:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 11:34:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 11:34:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 11:34:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 11:34:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:34:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 11:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 11:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 11:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 11:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 11:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 11:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 11:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:35:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:35:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:36:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:36:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmuqwvrryxq7kwqdyob5wwntq5n7cumdsjbawbgedwn7q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:36:49 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmuqwvrryxq7kwqdyob5wwntq5n7cumdsjbawbgedwn7q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:36:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:36:50 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:36:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:36:50 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:36:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 11:36:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 11:36:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 11:36:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 11:36:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:36:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:36:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 11:36:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 11:36:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 11:36:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 11:36:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:36:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 11:36:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 11:36:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 11:36:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 11:36:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 11:36:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 11:36:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:36:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:36:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 11:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 11:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 11:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 11:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 11:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 11:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 11:36:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 11:36:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:36:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 11:37:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:37:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:37:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 11:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 11:37:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 11:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 11:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 11:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 11:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 11:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 11:37:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:37:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 11:37:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:37:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 11:37:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:37:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:37:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 11:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 11:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 11:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 11:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 11:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 11:37:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 11:37:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:38:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:38:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:39:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:39:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:39:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:39:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:39:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:39:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbr4kyfqalxrigdiotu53xr4kf3ipgsgke3qtqv5ekoka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:39:38 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbr4kyfqalxrigdiotu53xr4kf3ipgsgke3qtqv5ekoka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:39:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:39:39 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 11:39:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 11:39:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 11:39:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 11:39:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 11:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 11:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 11:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 11:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 11:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 11:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 11:39:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 11:39:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 11:39:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 11:39:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 11:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 11:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 11:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 11:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 11:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 11:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 11:39:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 11:39:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 11:39:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 11:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 11:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 11:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 11:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 11:39:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 11:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 11:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 11:39:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 11:39:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 11:39:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:39:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+2021-09-05 11:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 11:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 11:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 11:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 11:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 11:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 11:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 11:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 11:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:41:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:41:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:42:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:42:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:42:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:42:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:42:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:42:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:42:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syctdbmbxwf4cnzu7e3gh3nqobgm57xw5ntxsyfqaeo7dma, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:42:38 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syctdbmbxwf4cnzu7e3gh3nqobgm57xw5ntxsyfqaeo7dma, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:42:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:42:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:42:39 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:42:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:43:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:43:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:44:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:44:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:44:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:44:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:45:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclw2feaw7a37fxwucqaajhhv4avxl7jc3ylt7mnltjnkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:45:06 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclw2feaw7a37fxwucqaajhhv4avxl7jc3ylt7mnltjnkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:45:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:45:07 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:46:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:46:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:47:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:47:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:47:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syckh3worps45mjyx7eiyghx2tqyvwqhsl7gaba55p53voq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:47:52 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syckh3worps45mjyx7eiyghx2tqyvwqhsl7gaba55p53voq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:47:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:47:53 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+SKIPPED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:49:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:49:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:49:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:50:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:50:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:50:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc74lra6wqvfqj7pbwuwzz7pfmqnp6ioqxavdjvvuoekoq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:50:25 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc74lra6wqvfqj7pbwuwzz7pfmqnp6ioqxavdjvvuoekoq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:50:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:50:26 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:50:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:52:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:52:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:53:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:53:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:53:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:53:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:53:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:53:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:53:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:53:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycvc6f4zxf6csbzed2cfe3xtggtwj3lasokzelh667nj7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:53:34 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycvc6f4zxf6csbzed2cfe3xtggtwj3lasokzelh667nj7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:53:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:53:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:53:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:53:35 INFO      integration_testing:clouds.py:183 image serial: 20210825
+Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:53:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:55:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:55:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:55:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:56:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:56:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmgvke7rhgchpdrn5udvcvo3lu6plvxkd5opsdem3a25a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:56:20 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmgvke7rhgchpdrn5udvcvo3lu6plvxkd5opsdem3a25a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 11:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:56:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 11:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 11:56:21 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 11:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 11:56:22 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 11:56:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 11:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:49 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 11:56:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:56:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:56:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:56:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 11:56:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 11:57:00 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 11:57:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/48774725-ab9c-410b-a965-143b79f12e37.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 11:57:01 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 11:57:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 11:57:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:29 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 11:57:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 11:57:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 11:57:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 11:57:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 11:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 11:59:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:59:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 11:59:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:00:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:00:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycatfrlkgze6hv6rdmahyznuwiiom3iebmhwrnqupswzia, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:00:19 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycatfrlkgze6hv6rdmahyznuwiiom3iebmhwrnqupswzia, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:00:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 12:00:20 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:00:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 12:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/6df46b70-8c4c-43a4-95ca-2853e8fdd088.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 12:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 12:00:21 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 12:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 12:00:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:49 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 12:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:00:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:00:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:00:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 12:02:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:02:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 12:02:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 12:03:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:03:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:03:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:03:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:03:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:03:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:03:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:03:45 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syco772ganvbihkqjyv6robprrgemvybkgzwuprgiuzezna, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:03:48 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syco772ganvbihkqjyv6robprrgemvybkgzwuprgiuzezna, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:03:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:03:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:03:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 12:03:49 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:03:49 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 12:03:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b8811005-b212-49fd-8a99-cf174cfc4746.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 12:03:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 12:03:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 12:03:50 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 12:03:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 12:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:04:17 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 12:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:04:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:04:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:04:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:06:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 12:06:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+2021-09-05 12:06:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 12:06:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:07:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:07:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:07:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczz77biajssxhhjug4y62kji4unt4dl3omja23uyqzq6a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:07:24 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczz77biajssxhhjug4y62kji4unt4dl3omja23uyqzq6a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 12:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:07:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210825
+2021-09-05 12:07:25 INFO      integration_testing:clouds.py:183 image serial: 20210825
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:07:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:07:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:07:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:07:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=bionic os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:07:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=bionic os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 12:08:58 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ocid1.image.oc1.phx.aaaaaaaa4g33zdalzm44hpk5no2p4bzs5ema5dfdudmx36q7g35n2ewyaxrq
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 118 passed, 31 skipped, 1 warning in 9697.22s (2:41:37) ============

--- a/21.3-1/integration_tests/oci_focal_integration_tests.txt
+++ b/21.3-1/integration_tests/oci_focal_integration_tests.txt
@@ -1,0 +1,3728 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 17:53:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 17:53:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=oci
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 17:54:00 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=focal
+PLATFORM=oci
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for oci
+2021-09-05 17:54:00 INFO      integration_testing:conftest.py:156 Setting up environment for oci
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+2021-09-05 17:54:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+2021-09-05 17:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 17:54:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 17:54:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 17:54:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyintokpjpygvqlv3jkxbzw3o25e75rx5zbqssztugv4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 17:55:06 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyintokpjpygvqlv3jkxbzw3o25e75rx5zbqssztugv4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 17:55:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 17:55:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 17:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 17:55:07 INFO      integration_testing:clouds.py:183 image serial: 20210826
+Installing proposed image
+2021-09-05 17:55:07 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 17:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 17:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 17:55:09 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 17:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 17:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 17:55:11 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 17:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 17:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 17:55:15 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 17:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 17:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 17:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+Installing proposed image
+2021-09-05 17:55:24 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 17:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 17:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 17:55:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 17:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 17:55:43 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 17:55:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 17:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 17:55:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 17:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 17:57:55 INFO      integration_testing:instances.py:114 Created new image: ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+Done with environment setup
+2021-09-05 17:59:34 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 17:59:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:00:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:00:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:00:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:00:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2sfbybcfcilasz7dqcqg27dfo7itibzzckdajyuvwgpa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:00:37 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2sfbybcfcilasz7dqcqg27dfo7itibzzckdajyuvwgpa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:00:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:00:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:00:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:00:38 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:00:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 18:00:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:02:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:02:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+2021-09-05 18:02:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+2021-09-05 18:02:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:03:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:03:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:03:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:03:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:03:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:03:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycciwhmmlktbo3ddtex4hrl3v5wqajbwy25qvnhwgahxza, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:03:24 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycciwhmmlktbo3ddtex4hrl3v5wqajbwy25qvnhwgahxza, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:03:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 18:03:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 18:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:03:25 INFO      integration_testing:clouds.py:183 image serial: 20210826
+2021-09-05 18:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 18:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 18:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 18:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 18:03:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 18:03:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 18:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 18:03:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 18:03:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 18:03:31 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:03:34 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:03:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:03:38 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 18:03:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+Installing proposed image
+2021-09-05 18:03:48 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:03:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:03:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 18:03:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 18:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:04:05 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:04:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 18:04:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 18:04:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 18:04:06 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 18:04:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 18:04:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:04:33 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 18:04:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:04:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:04:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:04:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 18:04:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 18:04:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 18:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 18:04:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 18:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 18:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 18:04:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 18:04:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 18:04:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 18:04:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 18:04:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.805s (kernel) + 22.009s (userspace) = 26.815s 
+graphical.target reached after 19.285s in userspace
+=== `systemd-analyze` after:
+Startup finished in 7.578s (kernel) + 18.773s (userspace) = 26.351s 
+graphical.target reached after 16.210s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+9.133s snapd.seeded.service                          
+2.568s cloud-init.service                            
+2.495s snapd.apparmor.service                        
+2.349s cloud-init-local.service                      
+1.706s snapd.service                                 
+1.571s cloud-config.service                          
+1.313s pollinate.service                             
+1.142s cloud-final.service                           
+1.121s snap.lxd.activate.service                     
+1.121s dev-sda1.device                               
+=== `systemd-analyze blame` after (first 10 lines):
+10.397s snap.lxd.activate.service                     
+ 9.792s snapd.service                                 
+ 1.693s cloud-config.service                          
+ 1.582s cloud-init-local.service                      
+ 1.417s cloud-init.service                            
+ 1.271s dev-sda1.device                               
+ 1.245s cloud-final.service                           
+  933ms systemd-udev-settle.service                   
+  829ms networkd-dispatcher.service                   
+  735ms udisks2.service                               
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.78100 seconds
+Finished stage: (init-network) 01.87900 seconds
+Finished stage: (modules-config) 00.67900 seconds
+Finished stage: (modules-final) 00.28400 seconds
+Total Time: 3.62300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.38000 seconds
+Finished stage: (init-network) 00.71700 seconds
+Finished stage: (modules-config) 00.63300 seconds
+Finished stage: (modules-final) 00.38400 seconds
+Total Time: 2.11400 seconds
+Finished stage: (init-network) 00.40400 seconds
+Total Time: 0.40400 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.53200s (init-network/config-ssh)
+     00.50100s (init-network/config-resizefs)
+     00.45100s (init-network/config-growpart)
+     00.43100s (modules-config/config-grub-dpkg)
+     00.15600s (init-local/search-Oracle)
+     00.14500s (modules-config/config-apt-configure)
+     00.13400s (init-network/config-users-groups)
+     00.12700s (modules-final/config-keys-to-console)
+     00.05100s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.37200s (modules-config/config-grub-dpkg)
+     00.24800s (init-network/config-ssh)
+     00.15400s (modules-config/config-apt-configure)
+     00.15300s (modules-final/config-ssh-authkey-fingerprints)
+     00.14700s (modules-final/config-keys-to-console)
+     00.09600s (init-local/search-Oracle)
+     00.08700s (init-network/config-resizefs)
+     00.06900s (init-network/config-users-groups)
+     00.05600s (init-network/config-growpart)
+
+2021-09-05 18:04:55 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 4.805s (kernel) + 22.009s (userspace) = 26.815s 
+graphical.target reached after 19.285s in userspace
+=== `systemd-analyze` after:
+Startup finished in 7.578s (kernel) + 18.773s (userspace) = 26.351s 
+graphical.target reached after 16.210s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+9.133s snapd.seeded.service                          
+2.568s cloud-init.service                            
+2.495s snapd.apparmor.service                        
+2.349s cloud-init-local.service                      
+1.706s snapd.service                                 
+1.571s cloud-config.service                          
+1.313s pollinate.service                             
+1.142s cloud-final.service                           
+1.121s snap.lxd.activate.service                     
+1.121s dev-sda1.device                               
+=== `systemd-analyze blame` after (first 10 lines):
+10.397s snap.lxd.activate.service                     
+ 9.792s snapd.service                                 
+ 1.693s cloud-config.service                          
+ 1.582s cloud-init-local.service                      
+ 1.417s cloud-init.service                            
+ 1.271s dev-sda1.device                               
+ 1.245s cloud-final.service                           
+  933ms systemd-udev-settle.service                   
+  829ms networkd-dispatcher.service                   
+  735ms udisks2.service                               
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 00.78100 seconds
+Finished stage: (init-network) 01.87900 seconds
+Finished stage: (modules-config) 00.67900 seconds
+Finished stage: (modules-final) 00.28400 seconds
+Total Time: 3.62300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 00.38000 seconds
+Finished stage: (init-network) 00.71700 seconds
+Finished stage: (modules-config) 00.63300 seconds
+Finished stage: (modules-final) 00.38400 seconds
+Total Time: 2.11400 seconds
+Finished stage: (init-network) 00.40400 seconds
+Total Time: 0.40400 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     00.53200s (init-network/config-ssh)
+     00.50100s (init-network/config-resizefs)
+     00.45100s (init-network/config-growpart)
+     00.43100s (modules-config/config-grub-dpkg)
+     00.15600s (init-local/search-Oracle)
+     00.14500s (modules-config/config-apt-configure)
+     00.13400s (init-network/config-users-groups)
+     00.12700s (modules-final/config-keys-to-console)
+     00.05100s (modules-config/config-locale)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     00.37200s (modules-config/config-grub-dpkg)
+     00.24800s (init-network/config-ssh)
+     00.15400s (modules-config/config-apt-configure)
+     00.15300s (modules-final/config-ssh-authkey-fingerprints)
+     00.14700s (modules-final/config-keys-to-console)
+     00.09600s (init-local/search-Oracle)
+     00.08700s (init-network/config-resizefs)
+     00.06900s (init-network/config-users-groups)
+     00.05600s (init-network/config-growpart)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:06:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:06:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaar5th7viefxeqfm54s32frxevayrbf3ccxxuzlt2ob2osez42n2ua
+2021-09-05 18:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:07:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:07:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:07:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc6ndfhttjxufybaljtabntcv7tldph24rivjiujmkc5cq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:07:52 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc6ndfhttjxufybaljtabntcv7tldph24rivjiujmkc5cq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:07:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 18:07:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 18:07:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:07:53 INFO      integration_testing:clouds.py:183 image serial: 20210826
+Installing proposed image
+2021-09-05 18:07:53 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:07:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:07:55 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:07:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:07:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:07:57 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:07:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:08:01 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+Installing proposed image
+2021-09-05 18:08:05 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 18:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 18:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 18:08:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 18:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:08:26 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-05 18:08:26 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 18:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 18:08:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:09:01 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 18:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:09:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:09:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:09:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 18:09:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:11:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:11:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:11:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:11:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:11:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:11:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:12:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsdg5drqnxkfu6dogc4ragp6he2ilocisbbfocz2moila, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:12:21 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsdg5drqnxkfu6dogc4ragp6he2ilocisbbfocz2moila, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:12:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:12:22 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:13:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:13:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:14:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:14:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:14:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczorz3rqsozicd7icvfzrrlvjcftdts3sy547hrbikkla, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:15:10 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczorz3rqsozicd7icvfzrrlvjcftdts3sy547hrbikkla, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:15:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:15:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:15:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:15:11 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:15:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:16:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:16:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:17:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:17:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:17:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:17:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczir5wwpskosskbu6wkchwvr5wohhlsv4qr23lx5ve2ka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:17:38 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczir5wwpskosskbu6wkchwvr5wohhlsv4qr23lx5ve2ka, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:17:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:17:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:17:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:17:39 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:17:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:18:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:18:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:19:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:19:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:19:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:19:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:19:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmvs4pbpwvrehkd5imumobmnltfrxjbf67hwuwvhlqbzq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:19:56 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmvs4pbpwvrehkd5imumobmnltfrxjbf67hwuwvhlqbzq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:19:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:19:57 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:19:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:19:57 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:19:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 18:19:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 18:19:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:21:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:21:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:22:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:22:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:22:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycuy3vugsqjl4qd4ppeuv5mzjksryqqgqrgo7jc3vnnhnq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:22:40 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycuy3vugsqjl4qd4ppeuv5mzjksryqqgqrgo7jc3vnnhnq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:22:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:22:41 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 18:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 18:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 18:22:42 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 18:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 18:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:23:08 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 18:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:23:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:23:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:23:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 18:23:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 18:23:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:25:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:25:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:26:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:26:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:26:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3opknnxeflck625aiwxvng76kv6ccltx7d7byje7cxda, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:26:29 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3opknnxeflck625aiwxvng76kv6ccltx7d7byje7cxda, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:26:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:26:30 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 18:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-05 18:26:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 18:26:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 18:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:26:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:26:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack SKIPPED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:28:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:28:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:28:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:28:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:29:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycscw4pavupsardy7afzepsbdpah773g6nhlxjxjw5kj4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:29:07 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycscw4pavupsardy7afzepsbdpah773g6nhlxjxjw5kj4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:29:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:29:08 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:30:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:30:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:31:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:31:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:31:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:31:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4fkgnb5mwszh62d4urufo2soir6aqobt2ywgwzjbjqna, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:31:57 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc4fkgnb5mwszh62d4urufo2soir6aqobt2ywgwzjbjqna, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:31:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:31:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:31:59 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:33:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:33:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:34:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:34:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:34:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:34:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycobtfimc63m2lf3bc7yakwrmuxm2pgt7qpphwckyqrz7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:34:55 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycobtfimc63m2lf3bc7yakwrmuxm2pgt7qpphwckyqrz7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:34:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:34:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:34:56 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:34:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:36:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:36:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:37:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:37:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:37:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:37:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbsqlkee4ohi6hcykfgm5beqtvt2qu23he2q6i74urr4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:37:55 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbsqlkee4ohi6hcykfgm5beqtvt2qu23he2q6i74urr4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:37:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:37:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:37:56 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 18:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 18:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 18:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:37:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:37:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:39:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:39:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:40:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:40:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:40:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycj6oeykgh2gzle7zrrfmez3ds37b4jom5nulevt6dhnba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:40:30 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycj6oeykgh2gzle7zrrfmez3ds37b4jom5nulevt6dhnba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:40:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:40:31 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:41:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:41:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:42:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:42:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:42:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:42:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclc34evpoehihkgu5iqkonafojdqecilkzsahpqvmopiq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:43:05 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclc34evpoehihkgu5iqkonafojdqecilkzsahpqvmopiq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:43:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:43:06 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:43:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:44:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:44:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:45:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:45:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:45:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycd5zqnhoj5wzx6kbetlkgj32arz5a3qctmyejxjsecvkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:45:40 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycd5zqnhoj5wzx6kbetlkgj32arz5a3qctmyejxjsecvkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:45:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:45:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:45:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:45:41 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 18:45:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:45:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:45:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:45:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 18:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 18:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:45:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:45:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 18:45:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 18:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:47:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:47:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:48:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:48:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:48:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycg6kkor66fsi7ov5yocwa5o5gavzc7c3b225xn2zhzzaq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:48:21 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycg6kkor66fsi7ov5yocwa5o5gavzc7c3b225xn2zhzzaq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:48:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:48:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:48:22 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata SKIPPED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:49:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:49:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:50:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:50:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:50:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:50:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycg4frbxeye2h4jxlua2qga2oviqi3sqbiv5rzw4jixgua, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:50:45 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycg4frbxeye2h4jxlua2qga2oviqi3sqbiv5rzw4jixgua, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:50:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:50:46 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 18:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:52:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:52:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:53:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:53:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:53:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:53:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclvq3axntmhnervvr3gmhiwwxz5icg7gf77zdnevobbtq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:53:43 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclvq3axntmhnervvr3gmhiwwxz5icg7gf77zdnevobbtq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:53:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:53:44 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:53:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:53:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:53:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:53:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:53:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:55:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:55:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:55:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:56:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:56:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:56:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyppk6zvuji4n3kborkzdmmylmnxvmiaqb55r73mu25ga, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:56:26 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyppk6zvuji4n3kborkzdmmylmnxvmiaqb55r73mu25ga, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:56:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:56:28 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:56:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:58:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:58:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 18:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 18:59:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 18:59:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 18:59:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycrvz6s3hvmw4rb6cjm2wasq2lizaskjcjcml4k2mm5xqa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:59:12 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycrvz6s3hvmw4rb6cjm2wasq2lizaskjcjcml4k2mm5xqa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 18:59:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:59:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 18:59:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 18:59:13 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:59:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:59:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:59:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:59:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 18:59:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 18:59:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:00:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:00:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:01:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:01:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:01:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:01:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczhka7doxkyedosjtjd2qq7txxlldzygym5wzuhlxmvya, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:02:00 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syczhka7doxkyedosjtjd2qq7txxlldzygym5wzuhlxmvya, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:02:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:02:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:02:02 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:02:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:02:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 19:02:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 19:02:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:03:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:03:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:04:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:04:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:04:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:04:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:04:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:04:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syceepcjkdnl6jyaj7txsvq6pkh5zy6bjpuzsqnfusoxc7q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:05:16 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syceepcjkdnl6jyaj7txsvq6pkh5zy6bjpuzsqnfusoxc7q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:05:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:05:17 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:05:17 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:05:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:05:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:05:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:07:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:07:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:07:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:08:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:08:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:08:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyjm35lrcy6lm4unmoavhk5wkuyd2jr2edmsmzqs4yanq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:08:38 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycyjm35lrcy6lm4unmoavhk5wkuyd2jr2edmsmzqs4yanq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:08:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:08:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:08:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:08:39 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:08:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 19:08:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:10:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:10:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:10:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:10:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:10:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:11:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2dtdl6jmwhmd2ftcravd62a2tw6kl7r6ngc2gdpito3q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:11:09 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2dtdl6jmwhmd2ftcravd62a2tw6kl7r6ngc2gdpito3q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:11:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:11:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:11:10 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:12:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:12:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:13:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:13:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:13:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:13:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdlpywll4ueqtym6laeeedgfnpagxra5qmsliomtg34kq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:14:12 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdlpywll4ueqtym6laeeedgfnpagxra5qmsliomtg34kq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:14:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:14:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:14:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:14:13 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:14:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 19:14:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 19:14:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:15:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:15:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:16:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:16:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:16:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:16:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:16:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc6icbatxnyujymqb2lb4edgx2lbrq7jagwt2p3vxcuavq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:18:53 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc6icbatxnyujymqb2lb4edgx2lbrq7jagwt2p3vxcuavq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:18:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:18:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:18:54 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:18:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:18:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:18:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:18:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:21:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:21:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:22:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:22:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:22:10 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc52dwrtortpc4vmmk4ojc33gcudcwgpugjrvb4wyjhpqa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:22:19 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc52dwrtortpc4vmmk4ojc33gcudcwgpugjrvb4wyjhpqa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:22:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:22:20 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:24:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:24:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:25:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:25:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:25:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycugfwwwkce5ooesyssjqygrg5iyax6wcaiuqxxoujzana, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:25:23 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycugfwwwkce5ooesyssjqygrg5iyax6wcaiuqxxoujzana, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:25:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:25:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:25:24 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:27:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:27:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:27:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:28:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:28:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:28:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycujql3w4fsbzq47o6dtbmgwpetuybkhfrj5hd42bmt6ba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:28:11 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycujql3w4fsbzq47o6dtbmgwpetuybkhfrj5hd42bmt6ba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:28:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:28:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:28:12 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:29:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:29:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:30:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:30:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:30:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:30:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmn7lkvjrklwpvwvnn35g5ps5avqkdjpcxqavgotuvd4a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:30:52 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycmn7lkvjrklwpvwvnn35g5ps5avqkdjpcxqavgotuvd4a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:30:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:30:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:30:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:30:53 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:30:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:32:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:32:14 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:32:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:33:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:33:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:33:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc5tmgylwanrdgvogp652u27ig33ofw4a5pu6mnilr5pga, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:33:17 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc5tmgylwanrdgvogp652u27ig33ofw4a5pu6mnilr5pga, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:33:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:33:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:33:18 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 19:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 19:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:34:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:34:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:35:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:35:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:35:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:35:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3gnwjrxa62eihh7uneboomvh2ucjlpjszz4oxdhpqi2a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:35:45 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3gnwjrxa62eihh7uneboomvh2ucjlpjszz4oxdhpqi2a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:35:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:35:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:35:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:35:47 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:35:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:35:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:37:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:37:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:38:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:38:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:38:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:38:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsnqurmovgazerwl2jdlqtb6ajiztcemxdtr7cl6khc5a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:38:34 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycsnqurmovgazerwl2jdlqtb6ajiztcemxdtr7cl6khc5a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:38:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:38:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:38:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:38:35 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:38:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:38:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:40:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:40:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:41:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:41:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:41:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdyqv2ummnd3npmbcmkrcwrw5r6qg524j3ezmcz3vaipq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:41:55 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdyqv2ummnd3npmbcmkrcwrw5r6qg524j3ezmcz3vaipq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:41:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:41:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:41:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:41:56 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:41:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:43:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:43:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:44:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:44:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:44:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:44:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdw2qnipjj4d37jsmsybbntuqzdxqa3ynmlxakt4lkcra, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:44:40 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycdw2qnipjj4d37jsmsybbntuqzdxqa3ynmlxakt4lkcra, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:44:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:44:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:44:41 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:46:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:46:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:47:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:47:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:47:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:47:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2ujifqwc7tfijortdmk6gcwcwxphhoku6zggl3cxghfa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:47:28 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc2ujifqwc7tfijortdmk6gcwcwxphhoku6zggl3cxghfa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:47:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:47:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:47:29 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:47:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:49:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:49:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:49:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:50:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:50:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:50:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycphlhilfgcc7ecd7zj524ggs6bwrnymbbhamg77yxie4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:50:15 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycphlhilfgcc7ecd7zj524ggs6bwrnymbbhamg77yxie4q, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:50:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:50:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:50:16 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:50:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:50:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:51:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:51:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:52:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:52:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:52:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:52:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycorfmkeiymbw4sbvjpguciisnkavnwkt42vkolsrp3h7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:53:01 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycorfmkeiymbw4sbvjpguciisnkavnwkt42vkolsrp3h7a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:53:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:53:02 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:54:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:54:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:55:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:55:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:55:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbejrcjrexgkbv4yn74e524ri7lv7rqw2sr2t7empjplq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:55:25 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbejrcjrexgkbv4yn74e524ri7lv7rqw2sr2t7empjplq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:55:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:55:26 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:55:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:57:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:57:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 19:58:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 19:58:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclezl67byzfcx4jc3e7mgwslbgnosngeph4vxkr7gimkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:58:09 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syclezl67byzfcx4jc3e7mgwslbgnosngeph4vxkr7gimkq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 19:58:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:58:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 19:58:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 19:58:10 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 19:58:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 19:58:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 19:58:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 19:58:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 19:58:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 19:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 19:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 19:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 19:58:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 19:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 19:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 19:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 19:58:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 19:58:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 19:58:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 19:58:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 19:58:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 19:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 19:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 19:58:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 19:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 19:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 19:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 19:58:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 19:58:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 19:58:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 19:58:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 19:58:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 19:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 19:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 19:58:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 19:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 19:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 19:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 19:58:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 19:58:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 19:58:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 19:58:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 19:58:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 19:58:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 19:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 19:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 19:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 19:58:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 19:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 19:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 19:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 19:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 19:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 19:59:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 19:59:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:00:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:01:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:01:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycoc2whypakqlvkvaesczoufjnwzf6n4dczdceuooajzsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:01:08 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycoc2whypakqlvkvaesczoufjnwzf6n4dczdceuooajzsq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:01:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:01:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:01:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:01:10 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 20:01:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 20:01:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 20:01:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 20:01:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 20:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 20:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 20:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 20:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 20:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 20:01:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 20:01:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 20:01:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 20:01:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 20:01:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 20:01:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 20:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 20:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 20:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 20:01:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 20:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 20:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 20:01:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 20:01:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 20:01:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 20:01:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 20:01:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 20:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 20:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 20:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 20:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:01:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 20:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 20:01:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 20:01:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 20:01:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 20:01:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:01:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 20:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 20:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 20:01:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 20:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 20:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 20:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 20:01:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:02:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:02:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:03:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:03:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:03:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:03:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwpwyd24xk3kju6oeptl3i2qcygaizhidkbuko2vqoraa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:04:08 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycwpwyd24xk3kju6oeptl3i2qcygaizhidkbuko2vqoraa, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:04:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:04:08 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:04:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:04:09 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 20:04:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 20:04:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 20:04:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 20:04:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 20:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 20:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 20:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 20:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 20:04:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 20:04:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 20:04:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 20:04:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 20:04:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 20:04:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 20:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 20:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 20:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 20:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:04:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 20:04:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 20:04:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 20:04:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 20:04:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 20:04:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 20:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 20:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 20:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 20:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 20:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 20:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 20:04:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 20:04:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 20:04:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 20:04:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:04:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 20:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 20:04:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 20:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 20:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 20:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 20:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 20:04:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:06:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:06:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:06:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:07:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:07:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc5sg3q3he3j6nc4aghgspszsed5rkhpf6ct37hognu5ma, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:07:11 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc5sg3q3he3j6nc4aghgspszsed5rkhpf6ct37hognu5ma, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:07:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:07:12 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 20:07:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 20:07:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 20:07:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 20:07:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 20:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 20:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 20:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 20:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 20:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 20:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 20:07:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 20:07:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 20:07:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 20:07:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 20:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 20:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 20:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 20:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 20:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 20:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 20:07:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 20:07:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 20:07:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 20:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 20:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 20:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 20:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 20:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 20:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 20:07:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 20:07:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 20:07:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 20:07:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:07:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+2021-09-05 20:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 20:07:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 20:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 20:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 20:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 20:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 20:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 20:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 20:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:09:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:09:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:09:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:09:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:09:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:10:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc54aywmdfulvs2txhmbjaadi44pwtou5c37vhjdjtrvbq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:10:08 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc54aywmdfulvs2txhmbjaadi44pwtou5c37vhjdjtrvbq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:10:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:10:09 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:11:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:11:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:12:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:12:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:12:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:12:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycme2f5xeuhc5zblvcqr3fhfwb5m62r2gorwtmi3l5esbq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:12:50 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycme2f5xeuhc5zblvcqr3fhfwb5m62r2gorwtmi3l5esbq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:12:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:12:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:12:52 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 20:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 20:12:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 20:12:53 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 20:12:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/23088b20-6d1a-455c-9627-4fcda40697ad.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 20:12:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 20:12:54 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:12:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:13:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:13:22 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:13:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:13:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:13:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 20:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:15:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:15:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:15:14 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+2021-09-05 20:16:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:16:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:16:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:16:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjzj3iysktbmc6u6u7dguxgyax56hvppf4o5xc7zfaquq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:16:42 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycjzj3iysktbmc6u6u7dguxgyax56hvppf4o5xc7zfaquq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:16:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:16:43 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 20:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 20:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 20:16:44 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 20:16:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/3c84921b-8112-46f5-b028-a1ac27e80146.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 20:16:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 20:16:45 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:16:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:17:17 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:17:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:17:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:17:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:17:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 20:17:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 20:18:48 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:18:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:18:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:19:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:19:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:19:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sych2k2tpygj3yc5h2maugxxrut2r2w6bqmber3rofmqqdq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:19:50 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sych2k2tpygj3yc5h2maugxxrut2r2w6bqmber3rofmqqdq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:19:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:19:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:19:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:19:51 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:19:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:19:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:21:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:21:19 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:22:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:22:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:22:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgaolfivceuvy6fdgpwc22qp6izxylaao2r6f5f7dmnba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:22:34 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycgaolfivceuvy6fdgpwc22qp6izxylaao2r6f5f7dmnba, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:22:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:22:35 INFO      integration_testing:clouds.py:183 image serial: 20210826
+Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:22:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:23:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:23:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:24:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:24:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:24:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbmmumoqffbjcizowernyr6s4ph34zmqgpiq5cacbgniq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:24:58 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycbmmumoqffbjcizowernyr6s4ph34zmqgpiq5cacbgniq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:24:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:24:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:25:00 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 20:25:00 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:25:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:25:26 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:25:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:25:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:25:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:25:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:25:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 20:25:36 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 20:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/94e35df6-e04a-4d83-a5ec-e9eff64b0e3a.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 20:25:36 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:25:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:25:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:26:03 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:26:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:26:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:26:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:26:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 20:27:39 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:27:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:27:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:28:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:28:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:28:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycuiyi4ywdcfq4t37x3zr442oavyg45trb7beihmuvogya, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:28:40 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycuiyi4ywdcfq4t37x3zr442oavyg45trb7beihmuvogya, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:28:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:28:42 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:28:42 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 20:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/992a48f8-4c7d-4d33-a877-e72c60b539e6.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 20:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 20:28:43 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:28:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:28:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:29:07 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:29:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:29:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:29:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:30:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:30:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:31:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:31:28 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 20:31:44 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:31:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:31:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3bs2knadvnl5yfjmhkhzk3ru57fzkof5lk2gxbycxvda, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:31:54 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc3bs2knadvnl5yfjmhkhzk3ru57fzkof5lk2gxbycxvda, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:31:55 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:31:55 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:31:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 20:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/b8b9bd0f-8bd6-4b16-9656-1fe7af3505ea.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 20:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 20:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 20:31:56 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 20:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c sync
+2021-09-05 20:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:32:24 ERROR     paramiko.transport:transport.py:1819 Socket exception: Connection reset by peer (104)
+2021-09-05 20:32:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:32:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:32:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:32:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 20:32:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:34:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:34:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+2021-09-05 20:34:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+2021-09-05 20:34:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 20:35:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 20:35:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 20:35:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc32moyyu5ljcpnek3re4kde7ij4ogsm2aygxvupct3rvq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:35:13 INFO      integration_testing:clouds.py:173 Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc32moyyu5ljcpnek3re4kde7ij4ogsm2aygxvupct3rvq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+2021-09-05 20:35:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:35:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 20:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210826
+2021-09-05 20:35:15 INFO      integration_testing:clouds.py:183 image serial: 20210826
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:35:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:35:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:35:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=focal os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 20:35:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=focal os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 20:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 20:36:44 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: ocid1.image.oc1.phx.aaaaaaaa2ebsollrwt7dtcg6iwsjg7isxflzta3newjgyilmdv24tfnkjjoq
+
+
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========== 120 passed, 29 skipped, 1 warning in 9769.13s (2:42:49) ============

--- a/21.3-1/integration_tests/openstack_4a6d8184-a839-44f5-b09d-be6170837068::ubuntu::hirsute_integration_tests.txt
+++ b/21.3-1/integration_tests/openstack_4a6d8184-a839-44f5-b09d-be6170837068::ubuntu::hirsute_integration_tests.txt
@@ -1,0 +1,4648 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:31:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 04:31:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=4a6d8184-a839-44f5-b09d-be6170837068::ubuntu::hirsute
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-06 04:31:33 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=4a6d8184-a839-44f5-b09d-be6170837068::ubuntu::hirsute
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for openstack
+2021-09-06 04:31:33 INFO      integration_testing:conftest.py:156 Setting up environment for openstack
+Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=None
+2021-09-06 04:31:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=None
+2021-09-06 04:32:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:32:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:32:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:32:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=cb5f39f2-e078-4857-be93-b001851e60de)
+2021-09-06 04:32:50 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=cb5f39f2-e078-4857-be93-b001851e60de)
+2021-09-06 04:32:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:32:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:32:51 INFO      integration_testing:clouds.py:183 image serial: 20210820
+Installing proposed image
+2021-09-06 04:32:51 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 04:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 04:32:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 04:33:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 04:33:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:33:13 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:33:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 04:33:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-06 04:33:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 04:33:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: 84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+2021-09-06 04:34:17 INFO      integration_testing:instances.py:114 Created new image: 84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+Done with environment setup
+2021-09-06 04:34:26 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 04:34:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 04:35:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:35:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:35:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:35:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=44b3c0bb-3c14-4e2f-b2d6-3907528abcaf)
+2021-09-06 04:35:34 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=44b3c0bb-3c14-4e2f-b2d6-3907528abcaf)
+2021-09-06 04:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:35:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:35:34 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-06 04:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:35:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:35:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-06 04:35:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-06 04:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:36:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:36:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:36:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4e6deb25-bbbc-4aa7-8596-0694749c1f3d)
+2021-09-06 04:36:33 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4e6deb25-bbbc-4aa7-8596-0694749c1f3d)
+2021-09-06 04:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:36:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:36:34 INFO      integration_testing:clouds.py:183 image serial: 20210820
+2021-09-06 04:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-06 04:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-06 04:36:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-06 04:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 04:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-06 04:36:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-06 04:36:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-06 04:36:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-06 04:36:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-06 04:36:37 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 04:36:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 04:36:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 04:36:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 04:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:36:58 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:36:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 04:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-06 04:36:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-06 04:36:59 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 04:37:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:37:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:37:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:37:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 04:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-06 04:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-06 04:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-06 04:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-06 04:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-06 04:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 04:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-06 04:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-06 04:37:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-06 04:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-06 04:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.032s (kernel) + 25.446s (userspace) = 29.479s 
+graphical.target reached after 23.676s in userspace
+=== `systemd-analyze` after:
+Startup finished in 3.754s (kernel) + 23.964s (userspace) = 27.719s 
+graphical.target reached after 22.467s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+9.713s cloud-init-local.service
+6.437s snapd.seeded.service
+2.563s snapd.apparmor.service
+2.128s cloud-init.service
+1.849s snapd.service
+1.228s pollinate.service
+1.192s dev-vda1.device
+1.063s systemd-udev-settle.service
+1.044s cloud-config.service
+1.037s apparmor.service
+=== `systemd-analyze blame` after (first 10 lines):
+10.124s cloud-init-local.service
+ 7.330s snap.lxd.activate.service
+ 6.354s snapd.service
+ 2.385s cloud-init.service
+ 1.403s cloud-config.service
+ 1.292s dev-vda1.device
+ 1.048s networkd-dispatcher.service
+  881ms systemd-udev-settle.service
+  878ms udisks2.service
+  864ms cloud-final.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 08.74000 seconds
+Finished stage: (init-network) 01.53100 seconds
+Finished stage: (modules-config) 00.45600 seconds
+Finished stage: (modules-final) 00.16600 seconds
+Total Time: 10.89300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 09.28100 seconds
+Finished stage: (init-network) 01.67600 seconds
+Finished stage: (modules-config) 00.36800 seconds
+Finished stage: (modules-final) 00.20200 seconds
+Total Time: 11.52700 seconds
+Finished stage: (init-network) 00.25500 seconds
+Total Time: 0.25500 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.28500s (init-local/search-OpenStackLocal)
+     00.49800s (init-network/config-growpart)
+     00.39500s (init-network/config-mounts)
+     00.25500s (init-network/config-ssh)
+     00.20000s (modules-config/config-grub-dpkg)
+     00.18400s (modules-config/config-apt-configure)
+     00.11500s (init-network/config-resizefs)
+     00.06100s (modules-final/config-keys-to-console)
+     00.06100s (init-network/config-users-groups)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     08.74700s (init-local/search-OpenStackLocal)
+     00.85800s (init-network/config-ssh)
+     00.43800s (init-network/config-mounts)
+     00.19200s (modules-config/config-grub-dpkg)
+     00.10700s (modules-config/config-apt-configure)
+     00.09500s (modules-final/config-keys-to-console)
+     00.08800s (init-network/config-resizefs)
+     00.05500s (init-network/config-growpart)
+     00.03500s (modules-config/config-locale)
+
+2021-09-06 04:37:53 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 4.032s (kernel) + 25.446s (userspace) = 29.479s 
+graphical.target reached after 23.676s in userspace
+=== `systemd-analyze` after:
+Startup finished in 3.754s (kernel) + 23.964s (userspace) = 27.719s 
+graphical.target reached after 22.467s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+9.713s cloud-init-local.service
+6.437s snapd.seeded.service
+2.563s snapd.apparmor.service
+2.128s cloud-init.service
+1.849s snapd.service
+1.228s pollinate.service
+1.192s dev-vda1.device
+1.063s systemd-udev-settle.service
+1.044s cloud-config.service
+1.037s apparmor.service
+=== `systemd-analyze blame` after (first 10 lines):
+10.124s cloud-init-local.service
+ 7.330s snap.lxd.activate.service
+ 6.354s snapd.service
+ 2.385s cloud-init.service
+ 1.403s cloud-config.service
+ 1.292s dev-vda1.device
+ 1.048s networkd-dispatcher.service
+  881ms systemd-udev-settle.service
+  878ms udisks2.service
+  864ms cloud-final.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 08.74000 seconds
+Finished stage: (init-network) 01.53100 seconds
+Finished stage: (modules-config) 00.45600 seconds
+Finished stage: (modules-final) 00.16600 seconds
+Total Time: 10.89300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 09.28100 seconds
+Finished stage: (init-network) 01.67600 seconds
+Finished stage: (modules-config) 00.36800 seconds
+Finished stage: (modules-final) 00.20200 seconds
+Total Time: 11.52700 seconds
+Finished stage: (init-network) 00.25500 seconds
+Total Time: 0.25500 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.28500s (init-local/search-OpenStackLocal)
+     00.49800s (init-network/config-growpart)
+     00.39500s (init-network/config-mounts)
+     00.25500s (init-network/config-ssh)
+     00.20000s (modules-config/config-grub-dpkg)
+     00.18400s (modules-config/config-apt-configure)
+     00.11500s (init-network/config-resizefs)
+     00.06100s (modules-final/config-keys-to-console)
+     00.06100s (init-network/config-users-groups)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     08.74700s (init-local/search-OpenStackLocal)
+     00.85800s (init-network/config-ssh)
+     00.43800s (init-network/config-mounts)
+     00.19200s (modules-config/config-grub-dpkg)
+     00.10700s (modules-config/config-apt-configure)
+     00.09500s (modules-final/config-keys-to-console)
+     00.08800s (init-network/config-resizefs)
+     00.05500s (init-network/config-growpart)
+     00.03500s (modules-config/config-locale)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:38:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:38:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=4a6d8184-a839-44f5-b09d-be6170837068
+user_data=None
+2021-09-06 04:38:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:39:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:39:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:39:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=af5ff610-4a6d-4b0d-8b53-d84a31324e9e)
+2021-09-06 04:39:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=af5ff610-4a6d-4b0d-8b53-d84a31324e9e)
+2021-09-06 04:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:39:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~21.04.1
+2021-09-06 04:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:39:15 INFO      integration_testing:clouds.py:183 image serial: 20210820
+Installing proposed image
+2021-09-06 04:39:15 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-06 04:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-06 04:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-06 04:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-06 04:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:39:38 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~21.04.2
+Restarting instance and waiting for boot
+2021-09-06 04:39:38 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 04:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:40:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:40:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 04:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:40:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-06 04:40:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-06 04:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:41:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:41:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=fce045e5-0670-41ea-8af7-2df8b57760e3)
+2021-09-06 04:43:35 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=fce045e5-0670-41ea-8af7-2df8b57760e3)
+2021-09-06 04:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:43:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:43:36 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:43:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-06 04:43:45 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-06 04:44:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:44:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:44:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:44:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e4881a80-28a7-4297-82a2-00f36f1cf95e)
+2021-09-06 04:44:51 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e4881a80-28a7-4297-82a2-00f36f1cf95e)
+2021-09-06 04:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:44:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:44:51 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:45:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-06 04:45:07 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-06 04:45:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:45:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:45:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:46:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f15f0822-b3e9-40db-8d1e-64781f2fe126)
+2021-09-06 04:46:04 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f15f0822-b3e9-40db-8d1e-64781f2fe126)
+2021-09-06 04:46:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:46:05 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:46:05 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:46:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-06 04:46:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-06 04:46:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:46:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:47:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:47:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f54eaf1a-6fb3-4672-b17d-e4bd6cd43300)
+2021-09-06 04:47:11 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f54eaf1a-6fb3-4672-b17d-e4bd6cd43300)
+2021-09-06 04:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:47:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:47:12 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 04:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-06 04:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:47:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 04:47:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 04:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:48:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:48:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:48:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:48:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:48:05 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=ec8c9589-3eb1-4dd2-a5aa-48097ba39a45)
+2021-09-06 04:48:11 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=ec8c9589-3eb1-4dd2-a5aa-48097ba39a45)
+2021-09-06 04:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:48:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:48:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:48:12 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-06 04:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-06 04:48:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-06 04:48:12 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 04:48:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:48:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:48:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:49:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 04:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-06 04:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:49:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-06 04:49:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-06 04:49:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:50:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:50:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:50:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:50:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=db646431-4d25-414d-b86a-349cc406eb41)
+2021-09-06 04:50:24 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=db646431-4d25-414d-b86a-349cc406eb41)
+2021-09-06 04:50:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:50:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:50:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:50:25 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 04:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-hirsute.list'
+2021-09-06 04:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-06 04:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-06 04:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:50:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-06 04:50:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-06 04:50:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:51:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:51:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:51:18 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=23cbc88b-d7f9-4955-82d5-966ac581887c)
+2021-09-06 04:51:23 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=23cbc88b-d7f9-4955-82d5-966ac581887c)
+2021-09-06 04:51:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:51:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:51:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:51:23 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:51:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init query v1.availability_zone'
+2021-09-06 04:51:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:51:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:51:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:51:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-06 04:51:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-06 04:52:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:52:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:52:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:52:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=ca55c17e-6113-4fdf-ba5f-e028043e08eb)
+2021-09-06 04:52:26 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=ca55c17e-6113-4fdf-ba5f-e028043e08eb)
+2021-09-06 04:52:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:52:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:52:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:52:27 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:52:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:52:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-06 04:52:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-06 04:53:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:53:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:53:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:53:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=755e6381-319b-49c4-b07f-63e6a80f7591)
+2021-09-06 04:53:30 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=755e6381-319b-49c4-b07f-63e6a80f7591)
+2021-09-06 04:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:53:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:53:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:53:31 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:53:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:53:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:53:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-06 04:53:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-06 04:54:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:54:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:54:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:54:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=74890380-9130-485a-92da-ef21ed3ceb14)
+2021-09-06 04:54:41 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=74890380-9130-485a-92da-ef21ed3ceb14)
+2021-09-06 04:54:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:54:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:54:42 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-06 04:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-06 04:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-06 04:54:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:54:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:54:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:54:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-06 04:54:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-06 04:55:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:55:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:55:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:55:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=fbfffc5f-8645-4ef4-bc7d-f711b2727d43)
+2021-09-06 04:55:45 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=fbfffc5f-8645-4ef4-bc7d-f711b2727d43)
+2021-09-06 04:55:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:55:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:55:46 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:55:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:55:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-06 04:55:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-06 04:56:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:56:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:56:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:56:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5537ec96-2335-44ac-a429-32e500363a6e)
+2021-09-06 04:56:49 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5537ec96-2335-44ac-a429-32e500363a6e)
+2021-09-06 04:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:56:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:56:49 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:56:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:57:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-06 04:57:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-06 04:57:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:57:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:57:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:57:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6e4e6a20-4d03-4909-9405-4585c6513982)
+2021-09-06 04:58:03 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6e4e6a20-4d03-4909-9405-4585c6513982)
+2021-09-06 04:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:58:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:58:03 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-06 04:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-06 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-06 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-06 04:58:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:58:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-06 04:58:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-06 04:58:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:58:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:59:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:59:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=fa11461c-ce17-4c4d-a210-ab4ef726c898)
+2021-09-06 04:59:13 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=fa11461c-ce17-4c4d-a210-ab4ef726c898)
+2021-09-06 04:59:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:59:14 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 04:59:14 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 04:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 04:59:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+updates:
+  network:
+    when: ['hotplug']
+
+2021-09-06 04:59:24 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+updates:
+  network:
+    when: ['hotplug']
+
+2021-09-06 04:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:59:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:00:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:00:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:00:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:00:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:00:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:00:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:00:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=a477a891-5b4e-47cc-a97e-a2306980b064)
+2021-09-06 05:00:13 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=a477a891-5b4e-47cc-a97e-a2306980b064)
+2021-09-06 05:00:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:00:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:00:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:00:14 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:00:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-06 05:00:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-06 05:00:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:00:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:01:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-06 05:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel hotplug-hook -s net query'
+PASSED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:01:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:01:27 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:01:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:02:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:02:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:02:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=916721d3-a7ee-416c-8ce2-8e63c787fe29)
+2021-09-06 05:02:23 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=916721d3-a7ee-416c-8ce2-8e63c787fe29)
+2021-09-06 05:02:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:02:24 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:02:24 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-06 05:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:02:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:02:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:02:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:02:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-06 05:02:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel hotplug-hook -s net query'
+PASSED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:03:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-06 05:03:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-06 05:03:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:03:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:03:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:03:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:03:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:03:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:04:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:04:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:04:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=de7d05be-7e40-4135-a37a-d0395860e27e)
+2021-09-06 05:04:18 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=de7d05be-7e40-4135-a37a-d0395860e27e)
+2021-09-06 05:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:04:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:04:19 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-06 05:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:04:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-06 05:04:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-06 05:04:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:05:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:05:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:05:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=990c16b9-a894-4534-84c4-8e263433dae3)
+2021-09-06 05:05:28 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=990c16b9-a894-4534-84c4-8e263433dae3)
+2021-09-06 05:05:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:05:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:05:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:05:29 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:05:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:05:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:05:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:05:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:05:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:05:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:05:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:05:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-06 05:05:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-06 05:06:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:06:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:06:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:06:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=dd9c76c4-0034-4b3a-8002-e5d3fee9560f)
+2021-09-06 05:06:28 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=dd9c76c4-0034-4b3a-8002-e5d3fee9560f)
+2021-09-06 05:06:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:06:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:06:29 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:06:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:06:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:06:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-06 05:06:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-06 05:07:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:07:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:07:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:07:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=b28e563d-dd66-464e-b703-5b36e02fb3aa)
+2021-09-06 05:07:30 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=b28e563d-dd66-464e-b703-5b36e02fb3aa)
+2021-09-06 05:07:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:07:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:07:31 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:07:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:07:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-06 05:07:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-06 05:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:08:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:08:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:08:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3bbd951e-1fa4-47e1-9305-170be2a2c1d6)
+2021-09-06 05:08:51 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3bbd951e-1fa4-47e1-9305-170be2a2c1d6)
+2021-09-06 05:08:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:08:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:08:52 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:08:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-06 05:08:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:09:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-06 05:09:01 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-06 05:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:09:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:09:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:09:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=70a2b309-5c8e-4c2a-bc68-4476ad13247e)
+2021-09-06 05:10:06 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=70a2b309-5c8e-4c2a-bc68-4476ad13247e)
+2021-09-06 05:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:10:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:10:07 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:10:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:10:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:10:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:10:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-06 05:10:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-06 05:10:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:10:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:11:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:11:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:11:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:11:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:11:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=a670b712-cba0-4bc2-b912-32141157bb8a)
+2021-09-06 05:11:27 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=a670b712-cba0-4bc2-b912-32141157bb8a)
+2021-09-06 05:11:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:11:28 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:11:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:11:28 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:11:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-06 05:11:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:11:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-06 05:11:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-06 05:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:12:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:12:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:12:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c5279168-ddd5-4cec-9d59-c83c777c8d9b)
+2021-09-06 05:12:30 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c5279168-ddd5-4cec-9d59-c83c777c8d9b)
+2021-09-06 05:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:12:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:12:31 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:12:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-06 05:12:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-06 05:13:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:13:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:13:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:13:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=16dc278b-fe81-4888-a529-1799b7ddc967)
+2021-09-06 05:13:55 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=16dc278b-fe81-4888-a529-1799b7ddc967)
+2021-09-06 05:13:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:13:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:13:56 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-06 05:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-06 05:13:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:14:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-06 05:14:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-06 05:14:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:14:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:14:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:14:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5b8aff54-346c-4d1a-821f-7a4460b9cdc9)
+2021-09-06 05:16:17 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5b8aff54-346c-4d1a-821f-7a4460b9cdc9)
+2021-09-06 05:16:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:16:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:16:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:16:18 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:16:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:16:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:16:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:16:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:16:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:16:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-06 05:16:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-06 05:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:17:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:17:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:17:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=8ebf2dfb-b4c9-49bc-b858-cea094d2dae4)
+2021-09-06 05:17:31 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=8ebf2dfb-b4c9-49bc-b858-cea094d2dae4)
+2021-09-06 05:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:17:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:17:31 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:17:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:17:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-06 05:17:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-06 05:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:18:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:18:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:18:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0334a3df-de30-4f3a-b9a6-65ad805f1301)
+2021-09-06 05:18:37 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0334a3df-de30-4f3a-b9a6-65ad805f1301)
+2021-09-06 05:18:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:18:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:18:38 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:18:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:18:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-06 05:18:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-06 05:19:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:19:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:19:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:19:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4954f028-ea11-4b96-ae9c-2041a8d7eff8)
+2021-09-06 05:19:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4954f028-ea11-4b96-ae9c-2041a8d7eff8)
+2021-09-06 05:19:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:19:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:19:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:19:40 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:19:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:19:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-06 05:19:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-06 05:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:20:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:20:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:20:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6963c275-0c4f-4d34-9fcf-8e93abad0f38)
+2021-09-06 05:20:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6963c275-0c4f-4d34-9fcf-8e93abad0f38)
+2021-09-06 05:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:20:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:20:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:20:44 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:20:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:20:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-06 05:20:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-06 05:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:21:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:21:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:21:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3f9eab69-a546-4a35-9ff9-b8f047e34f7a)
+2021-09-06 05:21:57 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3f9eab69-a546-4a35-9ff9-b8f047e34f7a)
+2021-09-06 05:21:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:21:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:21:58 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-06 05:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-06 05:21:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:22:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-06 05:22:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-06 05:22:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:22:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:22:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:22:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=d9798b36-2a5a-49e4-a62d-cf9fb8a91429)
+2021-09-06 05:23:04 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=d9798b36-2a5a-49e4-a62d-cf9fb8a91429)
+2021-09-06 05:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:23:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:23:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-06 05:23:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-06 05:23:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:23:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:23:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:23:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=03a633a6-abe3-424e-bcb2-29a52ab70b8a)
+2021-09-06 05:24:03 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=03a633a6-abe3-424e-bcb2-29a52ab70b8a)
+2021-09-06 05:24:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:24:04 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:24:04 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:24:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:24:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-06 05:24:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-06 05:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:24:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:24:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:24:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=a77d71cc-0588-40ea-be41-6ba8da503096)
+2021-09-06 05:25:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=a77d71cc-0588-40ea-be41-6ba8da503096)
+2021-09-06 05:25:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:25:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:25:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:25:26 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:25:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:25:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-06 05:25:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-06 05:26:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:26:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:26:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:26:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4c477ccf-aa18-4bcf-bfc3-98369ce182c1)
+2021-09-06 05:26:29 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4c477ccf-aa18-4bcf-bfc3-98369ce182c1)
+2021-09-06 05:26:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:26:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:26:30 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:26:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-06 05:26:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-06 05:27:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:27:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:27:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:27:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=2c5e8830-1aed-4f8c-a2f1-e2de24c3b1f5)
+2021-09-06 05:27:40 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=2c5e8830-1aed-4f8c-a2f1-e2de24c3b1f5)
+2021-09-06 05:27:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:27:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:27:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:27:41 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:27:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:27:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-06 05:27:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-06 05:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:28:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:28:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:28:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e770b762-b074-4274-9352-0f063d08e189)
+2021-09-06 05:28:31 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e770b762-b074-4274-9352-0f063d08e189)
+2021-09-06 05:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:28:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:28:32 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:28:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-06 05:28:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-06 05:29:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:29:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:29:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:29:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=449021e3-c31f-4cc9-8e40-39c089606bef)
+2021-09-06 05:29:32 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=449021e3-c31f-4cc9-8e40-39c089606bef)
+2021-09-06 05:29:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:29:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:29:33 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:29:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-06 05:29:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-06 05:30:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:30:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:30:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:30:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=45427f1d-2f41-4881-ab11-c3328349abe2)
+2021-09-06 05:30:42 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=45427f1d-2f41-4881-ab11-c3328349abe2)
+2021-09-06 05:30:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:30:43 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:30:43 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:30:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:30:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:31:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:31:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=9980e6a9-bc00-4a7c-8b23-b0d7bf2fcf58)
+2021-09-06 05:31:50 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=9980e6a9-bc00-4a7c-8b23-b0d7bf2fcf58)
+2021-09-06 05:31:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:31:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:31:51 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-06 05:31:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-06 05:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-06 05:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-06 05:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-06 05:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-06 05:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-06 05:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-06 05:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-06 05:31:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-06 05:31:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-06 05:31:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-06 05:31:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-06 05:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-06 05:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-06 05:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-06 05:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-06 05:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-06 05:31:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-06 05:31:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-06 05:31:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-06 05:31:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-06 05:31:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:31:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-06 05:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-06 05:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-06 05:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-06 05:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-06 05:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-06 05:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-06 05:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-06 05:31:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-06 05:32:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-06 05:32:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:32:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-06 05:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-06 05:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-06 05:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:32:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:32:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:32:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:32:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4a4254d8-ae1a-4c0e-8123-e5ee9c7b3a8f)
+2021-09-06 05:32:56 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4a4254d8-ae1a-4c0e-8123-e5ee9c7b3a8f)
+2021-09-06 05:32:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:32:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:32:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:32:56 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:32:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-06 05:32:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-06 05:32:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-06 05:32:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-06 05:32:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:32:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:32:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-06 05:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-06 05:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-06 05:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-06 05:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-06 05:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-06 05:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-06 05:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-06 05:32:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-06 05:33:00 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:01 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-06 05:33:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:33:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-06 05:33:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-06 05:33:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-06 05:33:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-06 05:33:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-06 05:33:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-06 05:33:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-06 05:33:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-06 05:33:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-06 05:33:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-06 05:33:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:33:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-06 05:33:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-06 05:33:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-06 05:33:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-06 05:33:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-06 05:33:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:33:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-06 05:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:33:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-06 05:33:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-06 05:33:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:33:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:33:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:33:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:33:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:34:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:34:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3c06c160-545d-4013-b552-2411d53d9990)
+2021-09-06 05:34:11 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3c06c160-545d-4013-b552-2411d53d9990)
+2021-09-06 05:34:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:34:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:34:12 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:34:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-06 05:34:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-06 05:34:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-06 05:34:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-06 05:34:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-06 05:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-06 05:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-06 05:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-06 05:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-06 05:34:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-06 05:34:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-06 05:34:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-06 05:34:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-06 05:34:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-06 05:34:16 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-06 05:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-06 05:34:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-06 05:34:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-06 05:34:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-06 05:34:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-06 05:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-06 05:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-06 05:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-06 05:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-06 05:34:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:34:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-06 05:34:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-06 05:34:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-06 05:34:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-06 05:34:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-06 05:34:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:34:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-06 05:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-06 05:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-06 05:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:34:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:34:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-06 05:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:35:17 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:17 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:35:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c9316e13-0536-42a0-8fe0-b540ce06c5c8)
+2021-09-06 05:35:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c9316e13-0536-42a0-8fe0-b540ce06c5c8)
+2021-09-06 05:35:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:35:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:35:26 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-06 05:35:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-06 05:35:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-06 05:35:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-06 05:35:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-06 05:35:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-06 05:35:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-06 05:35:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-06 05:35:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-06 05:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-06 05:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-06 05:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-06 05:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-06 05:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-06 05:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-06 05:35:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-06 05:35:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-06 05:35:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-06 05:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-06 05:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-06 05:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-06 05:35:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-06 05:35:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-06 05:35:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:35:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-06 05:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-06 05:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-06 05:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-06 05:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-06 05:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-06 05:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-06 05:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-06 05:35:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:35:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-06 05:35:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-06 05:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:36:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:36:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:36:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0b70428f-d656-4386-aa38-9818596c6b7d)
+2021-09-06 05:36:42 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0b70428f-d656-4386-aa38-9818596c6b7d)
+2021-09-06 05:36:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:36:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:36:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:36:42 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:36:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:36:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:36:53 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:37:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:37:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:37:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:37:55 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=418f3947-d524-4906-babc-605042073617)
+2021-09-06 05:37:59 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=418f3947-d524-4906-babc-605042073617)
+2021-09-06 05:37:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:38:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:38:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:38:00 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:38:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:38:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-06 05:38:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:38:01 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-06 05:38:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/1326725f-8095-44f2-850f-e3d553fa33fa.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:38:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-06 05:38:01 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:38:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:38:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:38:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:38:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:38:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:38:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-06 05:38:48 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:38:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-06 05:38:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-06 05:39:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:39:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:39:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:39:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5372b47a-d9ce-4ce5-9acb-f450a0ab646c)
+2021-09-06 05:39:47 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5372b47a-d9ce-4ce5-9acb-f450a0ab646c)
+2021-09-06 05:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:39:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:39:48 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-06 05:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:39:49 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-06 05:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/6089b160-0c50-41ec-a9ac-ff37ed78abb6.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-06 05:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-06 05:39:49 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:40:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:40:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:40:40 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-06 05:41:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-06 05:41:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-06 05:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:41:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:41:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:41:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0b92d9fb-f100-492f-8001-6898863f5e13)
+2021-09-06 05:41:57 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0b92d9fb-f100-492f-8001-6898863f5e13)
+2021-09-06 05:41:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:41:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:41:58 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:41:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:42:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-06 05:42:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-06 05:42:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:42:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:43:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:43:09 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=7695bd61-7831-4953-9301-df1a497ab0b7)
+2021-09-06 05:43:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=7695bd61-7831-4953-9301-df1a497ab0b7)
+2021-09-06 05:43:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:43:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:43:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:43:15 INFO      integration_testing:clouds.py:183 image serial: 20210820
+Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:43:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 05:43:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sed -i '"'"'s/#include/@include/g'"'"' /etc/sudoers'
+2021-09-06 05:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+2021-09-06 05:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-06 05:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Restarting instance and waiting for boot
+2021-09-06 05:43:16 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:43:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:43:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:44:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:44:02 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:44:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/sudoers'
+PASSED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:44:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:44:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:44:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:44:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:45:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:45:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6a59626a-5fd7-4339-9db5-dd55753943b0)
+2021-09-06 05:45:20 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6a59626a-5fd7-4339-9db5-dd55753943b0)
+2021-09-06 05:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:45:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:45:20 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-06 05:45:21 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:45:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:45:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:46:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-06 05:46:05 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-06 05:46:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/95d86212-131a-4f2a-ac85-a9b0cd3d0ab4.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-06 05:46:06 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:46:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:46:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:46:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:47:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-06 05:47:12 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:47:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:47:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:47:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:47:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:47:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:47:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=7f9cd5bd-b52b-4f43-a077-7af355e0096d)
+2021-09-06 05:48:03 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=7f9cd5bd-b52b-4f43-a077-7af355e0096d)
+2021-09-06 05:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:48:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:48:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:48:03 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:48:04 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-06 05:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/4d7b065b-d925-4194-9cb5-91a7fbd6e931.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-06 05:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-06 05:48:04 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:48:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:48:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:48:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:48:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:48:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:48:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:48:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-06 05:48:59 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:48:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:48:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=None
+2021-09-06 05:49:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:49:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:49:44 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:49:47 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=aa31e9ed-8f25-4123-8c13-7404741f78ca)
+2021-09-06 05:49:51 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=aa31e9ed-8f25-4123-8c13-7404741f78ca)
+2021-09-06 05:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:49:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:49:51 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:49:52 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-06 05:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/c86f1717-bfdf-40a5-8faa-4b704d78a9f8.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-06 05:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-06 05:49:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-06 05:49:52 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-06 05:50:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:50:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:50:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:50:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 05:50:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-06 05:50:48 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:50:48 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-06 05:50:48 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-06 05:51:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 05:51:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 05:51:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 05:51:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=756dbeca-36ec-4fa9-bc7a-f5146010e28a)
+2021-09-06 05:51:38 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=756dbeca-36ec-4fa9-bc7a-f5146010e28a)
+2021-09-06 05:51:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:51:39 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210820
+2021-09-06 05:51:39 INFO      integration_testing:clouds.py:183 image serial: 20210820
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:51:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:51:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:51:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:51:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+
+-------------------------------- live log setup --------------------------------
+2021-09-06 05:51:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+-------------------------------- live log call ---------------------------------
+2021-09-06 05:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: 84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+
+------------------------------ live log teardown -------------------------------
+2021-09-06 05:51:50 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: 84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+
+
+=================================== FAILURES ===================================
+______________________________ test_chef_license _______________________________
+
+client = <tests.integration_tests.instances.IntegrationInstance object at 0x7fe1876b8208>
+
+    @pytest.mark.adhoc  # Can't be regularly reaching out to chef install script
+    @pytest.mark.user_data(USERDATA)
+    def test_chef_license(client: IntegrationInstance):
+        log = client.read_from_file('/var/log/cloud-init.log')
+>       verify_clean_log(log)
+
+tests/integration_tests/bugs/test_gh868.py:22: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+log = "2021-09-06 04:41:03,575 - util.py[DEBUG]: Cloud-init v. 21.3-1-g6803368d-0ubuntu1~21.04.2 running 'init-local' at Mon...seconds (131.26)\n2021-09-06 04:43:35,401 - handlers.py[DEBUG]: finish: modules-final: FAIL: running modules for final"
+
+    def verify_clean_log(log):
+        """Assert no unexpected tracebacks or warnings in logs"""
+        warning_count = log.count('WARN')
+        expected_warnings = 0
+        traceback_count = log.count('Traceback')
+        expected_tracebacks = 0
+    
+        warning_texts = [
+            # Consistently on all Azure launches:
+            # azure.py[WARNING]: No lease found; using default endpoint
+            'No lease found; using default endpoint'
+        ]
+        traceback_texts = []
+        if 'oracle' in log:
+            # LP: #1842752
+            lease_exists_text = 'Stderr: RTNETLINK answers: File exists'
+            warning_texts.append(lease_exists_text)
+            traceback_texts.append(lease_exists_text)
+            # LP: #1833446
+            fetch_error_text = (
+                'UrlError: 404 Client Error: Not Found for url: '
+                'http://169.254.169.254/latest/meta-data/')
+            warning_texts.append(fetch_error_text)
+            traceback_texts.append(fetch_error_text)
+    
+        for warning_text in warning_texts:
+            expected_warnings += log.count(warning_text)
+        for traceback_text in traceback_texts:
+            expected_tracebacks += log.count(traceback_text)
+    
+>       assert warning_count == expected_warnings
+E       AssertionError
+
+tests/integration_tests/util.py:61: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-06 04:40:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=4a6d8184-a839-44f5-b09d-be6170837068 os=ubuntu release=hirsute
+2021-09-06 04:40:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=84226cf6-d15e-4e44-a8d0-2994bfbe7c09
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-06 04:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-06 04:41:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.4p1)
+2021-09-06 04:41:16 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-06 04:41:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-06 04:43:35 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=fce045e5-0670-41ea-8af7-2df8b57760e3)
+2021-09-06 04:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-06 04:43:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~21.04.2
+2021-09-06 04:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-06 04:43:36 INFO      integration_testing:clouds.py:183 image serial: 20210820
+------------------------------ Captured log call -------------------------------
+2021-09-06 04:43:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 351 warnings
+tests/integration_tests/test_upgrade.py: 82 warnings
+tests/integration_tests/bugs/test_gh868.py: 41 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 41 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 41 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 41 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 41 warnings
+tests/integration_tests/modules/test_apt.py: 164 warnings
+tests/integration_tests/modules/test_ca_certs.py: 41 warnings
+tests/integration_tests/modules/test_cli.py: 82 warnings
+tests/integration_tests/modules/test_combined.py: 41 warnings
+tests/integration_tests/modules/test_command_output.py: 41 warnings
+tests/integration_tests/modules/test_hotplug.py: 107 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 41 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 123 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 41 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 164 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 41 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 41 warnings
+tests/integration_tests/modules/test_set_hostname.py: 164 warnings
+tests/integration_tests/modules/test_set_password.py: 82 warnings
+tests/integration_tests/modules/test_snap.py: 41 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 82 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 41 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 164 warnings
+tests/integration_tests/modules/test_timezone.py: 41 warnings
+tests/integration_tests/modules/test_user_events.py: 82 warnings
+tests/integration_tests/modules/test_users_groups.py: 82 warnings
+tests/integration_tests/modules/test_version_change.py: 123 warnings
+tests/integration_tests/modules/test_write_files.py: 75 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/openstack/resource.py:351: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
+    len(inspect.getargspec(type_).args) > 1)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/bugs/test_gh868.py::test_chef_license - Assert...
+==== 1 failed, 125 passed, 23 skipped, 2625 warnings in 4824.62s (1:20:24) =====

--- a/21.3-1/integration_tests/openstack_7e8a63f0-7ad4-4845-8cf3-44e3fc546915::ubuntu::focal_integration_tests.txt
+++ b/21.3-1/integration_tests/openstack_7e8a63f0-7ad4-4845-8cf3-44e3fc546915::ubuntu::focal_integration_tests.txt
@@ -1,0 +1,4718 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:19:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 21:19:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=7e8a63f0-7ad4-4845-8cf3-44e3fc546915::ubuntu::focal
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 21:19:06 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=7e8a63f0-7ad4-4845-8cf3-44e3fc546915::ubuntu::focal
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for openstack
+2021-09-05 21:19:06 INFO      integration_testing:conftest.py:156 Setting up environment for openstack
+Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=None
+2021-09-05 21:19:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=None
+2021-09-05 21:19:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:19:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:20:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:20:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:20:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=dcf462d8-f398-46c9-98f4-e6c53b0af68c)
+2021-09-05 21:20:22 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=dcf462d8-f398-46c9-98f4-e6c53b0af68c)
+2021-09-05 21:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:20:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:20:23 INFO      integration_testing:clouds.py:183 image serial: 20210819
+Installing proposed image
+2021-09-05 21:20:23 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 21:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 21:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 21:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 21:20:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:20:47 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:20:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 21:20:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 21:20:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 21:20:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: 45757b74-d92d-467d-bfcf-a84bd2e533fd
+2021-09-05 21:21:58 INFO      integration_testing:instances.py:114 Created new image: 45757b74-d92d-467d-bfcf-a84bd2e533fd
+Done with environment setup
+2021-09-05 21:22:06 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:22:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:22:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:22:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:22:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:23:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:23:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f74e1567-200a-4e5c-a7b0-980c0f849ef5)
+2021-09-05 21:23:20 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f74e1567-200a-4e5c-a7b0-980c0f849ef5)
+2021-09-05 21:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:23:21 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:23:21 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 21:23:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:23:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:23:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-05 21:23:31 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=#cloud-config
+hostname: SRU-worked
+
+2021-09-05 21:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:24:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:24:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:24:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=cdd76664-dcea-4927-9c4a-c60182ceb5e5)
+2021-09-05 21:24:32 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=cdd76664-dcea-4927-9c4a-c60182ceb5e5)
+2021-09-05 21:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:24:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:24:32 INFO      integration_testing:clouds.py:183 image serial: 20210819
+2021-09-05 21:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 21:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 21:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 21:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 21:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 21:24:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 21:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 21:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 21:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 21:24:37 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 21:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 21:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 21:24:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 21:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:24:59 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 21:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 21:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 21:25:01 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 21:25:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:25:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:25:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:25:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 21:25:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 21:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 21:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 21:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 21:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 21:25:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 21:25:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 21:25:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 21:25:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 21:25:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 21:25:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 3.629s (kernel) + 33.779s (userspace) = 37.409s 
+graphical.target reached after 31.474s in userspace
+=== `systemd-analyze` after:
+Startup finished in 3.578s (kernel) + 25.519s (userspace) = 29.098s 
+graphical.target reached after 23.584s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+10.306s cloud-init-local.service                      
+ 9.030s snapd.seeded.service                          
+ 3.382s cloud-init.service                            
+ 2.662s snapd.service                                 
+ 2.295s snapd.apparmor.service                        
+ 2.008s systemd-networkd-wait-online.service          
+ 1.693s dev-vda1.device                               
+ 1.551s pollinate.service                             
+ 1.441s cloud-config.service                          
+ 1.418s systemd-udev-settle.service                   
+=== `systemd-analyze blame` after (first 10 lines):
+10.955s cloud-init-local.service                      
+ 6.163s snap.lxd.activate.service                     
+ 4.348s snapd.service                                 
+ 2.422s cloud-config.service                          
+ 1.812s dev-vda1.device                               
+ 1.812s cloud-init.service                            
+ 1.481s systemd-networkd-wait-online.service          
+ 1.357s systemd-udev-settle.service                   
+ 1.269s networkd-dispatcher.service                   
+  955ms cloud-final.service                           
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 09.15400 seconds
+Finished stage: (init-network) 02.60400 seconds
+Finished stage: (modules-config) 00.56400 seconds
+Finished stage: (modules-final) 00.12100 seconds
+Total Time: 12.44300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 09.60400 seconds
+Finished stage: (init-network) 01.14400 seconds
+Finished stage: (modules-config) 00.54500 seconds
+Finished stage: (modules-final) 00.14000 seconds
+Total Time: 11.43300 seconds
+Finished stage: (init-network) 00.29400 seconds
+Total Time: 0.29400 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.67700s (init-local/search-OpenStackLocal)
+     01.36600s (init-network/config-ssh)
+     00.43300s (init-network/config-mounts)
+     00.40300s (init-network/config-growpart)
+     00.25300s (modules-config/config-grub-dpkg)
+     00.23800s (modules-config/config-apt-configure)
+     00.13900s (init-network/config-resizefs)
+     00.05800s (init-network/config-users-groups)
+     00.05500s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     09.09200s (init-local/search-OpenStackLocal)
+     00.41600s (init-network/config-mounts)
+     00.36200s (init-network/config-ssh)
+     00.27500s (modules-config/config-grub-dpkg)
+     00.19400s (modules-config/config-apt-configure)
+     00.08600s (init-network/config-growpart)
+     00.06500s (modules-final/config-keys-to-console)
+     00.06100s (init-network/config-resizefs)
+     00.03600s (modules-config/config-locale)
+
+2021-09-05 21:25:59 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 3.629s (kernel) + 33.779s (userspace) = 37.409s 
+graphical.target reached after 31.474s in userspace
+=== `systemd-analyze` after:
+Startup finished in 3.578s (kernel) + 25.519s (userspace) = 29.098s 
+graphical.target reached after 23.584s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+10.306s cloud-init-local.service                      
+ 9.030s snapd.seeded.service                          
+ 3.382s cloud-init.service                            
+ 2.662s snapd.service                                 
+ 2.295s snapd.apparmor.service                        
+ 2.008s systemd-networkd-wait-online.service          
+ 1.693s dev-vda1.device                               
+ 1.551s pollinate.service                             
+ 1.441s cloud-config.service                          
+ 1.418s systemd-udev-settle.service                   
+=== `systemd-analyze blame` after (first 10 lines):
+10.955s cloud-init-local.service                      
+ 6.163s snap.lxd.activate.service                     
+ 4.348s snapd.service                                 
+ 2.422s cloud-config.service                          
+ 1.812s dev-vda1.device                               
+ 1.812s cloud-init.service                            
+ 1.481s systemd-networkd-wait-online.service          
+ 1.357s systemd-udev-settle.service                   
+ 1.269s networkd-dispatcher.service                   
+  955ms cloud-final.service                           
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 09.15400 seconds
+Finished stage: (init-network) 02.60400 seconds
+Finished stage: (modules-config) 00.56400 seconds
+Finished stage: (modules-final) 00.12100 seconds
+Total Time: 12.44300 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 09.60400 seconds
+Finished stage: (init-network) 01.14400 seconds
+Finished stage: (modules-config) 00.54500 seconds
+Finished stage: (modules-final) 00.14000 seconds
+Total Time: 11.43300 seconds
+Finished stage: (init-network) 00.29400 seconds
+Total Time: 0.29400 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.67700s (init-local/search-OpenStackLocal)
+     01.36600s (init-network/config-ssh)
+     00.43300s (init-network/config-mounts)
+     00.40300s (init-network/config-growpart)
+     00.25300s (modules-config/config-grub-dpkg)
+     00.23800s (modules-config/config-apt-configure)
+     00.13900s (init-network/config-resizefs)
+     00.05800s (init-network/config-users-groups)
+     00.05500s (modules-final/config-keys-to-console)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     09.09200s (init-local/search-OpenStackLocal)
+     00.41600s (init-network/config-mounts)
+     00.36200s (init-network/config-ssh)
+     00.27500s (modules-config/config-grub-dpkg)
+     00.19400s (modules-config/config-apt-configure)
+     00.08600s (init-network/config-growpart)
+     00.06500s (modules-final/config-keys-to-console)
+     00.06100s (init-network/config-resizefs)
+     00.03600s (modules-config/config-locale)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:26:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=None
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:26:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915
+user_data=None
+2021-09-05 21:26:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:26:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:27:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:27:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:27:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=887dcee0-4a29-4925-8a3b-5e90e1dfc9fc)
+2021-09-05 21:27:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=887dcee0-4a29-4925-8a3b-5e90e1dfc9fc)
+2021-09-05 21:27:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:27:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~20.04.1
+2021-09-05 21:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:27:16 INFO      integration_testing:clouds.py:183 image serial: 20210819
+Installing proposed image
+2021-09-05 21:27:16 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 21:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 21:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 21:27:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 21:27:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:27:39 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~20.04.2
+Restarting instance and waiting for boot
+2021-09-05 21:27:39 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 21:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:28:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:28:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:28:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 21:28:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:28:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-05 21:28:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-05 21:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:29:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:29:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=122f4ead-4b21-49a0-bf74-e0465a2c9e79)
+2021-09-05 21:31:37 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=122f4ead-4b21-49a0-bf74-e0465a2c9e79)
+2021-09-05 21:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:31:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:31:38 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:31:51 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-05 21:31:51 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+2021-09-05 21:32:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:32:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:32:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:32:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=25445c3c-519d-46ff-853f-09e95a8f7ab5)
+2021-09-05 21:32:58 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=25445c3c-519d-46ff-853f-09e95a8f7ab5)
+2021-09-05 21:32:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:32:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:32:59 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:32:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:33:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-05 21:33:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+2021-09-05 21:33:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:33:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:02 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:34:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:34:03 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c7538456-d0e4-4cef-8310-dd371e607d28)
+2021-09-05 21:34:08 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c7538456-d0e4-4cef-8310-dd371e607d28)
+2021-09-05 21:34:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:34:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:34:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:34:09 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:34:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:34:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-05 21:34:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+2021-09-05 21:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:35:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:35:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=cf8d8411-6705-4738-bb4f-16ccd63c4a4c)
+2021-09-05 21:35:11 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=cf8d8411-6705-4738-bb4f-16ccd63c4a4c)
+2021-09-05 21:35:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:35:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:35:12 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 21:35:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:35:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:35:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:35:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:35:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:36:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:36:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=29573590-9728-456a-9cb6-382af3af31c2)
+2021-09-05 21:36:12 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=29573590-9728-456a-9cb6-382af3af31c2)
+2021-09-05 21:36:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:36:12 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:36:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:36:13 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 21:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 21:36:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 21:36:13 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 21:36:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:36:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:36:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:36:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 21:36:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 21:36:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:37:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-05 21:37:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+2021-09-05 21:37:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:37:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:37:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:37:53 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0a3d0a49-34a6-47ca-9363-581956880f81)
+2021-09-05 21:38:06 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0a3d0a49-34a6-47ca-9363-581956880f81)
+2021-09-05 21:38:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-focal.list'
+2021-09-05 21:38:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 21:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 21:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:38:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:38:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-05 21:38:22 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+2021-09-05 21:38:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:38:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:39:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:39:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=43301bf7-9ce2-486e-ab59-2531e5bdb353)
+2021-09-05 21:39:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=43301bf7-9ce2-486e-ab59-2531e5bdb353)
+2021-09-05 21:39:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:39:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:39:16 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:39:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init query v1.availability_zone'
+2021-09-05 21:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:39:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:39:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:39:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-05 21:39:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+2021-09-05 21:39:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:39:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:40:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:40:14 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=09168fa4-fd0c-4161-a5aa-724d01e31dfe)
+2021-09-05 21:40:18 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=09168fa4-fd0c-4161-a5aa-724d01e31dfe)
+2021-09-05 21:40:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:40:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:40:19 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:40:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:40:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-05 21:40:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+2021-09-05 21:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:40:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:41:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:41:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e43ad713-1906-49d4-a35f-4c57c1599106)
+2021-09-05 21:41:19 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e43ad713-1906-49d4-a35f-4c57c1599106)
+2021-09-05 21:41:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:41:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:41:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:41:20 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:41:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:41:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:41:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:41:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-05 21:41:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+2021-09-05 21:41:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:42:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:42:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=492774f0-c8bf-42ca-a0be-81b6af862a7a)
+2021-09-05 21:42:23 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=492774f0-c8bf-42ca-a0be-81b6af862a7a)
+2021-09-05 21:42:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:42:23 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:42:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:42:23 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:42:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 21:42:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 21:42:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 21:42:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:42:24 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:42:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:42:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-05 21:42:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-05 21:42:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:42:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:43:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:43:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6f7c620a-c758-4148-ae2c-d5648053e335)
+2021-09-05 21:43:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6f7c620a-c758-4148-ae2c-d5648053e335)
+2021-09-05 21:43:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:43:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:43:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:43:26 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:43:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:43:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-05 21:43:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+2021-09-05 21:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:43:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:44:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:44:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:44:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f0105265-cc47-4568-ba42-cdd71582feb1)
+2021-09-05 21:44:21 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f0105265-cc47-4568-ba42-cdd71582feb1)
+2021-09-05 21:44:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:44:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:44:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:44:22 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:44:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:44:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-05 21:44:34 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+2021-09-05 21:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:45:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:45:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:45:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=30ce5cf2-0160-4b12-8e3a-e726955eba16)
+2021-09-05 21:45:29 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=30ce5cf2-0160-4b12-8e3a-e726955eba16)
+2021-09-05 21:45:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:45:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:45:30 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:45:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:45:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 21:45:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 21:45:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:45:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-05 21:45:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+2021-09-05 21:46:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:46:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:46:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:46:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=a7a55f1b-30d1-4cd2-a592-c6cdc9aacd39)
+2021-09-05 21:46:29 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=a7a55f1b-30d1-4cd2-a592-c6cdc9aacd39)
+2021-09-05 21:46:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:46:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:46:30 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:46:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:46:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+updates:
+  network:
+    when: ['hotplug']
+
+2021-09-05 21:46:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+updates:
+  network:
+    when: ['hotplug']
+
+2021-09-05 21:46:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:47:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:47:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:47:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=98864e04-6165-4c30-9fb5-b32347e62cb0)
+2021-09-05 21:47:31 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=98864e04-6165-4c30-9fb5-b32347e62cb0)
+2021-09-05 21:47:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:47:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:47:32 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 21:47:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:47:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:47:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:47:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 21:48:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 21:48:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 21:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 21:48:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel hotplug-hook -s net query'
+PASSED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:48:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:48:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 21:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:49:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:49:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:49:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e216be64-f220-4a4a-927c-e954deaa493e)
+2021-09-05 21:49:26 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e216be64-f220-4a4a-927c-e954deaa493e)
+2021-09-05 21:49:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:49:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:49:27 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 21:49:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 21:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel hotplug-hook -s net query'
+PASSED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:50:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-05 21:50:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+2021-09-05 21:50:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:50:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:50:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:50:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0bcc24fb-1865-4677-84a3-aed9572864e2)
+2021-09-05 21:50:59 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0bcc24fb-1865-4677-84a3-aed9572864e2)
+2021-09-05 21:50:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:51:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:51:00 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 21:51:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:51:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-05 21:51:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+2021-09-05 21:51:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:51:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:51:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:51:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=bcd72ea8-5ade-4aee-8f57-e839622e7bda)
+2021-09-05 21:52:01 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=bcd72ea8-5ade-4aee-8f57-e839622e7bda)
+2021-09-05 21:52:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:52:01 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:52:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:52:02 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:52:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:52:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:52:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:52:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-05 21:52:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+2021-09-05 21:52:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:52:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:53:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:53:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=582c6fee-8c56-4875-a34f-11de00dc69f9)
+2021-09-05 21:53:12 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=582c6fee-8c56-4875-a34f-11de00dc69f9)
+2021-09-05 21:53:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:53:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:53:13 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:53:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:53:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:53:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-05 21:53:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+2021-09-05 21:53:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:53:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:54:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:54:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:54:13 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=b18a8948-1363-4ebf-ade7-b54efd349fb4)
+2021-09-05 21:54:17 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=b18a8948-1363-4ebf-ade7-b54efd349fb4)
+2021-09-05 21:54:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:54:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:54:18 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:54:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:54:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-05 21:54:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+2021-09-05 21:54:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:55:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:55:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:55:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=46c26a20-db8e-48ae-a57c-4b007045fdf0)
+2021-09-05 21:55:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=46c26a20-db8e-48ae-a57c-4b007045fdf0)
+2021-09-05 21:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:55:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:55:40 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:55:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:55:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 21:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 21:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:55:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-05 21:55:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+2021-09-05 21:56:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:56:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:56:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:56:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=67c16d7b-efd5-42d6-a3cb-e774618b08c6)
+2021-09-05 21:57:09 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=67c16d7b-efd5-42d6-a3cb-e774618b08c6)
+2021-09-05 21:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:57:09 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:57:09 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:57:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:57:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:57:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:57:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:57:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:57:21 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-05 21:57:21 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+2021-09-05 21:57:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:57:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:58:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:58:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:58:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:58:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:58:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:58:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:58:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=df78e88e-d682-448a-8b0e-1b17e8d07a1a)
+2021-09-05 21:58:34 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=df78e88e-d682-448a-8b0e-1b17e8d07a1a)
+2021-09-05 21:58:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:58:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:58:35 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 21:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:58:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-05 21:58:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+2021-09-05 21:59:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:59:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:59:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:59:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=7754d579-013d-4fad-8c60-208526d55c23)
+2021-09-05 21:59:33 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=7754d579-013d-4fad-8c60-208526d55c23)
+2021-09-05 21:59:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:59:34 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:59:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 21:59:34 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 21:59:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 21:59:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-05 21:59:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+2021-09-05 22:00:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:00:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:00:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:00:30 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=77b71024-6f01-4db7-8783-157599544d6c)
+2021-09-05 22:00:59 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=77b71024-6f01-4db7-8783-157599544d6c)
+2021-09-05 22:00:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:01:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:01:00 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 22:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 22:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:01:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-05 22:01:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+2021-09-05 22:01:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:01:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:01:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:01:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=8f6faecf-a15d-4c64-81a7-dbca46409db7)
+2021-09-05 22:03:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=8f6faecf-a15d-4c64-81a7-dbca46409db7)
+2021-09-05 22:03:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:03:16 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:03:16 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:03:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:03:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:03:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:03:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:03:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-05 22:03:32 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+2021-09-05 22:04:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:04:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:04:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:04:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=936a0626-1e43-437d-8359-ec5244979897)
+2021-09-05 22:04:27 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=936a0626-1e43-437d-8359-ec5244979897)
+2021-09-05 22:04:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:04:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:04:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:04:27 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:04:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:04:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-05 22:04:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+hostname: cloudinit2
+
+2021-09-05 22:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:05:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:05:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:05:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4e33dfe1-903f-4552-8dee-b6435c9d28ce)
+2021-09-05 22:05:32 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4e33dfe1-903f-4552-8dee-b6435c9d28ce)
+2021-09-05 22:05:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:05:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:05:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:05:33 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:05:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:05:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-05 22:05:41 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-05 22:06:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:06:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:06:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:06:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=2c529a9c-7053-4809-b5e5-241eee3933e1)
+2021-09-05 22:06:30 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=2c529a9c-7053-4809-b5e5-241eee3933e1)
+2021-09-05 22:06:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:06:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:06:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:06:31 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:06:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:06:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-05 22:06:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+2021-09-05 22:07:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:07:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:07:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:07:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=71cb0f4f-e94e-4494-8bfb-c358468a4283)
+2021-09-05 22:07:27 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=71cb0f4f-e94e-4494-8bfb-c358468a4283)
+2021-09-05 22:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:07:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:07:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:07:28 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:07:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:07:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-05 22:07:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+2021-09-05 22:07:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:08:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:08:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=8bf97860-2ab5-491d-8a1d-420524fc12ca)
+2021-09-05 22:08:26 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=8bf97860-2ab5-491d-8a1d-420524fc12ca)
+2021-09-05 22:08:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:08:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:08:27 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 22:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 22:08:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:08:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-05 22:08:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-05 22:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:19 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:09:19 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:09:20 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e57d2ba8-88d0-490e-b012-82fc572da163)
+2021-09-05 22:09:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e57d2ba8-88d0-490e-b012-82fc572da163)
+2021-09-05 22:09:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:09:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:09:26 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:09:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:09:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-05 22:09:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+2021-09-05 22:09:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:09:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:10:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:10:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:10:21 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=7b9808b8-e543-46eb-8533-6863ab410d8b)
+2021-09-05 22:10:26 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=7b9808b8-e543-46eb-8533-6863ab410d8b)
+2021-09-05 22:10:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:10:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:10:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:10:26 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:27 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:10:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:10:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-05 22:10:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+2021-09-05 22:11:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:11:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:11:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:11:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=63cd4570-be6e-45f5-9426-45c95e53f657)
+2021-09-05 22:11:48 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=63cd4570-be6e-45f5-9426-45c95e53f657)
+2021-09-05 22:11:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:11:49 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:11:49 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:11:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:11:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-05 22:11:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+2021-09-05 22:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:12:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:12:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:12:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=bd27ae5b-c263-40d1-954e-5dc12fb41a49)
+2021-09-05 22:12:50 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=bd27ae5b-c263-40d1-954e-5dc12fb41a49)
+2021-09-05 22:12:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:12:51 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:12:51 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:12:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:13:00 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-05 22:13:00 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+2021-09-05 22:13:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:13:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:13:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:13:42 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=56551ea6-4a09-4376-883d-4e7e37f8cd87)
+2021-09-05 22:13:47 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=56551ea6-4a09-4376-883d-4e7e37f8cd87)
+2021-09-05 22:13:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:13:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:13:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:13:48 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:13:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:13:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-05 22:13:56 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+2021-09-05 22:14:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:14:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:14:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:14:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4b3104a1-c8bc-4878-b1c0-5840763bdb18)
+2021-09-05 22:14:42 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4b3104a1-c8bc-4878-b1c0-5840763bdb18)
+2021-09-05 22:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:14:42 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:14:42 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:14:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-05 22:14:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+2021-09-05 22:15:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:15:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:15:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:15:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3a1165ba-2d75-4542-8d20-3880a47006f7)
+2021-09-05 22:15:59 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3a1165ba-2d75-4542-8d20-3880a47006f7)
+2021-09-05 22:15:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:16:00 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:16:00 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-05 22:16:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+2021-09-05 22:16:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:16:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:16:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:16:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=732bfeef-869f-45a9-8efe-ce4666d896b6)
+2021-09-05 22:16:55 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=732bfeef-869f-45a9-8efe-ce4666d896b6)
+2021-09-05 22:16:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:16:56 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:16:56 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:56 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:16:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:16:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:17:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:17:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:17:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:17:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:17:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:17:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=48ca5657-e4f5-471c-b0d5-fbd68cc6e685)
+2021-09-05 22:18:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=48ca5657-e4f5-471c-b0d5-fbd68cc6e685)
+2021-09-05 22:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:18:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:18:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:18:03 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:18:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 22:18:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 22:18:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 22:18:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 22:18:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 22:18:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 22:18:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 22:18:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 22:18:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 22:18:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 22:18:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:07 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 22:18:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:18:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 22:18:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 22:18:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 22:18:09 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 22:18:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 22:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 22:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 22:18:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 22:18:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 22:18:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:18:12 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 22:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 22:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 22:18:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:18:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:18:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:18:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:18:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:18:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:19:12 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:19:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3a58a2a1-548a-444c-920d-7da48d1396ea)
+2021-09-05 22:19:20 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3a58a2a1-548a-444c-920d-7da48d1396ea)
+2021-09-05 22:19:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:19:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:19:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:19:20 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:19:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 22:19:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 22:19:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 22:19:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 22:19:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:22 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 22:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 22:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 22:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 22:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 22:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 22:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 22:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 22:19:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 22:19:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 22:19:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 22:19:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 22:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 22:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 22:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 22:19:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 22:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 22:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 22:19:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 22:19:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 22:19:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 22:19:27 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:28 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 22:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 22:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 22:19:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 22:19:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 22:19:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:19:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 22:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 22:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 22:19:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:19:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:19:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:20:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:20:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:20:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=182e1be5-3808-4c7c-9af8-e89f76b05c8c)
+2021-09-05 22:20:31 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=182e1be5-3808-4c7c-9af8-e89f76b05c8c)
+2021-09-05 22:20:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:20:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:20:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:20:32 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:20:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 22:20:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 22:20:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 22:20:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 22:20:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 22:20:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 22:20:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 22:20:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 22:20:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 22:20:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 22:20:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 22:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 22:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 22:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 22:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 22:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 22:20:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 22:20:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 22:20:38 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:38 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 22:20:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 22:20:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:20:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 22:20:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 22:20:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 22:20:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 22:20:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 22:20:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:20:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 22:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 22:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 22:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 22:20:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 22:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 22:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 22:20:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:20:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:20:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+2021-09-05 22:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:21:37 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:21:39 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=dfc87ae7-922c-4ec7-9bbb-86f311927ac8)
+2021-09-05 22:21:44 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=dfc87ae7-922c-4ec7-9bbb-86f311927ac8)
+2021-09-05 22:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:21:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:21:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:21:45 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:21:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 22:21:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 22:21:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 22:21:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 22:21:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 22:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 22:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 22:21:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 22:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 22:21:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 22:21:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 22:21:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 22:21:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 22:21:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 22:21:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 22:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 22:21:49 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 22:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 22:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 22:21:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 22:21:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 22:21:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 22:21:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 22:21:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 22:21:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 22:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 22:21:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 22:21:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 22:21:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 22:21:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:21:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 22:21:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 22:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 22:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 22:21:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:22:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-05 22:22:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+timezone: US/Aleutian
+
+2021-09-05 22:22:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:22:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:22:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:22:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=78e6eced-58a6-4aad-88b0-85ebdbd6dc3e)
+2021-09-05 22:22:57 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=78e6eced-58a6-4aad-88b0-85ebdbd6dc3e)
+2021-09-05 22:22:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:22:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:22:58 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:22:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:23:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:23:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:23:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:23:51 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:23:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:23:54 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c4ff9c63-5272-45b4-8190-ad48f981808a)
+2021-09-05 22:23:57 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c4ff9c63-5272-45b4-8190-ad48f981808a)
+2021-09-05 22:23:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:23:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:23:58 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:23:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 22:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:23:59 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 22:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/cfcf2ef7-6402-4b0d-b743-f7b9f08b3f55.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:23:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 22:24:00 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:24:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:24:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:24:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:24:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:24:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:24:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 22:24:49 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:24:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-05 22:24:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+2021-09-05 22:25:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:25:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:25:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:25:36 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=86830ebe-5edd-428b-b4f8-36935f163b4a)
+2021-09-05 22:25:40 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=86830ebe-5edd-428b-b4f8-36935f163b4a)
+2021-09-05 22:25:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:25:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:25:41 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:25:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 22:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:25:42 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 22:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/bbc3cb3b-d7aa-4159-a581-fede347949e9.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 22:25:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 22:25:42 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:26:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:26:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:26:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:26:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:26:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:26:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:26:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:26:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:26:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 22:26:40 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:26:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-05 22:26:40 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-05 22:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:27:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:27:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:27:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=1f8b578f-8118-474f-a575-def32d5db4cc)
+2021-09-05 22:27:32 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=1f8b578f-8118-474f-a575-def32d5db4cc)
+2021-09-05 22:27:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:27:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:27:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-05 22:27:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+2021-09-05 22:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:28:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:28:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:28:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=81ae59a7-594f-424f-ace3-3cec3f96e178)
+2021-09-05 22:28:32 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=81ae59a7-594f-424f-ace3-3cec3f96e178)
+2021-09-05 22:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:28:32 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:28:32 INFO      integration_testing:clouds.py:183 image serial: 20210819
+Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:28:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:28:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:28:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:29:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:29:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:29:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:29:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f3c7fc24-fe84-4c05-a8db-8c68c11624f8)
+2021-09-05 22:29:33 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f3c7fc24-fe84-4c05-a8db-8c68c11624f8)
+2021-09-05 22:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:29:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:29:34 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:29:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 22:29:34 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:29:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:30:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:30:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:30:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 22:30:11 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 22:30:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/f878fb3f-caad-4514-955d-553afe21148d.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 22:30:12 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:30:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:30:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:30:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:30:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:30:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 22:31:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:31:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:31:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:31:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:32:00 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:32:01 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=678accc9-6f14-4967-907c-814acee631d4)
+2021-09-05 22:32:06 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=678accc9-6f14-4967-907c-814acee631d4)
+2021-09-05 22:32:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:32:06 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:32:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:32:06 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:32:07 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 22:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/13577939-db52-41c0-ae08-a6a7cbfea5d8.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 22:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 22:32:07 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:32:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:32:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:32:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:32:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:32:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 22:33:08 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:33:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:33:08 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=None
+2021-09-05 22:33:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:33:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:33:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:33:49 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=8ba286dd-26b0-4616-b274-8691bf1754f2)
+2021-09-05 22:33:54 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=8ba286dd-26b0-4616-b274-8691bf1754f2)
+2021-09-05 22:33:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:33:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:33:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:33:55 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:33:55 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 22:33:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/a1f222ad-259d-4970-a590-1023cde1900c.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 22:33:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 22:33:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 22:33:55 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 22:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:34:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:34:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:34:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:34:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:34:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 22:34:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 22:34:57 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:34:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-05 22:34:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+2021-09-05 22:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 22:35:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 22:35:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 22:35:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=11e135fc-d118-4c0d-891e-6da651fc99af)
+2021-09-05 22:35:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=11e135fc-d118-4c0d-891e-6da651fc99af)
+2021-09-05 22:35:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:35:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 22:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210819
+2021-09-05 22:35:44 INFO      integration_testing:clouds.py:183 image serial: 20210819
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:35:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:35:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:35:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:35:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 22:35:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+-------------------------------- live log call ---------------------------------
+2021-09-05 22:35:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: 45757b74-d92d-467d-bfcf-a84bd2e533fd
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 22:35:58 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: 45757b74-d92d-467d-bfcf-a84bd2e533fd
+
+
+=================================== FAILURES ===================================
+______________________________ test_chef_license _______________________________
+
+client = <tests.integration_tests.instances.IntegrationInstance object at 0x7f269dfd4550>
+
+    @pytest.mark.adhoc  # Can't be regularly reaching out to chef install script
+    @pytest.mark.user_data(USERDATA)
+    def test_chef_license(client: IntegrationInstance):
+        log = client.read_from_file('/var/log/cloud-init.log')
+>       verify_clean_log(log)
+
+tests/integration_tests/bugs/test_gh868.py:22: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+log = "2021-09-05 21:29:06,085 - util.py[DEBUG]: Cloud-init v. 21.3-1-g6803368d-0ubuntu1~20.04.2 running 'init-local' at Sun...seconds (130.35)\n2021-09-05 21:31:37,402 - handlers.py[DEBUG]: finish: modules-final: FAIL: running modules for final"
+
+    def verify_clean_log(log):
+        """Assert no unexpected tracebacks or warnings in logs"""
+        warning_count = log.count('WARN')
+        expected_warnings = 0
+        traceback_count = log.count('Traceback')
+        expected_tracebacks = 0
+    
+        warning_texts = [
+            # Consistently on all Azure launches:
+            # azure.py[WARNING]: No lease found; using default endpoint
+            'No lease found; using default endpoint'
+        ]
+        traceback_texts = []
+        if 'oracle' in log:
+            # LP: #1842752
+            lease_exists_text = 'Stderr: RTNETLINK answers: File exists'
+            warning_texts.append(lease_exists_text)
+            traceback_texts.append(lease_exists_text)
+            # LP: #1833446
+            fetch_error_text = (
+                'UrlError: 404 Client Error: Not Found for url: '
+                'http://169.254.169.254/latest/meta-data/')
+            warning_texts.append(fetch_error_text)
+            traceback_texts.append(fetch_error_text)
+    
+        for warning_text in warning_texts:
+            expected_warnings += log.count(warning_text)
+        for traceback_text in traceback_texts:
+            expected_tracebacks += log.count(traceback_text)
+    
+>       assert warning_count == expected_warnings
+E       AssertionError
+
+tests/integration_tests/util.py:61: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 21:28:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=7e8a63f0-7ad4-4845-8cf3-44e3fc546915 os=ubuntu release=focal
+2021-09-05 21:28:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+image_id=45757b74-d92d-467d-bfcf-a84bd2e533fd
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+2021-09-05 21:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 21:29:20 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_8.2p1)
+2021-09-05 21:29:20 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 21:29:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 21:31:37 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=122f4ead-4b21-49a0-bf74-e0465a2c9e79)
+2021-09-05 21:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-05 21:31:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~20.04.2
+2021-09-05 21:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-05 21:31:38 INFO      integration_testing:clouds.py:183 image serial: 20210819
+------------------------------ Captured log call -------------------------------
+2021-09-05 21:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 351 warnings
+tests/integration_tests/test_upgrade.py: 82 warnings
+tests/integration_tests/bugs/test_gh868.py: 41 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 41 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 41 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 41 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 41 warnings
+tests/integration_tests/modules/test_apt.py: 164 warnings
+tests/integration_tests/modules/test_ca_certs.py: 41 warnings
+tests/integration_tests/modules/test_cli.py: 82 warnings
+tests/integration_tests/modules/test_combined.py: 41 warnings
+tests/integration_tests/modules/test_command_output.py: 41 warnings
+tests/integration_tests/modules/test_hotplug.py: 107 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 41 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 123 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 41 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 164 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 41 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 41 warnings
+tests/integration_tests/modules/test_set_hostname.py: 164 warnings
+tests/integration_tests/modules/test_set_password.py: 82 warnings
+tests/integration_tests/modules/test_snap.py: 41 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 82 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 41 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 164 warnings
+tests/integration_tests/modules/test_timezone.py: 41 warnings
+tests/integration_tests/modules/test_user_events.py: 82 warnings
+tests/integration_tests/modules/test_users_groups.py: 82 warnings
+tests/integration_tests/modules/test_version_change.py: 123 warnings
+tests/integration_tests/modules/test_write_files.py: 75 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/openstack/resource.py:351: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
+    len(inspect.getargspec(type_).args) > 1)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/bugs/test_gh868.py::test_chef_license - Assert...
+==== 1 failed, 124 passed, 24 skipped, 2625 warnings in 4620.65s (1:17:00) =====

--- a/21.3-1/integration_tests/openstack_87a74f70-d274-4e70-95d0-4ea36ce4dd4a::ubuntu::bionic_integration_tests.txt
+++ b/21.3-1/integration_tests/openstack_87a74f70-d274-4e70-95d0-4ea36ce4dd4a::ubuntu::bionic_integration_tests.txt
@@ -1,0 +1,4765 @@
+============================= test session starts ==============================
+platform linux -- Python 3.5.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, configfile: tox.ini
+plugins: cov-2.11.1
+collected 149 items
+
+tests/integration_tests/test_logging.py::TestVarLogCloudInitOutput::test_var_log_cloud_init_output_not_world_readable Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:27:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 12:27:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=87a74f70-d274-4e70-95d0-4ea36ce4dd4a::ubuntu::bionic
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+2021-09-05 12:27:42 INFO      integration_testing:clouds.py:129 Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+KEYPAIR_NAME=None
+LOCAL_LOG_PATH=/home/james/tmp_home/cloud_init_test_logs
+OPENSTACK_NETWORK=falcojr_admin_net
+ORACLE_AVAILABILITY_DOMAIN=qIZq:PHX-AD-3
+OS_IMAGE=87a74f70-d274-4e70-95d0-4ea36ce4dd4a::ubuntu::bionic
+PLATFORM=openstack
+PUBLIC_SSH_KEY=None
+RUN_UNSTABLE=False
+Setting up environment for openstack
+2021-09-05 12:27:42 INFO      integration_testing:conftest.py:156 Setting up environment for openstack
+Launching instance with launch_kwargs:
+user_data=None
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+2021-09-05 12:27:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+2021-09-05 12:28:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:28:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:28:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:28:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=36eb693b-9a63-4fb7-ba75-f0fd9d26f9c6)
+2021-09-05 12:28:47 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=36eb693b-9a63-4fb7-ba75-f0fd9d26f9c6)
+2021-09-05 12:28:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:28:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:28:48 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Installing proposed image
+2021-09-05 12:28:48 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 12:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 12:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 12:28:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 12:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:29:08 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 12:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 12:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 12:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+Created new image: 9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:30:05 INFO      integration_testing:instances.py:114 Created new image: 9fef3065-5074-414b-8549-34449f483d50
+Done with environment setup
+2021-09-05 12:30:15 INFO      integration_testing:conftest.py:162 Done with environment setup
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:30:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:30:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:30:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:31:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:31:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=29b2b946-3982-4173-a257-8a9aab5b090c)
+2021-09-05 12:31:19 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=29b2b946-3982-4173-a257-8a9aab5b090c)
+2021-09-05 12:31:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:31:20 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:31:20 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /var/log/cloud-init-output.log'
+2021-09-05 12:31:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a:%U:%G /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:31:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:31:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+2021-09-05 12:31:29 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+2021-09-05 12:31:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:31:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:32:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:32:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:32:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=85ccbc55-f18a-431e-ac1c-a726ae6355b5)
+2021-09-05 12:32:18 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=85ccbc55-f18a-431e-ac1c-a726ae6355b5)
+2021-09-05 12:32:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:32:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:32:19 INFO      integration_testing:clouds.py:183 image serial: 20210817
+2021-09-05 12:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 12:32:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 12:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 12:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 12:32:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 12:32:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 12:32:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 12:32:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 12:32:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Installing proposed image
+2021-09-05 12:32:23 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 12:32:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 12:32:23 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 12:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 12:32:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:32:44 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:32:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo cloud-init clean --logs'
+2021-09-05 12:32:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c 'sudo rm -rf /var/log/syslog'
+2021-09-05 12:32:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname something-else'
+Restarting instance and waiting for boot
+2021-09-05 12:32:46 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 12:33:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:33:25 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:33:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:33:27 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:33:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+2021-09-05 12:33:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init init'
+2021-09-05 12:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 12:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c cloud-id
+2021-09-05 12:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 12:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 12:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c systemd-analyze
+2021-09-05 12:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'systemd-analyze blame'
+2021-09-05 12:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze show'
+2021-09-05 12:33:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init analyze blame'
+2021-09-05 12:33:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+
+=== `systemd-analyze` before:
+Startup finished in 4.562s (kernel) + 25.082s (userspace) = 29.644s
+graphical.target reached after 21.098s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.606s (kernel) + 22.155s (userspace) = 26.762s
+graphical.target reached after 18.406s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+          9.680s cloud-init-local.service
+          3.377s dev-vda1.device
+          2.488s cloud-config.service
+          2.367s cloud-init.service
+          2.156s snapd.seeded.service
+          2.118s apparmor.service
+          1.986s keyboard-setup.service
+          1.461s cloud-final.service
+          1.383s pollinate.service
+          1.229s systemd-networkd-wait-online.service
+=== `systemd-analyze blame` after (first 10 lines):
+         10.420s cloud-init-local.service
+          3.544s dev-vda1.device
+          2.329s cloud-config.service
+          2.287s cloud-init.service
+          2.002s systemd-networkd-wait-online.service
+          1.968s keyboard-setup.service
+          1.393s cloud-final.service
+           738ms networkd-dispatcher.service
+           557ms systemd-udev-trigger.service
+           524ms snapd.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 08.90800 seconds
+Finished stage: (init-network) 01.46000 seconds
+Finished stage: (modules-config) 00.80400 seconds
+Finished stage: (modules-final) 00.20300 seconds
+Total Time: 11.37500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 08.93900 seconds
+Finished stage: (init-network) 01.43100 seconds
+Finished stage: (modules-config) 00.89600 seconds
+Finished stage: (modules-final) 00.28000 seconds
+Total Time: 11.54600 seconds
+Finished stage: (init-network) 00.25200 seconds
+Total Time: 0.25200 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.58800s (init-local/search-OpenStackLocal)
+     00.54600s (init-network/config-ssh)
+     00.37900s (modules-config/config-grub-dpkg)
+     00.32300s (modules-config/config-apt-configure)
+     00.31800s (init-network/config-mounts)
+     00.18400s (init-network/config-growpart)
+     00.09500s (init-network/config-resizefs)
+     00.08400s (modules-final/config-keys-to-console)
+     00.06000s (init-network/config-users-groups)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     08.57900s (init-local/search-OpenStackLocal)
+     00.73600s (init-network/config-ssh)
+     00.40400s (modules-config/config-grub-dpkg)
+     00.39400s (modules-config/config-apt-configure)
+     00.29500s (init-network/config-mounts)
+     00.13100s (modules-final/config-keys-to-console)
+     00.07100s (init-network/config-growpart)
+     00.03600s (modules-final/config-ssh-authkey-fingerprints)
+     00.02900s (init-network/config-resizefs)
+
+2021-09-05 12:33:34 INFO      integration_testing.test_upgrade:test_upgrade.py:144 
+=== `systemd-analyze` before:
+Startup finished in 4.562s (kernel) + 25.082s (userspace) = 29.644s
+graphical.target reached after 21.098s in userspace
+=== `systemd-analyze` after:
+Startup finished in 4.606s (kernel) + 22.155s (userspace) = 26.762s
+graphical.target reached after 18.406s in userspace
+
+=== `systemd-analyze blame` before (first 10 lines):
+          9.680s cloud-init-local.service
+          3.377s dev-vda1.device
+          2.488s cloud-config.service
+          2.367s cloud-init.service
+          2.156s snapd.seeded.service
+          2.118s apparmor.service
+          1.986s keyboard-setup.service
+          1.461s cloud-final.service
+          1.383s pollinate.service
+          1.229s systemd-networkd-wait-online.service
+=== `systemd-analyze blame` after (first 10 lines):
+         10.420s cloud-init-local.service
+          3.544s dev-vda1.device
+          2.329s cloud-config.service
+          2.287s cloud-init.service
+          2.002s systemd-networkd-wait-online.service
+          1.968s keyboard-setup.service
+          1.393s cloud-final.service
+           738ms networkd-dispatcher.service
+           557ms systemd-udev-trigger.service
+           524ms snapd.service
+
+=== `cloud-init analyze show` before:')
+Finished stage: (init-local) 08.90800 seconds
+Finished stage: (init-network) 01.46000 seconds
+Finished stage: (modules-config) 00.80400 seconds
+Finished stage: (modules-final) 00.20300 seconds
+Total Time: 11.37500 seconds
+=== `cloud-init analyze show` after:')
+Finished stage: (init-local) 08.93900 seconds
+Finished stage: (init-network) 01.43100 seconds
+Finished stage: (modules-config) 00.89600 seconds
+Finished stage: (modules-final) 00.28000 seconds
+Total Time: 11.54600 seconds
+Finished stage: (init-network) 00.25200 seconds
+Total Time: 0.25200 seconds
+
+=== `cloud-init analyze blame` before (first 10 lines): ')
+-- Boot Record 01 --
+     08.58800s (init-local/search-OpenStackLocal)
+     00.54600s (init-network/config-ssh)
+     00.37900s (modules-config/config-grub-dpkg)
+     00.32300s (modules-config/config-apt-configure)
+     00.31800s (init-network/config-mounts)
+     00.18400s (init-network/config-growpart)
+     00.09500s (init-network/config-resizefs)
+     00.08400s (modules-final/config-keys-to-console)
+     00.06000s (init-network/config-users-groups)
+=== `cloud-init analyze blame` after (first 10 lines): ')
+-- Boot Record 01 --
+     08.57900s (init-local/search-OpenStackLocal)
+     00.73600s (init-network/config-ssh)
+     00.40400s (modules-config/config-grub-dpkg)
+     00.39400s (modules-config/config-apt-configure)
+     00.29500s (init-network/config-mounts)
+     00.13100s (modules-final/config-keys-to-console)
+     00.07100s (init-network/config-growpart)
+     00.03600s (modules-final/config-ssh-authkey-fingerprints)
+     00.02900s (init-network/config-resizefs)
+
+PASSED
+tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:33:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:33:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a
+2021-09-05 12:34:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:34:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:34:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:34:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6b4f193a-3f24-4056-9897-b0176f01fb4b)
+2021-09-05 12:34:37 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6b4f193a-3f24-4056-9897-b0176f01fb4b)
+2021-09-05 12:34:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:34:38 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.2-3-g899bfaa9-0ubuntu2~18.04.1
+2021-09-05 12:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:34:38 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Installing proposed image
+2021-09-05 12:34:38 INFO      integration_testing:instances.py:150 Installing proposed image
+2021-09-05 12:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo deb "http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-proposed main" >> /etc/apt/sources.list.d/proposed.list'
+2021-09-05 12:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get update -q'
+2021-09-05 12:34:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-get install -qy cloud-init'
+2021-09-05 12:34:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init -v'
+Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:34:59 INFO      integration_testing:instances.py:137 Installed cloud-init version: 21.3-1-g6803368d-0ubuntu1~18.04.2
+Restarting instance and waiting for boot
+2021-09-05 12:34:59 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 12:35:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:35:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:35:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:35:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status --wait --long'
+PASSED
+tests/integration_tests/bugs/test_gh570.py::test_nocloud_seedfrom_vendordata SKIPPED
+tests/integration_tests/bugs/test_gh626.py::test_wakeonlan SKIPPED
+tests/integration_tests/bugs/test_gh632.py::test_datasource_rbx_no_stacktrace SKIPPED
+tests/integration_tests/bugs/test_gh668.py::test_static_route_to_host SKIPPED
+tests/integration_tests/bugs/test_gh671.py::test_update_default_password SKIPPED
+tests/integration_tests/bugs/test_gh868.py::test_chef_license Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:35:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:35:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:36:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:36:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4310cbff-83da-40a5-8e69-804bf4dce8a3)
+2021-09-05 12:38:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4310cbff-83da-40a5-8e69-804bf4dce8a3)
+2021-09-05 12:38:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:38:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:38:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+FAILED
+tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:38:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:38:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  sources:
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
+      keyserver: keyserver.ubuntu.com
+      keyid: E4D304DF
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:39:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:39:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:39:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:39:51 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6de4b91f-10e5-4d5c-9585-ccbc876f91f0)
+2021-09-05 12:40:01 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6de4b91f-10e5-4d5c-9585-ccbc876f91f0)
+2021-09-05 12:40:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:40:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:40:02 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:40:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid SKIPPED
+tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:40:12 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:40:12 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+- rm -f /etc/fstab
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:40:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:40:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:40:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:40:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=dd661ba6-9c24-4b8a-9f86-5809d2ee0dd2)
+2021-09-05 12:40:59 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=dd661ba6-9c24-4b8a-9f86-5809d2ee0dd2)
+2021-09-05 12:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:40:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:40:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:41:00 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:41:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1897099.py::test_fallocate_fallback Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:41:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:41:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+  - echo 'whoops' > /usr/bin/fallocate
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:41:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:41:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:41:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=223c35d0-2854-4bb8-98df-84257be8d841)
+2021-09-05 12:41:58 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=223c35d0-2854-4bb8-98df-84257be8d841)
+2021-09-05 12:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:41:58 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:41:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:41:59 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 12:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /proc/swaps'
+2021-09-05 12:41:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/fstab'
+PASSED
+tests/integration_tests/bugs/test_lp1898997.py::TestInterfaceListingWithOpenvSwitch::test_ovs_member_interfaces_not_excluded SKIPPED
+tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:42:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:42:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:42:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:42:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:42:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:42:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=dfb1f817-f9c6-4f82-b997-60dcc67e1d5c)
+2021-09-05 12:43:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=dfb1f817-f9c6-4f82-b997-60dcc67e1d5c)
+2021-09-05 12:43:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:43:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:43:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:43:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+2021-09-05 12:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
+2021-09-05 12:43:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 12:43:03 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 12:43:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:43:50 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:43:51 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:43:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:43:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init status'
+2021-09-05 12:43:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_DS1_v2-True] SKIPPED
+tests/integration_tests/bugs/test_lp1901011.py::test_ephemeral[Standard_D2s_v4-False] SKIPPED
+tests/integration_tests/bugs/test_lp1910835.py::test_crlf_in_azure_metadata_ssh_keys SKIPPED
+tests/integration_tests/bugs/test_lp1912844.py::test_get_interfaces_by_mac_doesnt_traceback SKIPPED
+tests/integration_tests/modules/test_apt.py::TestApt::test_sources_list Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:44:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:44:10 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  conf: |
+    APT {
+        Get {
+            Assume-Yes "true";
+            Fix-Broken "true";
+        }
+    }
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+  primary:
+    - arches: [default]
+      uri: http://badarchive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://badsecurity.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+  sources:
+    test_keyserver:
+        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
+        keyserver: keyserver.ubuntu.com
+        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+    test_key:
+      source: "deb http://ppa.launchpad.net/cloud-init-dev/test-archive/ubuntu $RELEASE main"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.6
+        Comment: Hostname: keyserver.ubuntu.com
+
+        mQINBFbZRUIBEAC+A0PIKYBP9kLC4hQtRrffRS11uLo8/BdtmOdrlW0hpPHzCfKnjR3tvSEI
+        lqPHG1QrrjAXKZDnZMRz+h/px7lUztvytGzHPSJd5ARUzAyjyRezUhoJ3VSCxrPqx62avuWf
+        RfoJaIeHfDehL5/dTVkyiWxfVZ369ZX6JN2AgLsQTeybTQ75+2z0xPrrhnGmgh6g0qTYcAaq
+        M5ONOGiqeSBX/Smjh6ALy5XkhUiFGLsI7Yluf6XSICY/x7gd6RAfgSIQrUTNMoS1sqhT4aot
+        +xvOfQy8ySkfAK4NddXql6E/+ZqTmBY/Lr0YklFBy8jGT+UysfiIznPMIwbmgq5Li7BtDDtX
+        b8Uyi4edPpjtextezfXYn4NVIpPL5dPZS/FXh4HpzyH0pYCfrH4QDGA7i52AGmhpiOFjJMo6
+        N33sdjZHOH/2Vyp+QZaQnsdUAi1N4M6c33tQbpIScn1SY+El8z5JDA4PBzkw8HpLCi1gGoa6
+        V4kfbWqXXbGAJFkLkP/vc4+pY9axOlmCkJg7xCPwhI75y1cONgovhz+BEXOzolh5KZuGbGbj
+        xe0wva5DLBeIg7EQFf+99pOS7Syby3Xpm6ZbswEFV0cllK4jf/QMjtfInxobuMoI0GV0bE5l
+        WlRtPCK5FnbHwxi0wPNzB/5fwzJ77r6HgPrR0OkT0lWmbUyoOQARAQABtC1MYXVuY2hwYWQg
+        UFBBIGZvciBjbG91ZCBpbml0IGRldmVsb3BtZW50IHRlYW2JAjgEEwECACIFAlbZRUICGwMG
+        CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAg9Bvvk0wTfHfcP/REK5N2s1JYc69qEa9ZN
+        o6oi+A7l6AYw+ZY88O5TJe7F9otv5VXCIKSUT0Vsepjgf0mtXAgf/sb2lsJn/jp7tzgov3YH
+        vSrkTkRydz8xcA87gwQKePuvTLxQpftF4flrBxgSueIn5O/tPrBOxLz7EVYBc78SKg9aj9L2
+        yUp+YuNevlwfZCTYeBb9r3FHaab2HcgkwqYch66+nKYfwiLuQ9NzXXm0Wn0JcEQ6pWvJscbj
+        C9BdawWovfvMK5/YLfI6Btm7F4mIpQBdhSOUp/YXKmdvHpmwxMCN2QhqYK49SM7qE9aUDbJL
+        arppSEBtlCLWhRBZYLTUna+BkuQ1bHz4St++XTR49Qd7vDERALpApDjB2dxPfMiBzCMwQQyq
+        uy13exU8o2ETLg+dZSLfDTzrBNsBFmXlw8WW17nTISYdKeGKL+QdlUjpzdwUMMzHhAO8SmMH
+        zjeSlDSRMXBJFAFSbCl7EwmMKa3yVX0zInT91fNllZ3iatAmtVdqVH/BFQfTIMH2ET7A8WzJ
+        ZzVSuMRhqoKdr5AMcHuJGPUoVkVJHQA+NNvEiXSysF3faL7jmKapmUwrhpYYX2H8pf+VMu2e
+        cLflKTI28dl+ZQ4Pl/aVsxrti/pzhdYy05Sn5ddtySyIkvo8L1cU5MWpbvSlFPkTstBUDLBf
+        pb0uBy+g0oxJQg15
+        =uy53
+        -----END PGP PUBLIC KEY BLOCK-----
+apt_pipelining: os
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:44:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:44:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:44:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:45:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=eb9a8e17-3ec4-4a3d-a585-6787aa9f48bf)
+2021-09-05 12:45:06 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=eb9a8e17-3ec4-4a3d-a585-6787aa9f48bf)
+2021-09-05 12:45:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:45:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:45:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_conf Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/94cloud-init-config'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_apt_proxy Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-aptproxy'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 12:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/simplestreams-dev-ubuntu-trunk-bionic.list'
+2021-09-05 12:45:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_key Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_key.list'
+2021-09-05 12:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_keyserver Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list.d/test_keyserver.list'
+2021-09-05 12:45:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'apt-key finger'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestApt::test_os_pipelining Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:10 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:45:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_primary_on_openstack Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:45:18 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:45:18 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      
+  security:
+    - arches:
+      - default
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:45:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:45:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:45:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:46:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=666c044a-9579-4769-a90b-cdebf800a5cf)
+2021-09-05 12:46:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=666c044a-9579-4769-a90b-cdebf800a5cf)
+2021-09-05 12:46:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:46:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:46:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:46:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:46:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init query v1.availability_zone'
+2021-09-05 12:46:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDefaults::test_security Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:46:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:46:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::test_default_primary_with_uri Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:46:16 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:46:16 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches:
+      - default
+      uri: "http://something.random.invalid/ubuntu"
+  security:
+    - arches:
+      - default
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:46:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:46:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:46:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:46:59 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=a0f4d0a0-1283-4a77-b7b2-36318243ce2f)
+2021-09-05 12:47:01 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=a0f4d0a0-1283-4a77-b7b2-36318243ce2f)
+2021-09-05 12:47:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:47:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:47:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:47:02 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:47:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list'
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_suites Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:47:09 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:47:09 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  disable_suites:
+  - $RELEASE
+  - $RELEASE-updates
+  - $RELEASE-backports
+  - $RELEASE-security
+apt_pipelining: false
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:47:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:47:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:47:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:47:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=b6aae71c-83dd-4571-9928-e116589c6d75)
+2021-09-05 12:47:58 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=b6aae71c-83dd-4571-9928-e116589c6d75)
+2021-09-05 12:47:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:47:59 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:47:59 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/sources.list | grep -v '"'"'^#'"'"''
+PASSED
+tests/integration_tests/modules/test_apt.py::TestDisabled::test_disable_apt_pipelining Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:47:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:47:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/apt/apt.conf.d/90cloud-init-pipelining'
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_certs_updated Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:48:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:48:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ca-certs:
+  remove-defaults: true
+  trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+      DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+      d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+      bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+      E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+      MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+      d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+      MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+      9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+      k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+      yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+      RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+      q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+      uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+      vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+      6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+      Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+      z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+      SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+      Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+      TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+      ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+      DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+      mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+      PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+      70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+      slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+      ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+      Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+      RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+      CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+      hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+      DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+      -----END CERTIFICATE-----
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:48:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:48:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:48:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:49:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6f74e7f5-99a7-44e4-8d6d-b371f6462ecc)
+2021-09-05 12:49:01 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6f74e7f5-99a7-44e4-8d6d-b371f6462ecc)
+2021-09-05 12:49:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:49:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:49:02 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:49:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- ls -1 /etc/ssl/certs
+2021-09-05 12:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/a535c1f3.0
+2021-09-05 12:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/ca-certificates.crt
+2021-09-05 12:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- readlink /etc/ssl/certs/cloud-init-ca-certs.pem
+PASSED
+tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:49:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:49:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum /etc/ssl/certs/ca-certificates.crt'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_valid_userdata Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:49:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:49:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:49:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:49:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:50:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:50:04 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=cafebdab-de70-419d-b5d0-ac2759dcf9d4)
+2021-09-05 12:50:06 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=cafebdab-de70-419d-b5d0-ac2759dcf9d4)
+2021-09-05 12:50:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:50:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:50:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:50:07 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:50:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_cli.py::test_invalid_userdata Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:50:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:50:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=runcmd:
+  - echo 'hi' > /var/tmp/test
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:50:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:50:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:50:57 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:51:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5f390774-78ff-4525-8859-08c39d2ce2bb)
+2021-09-05 12:51:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5f390774-78ff-4525-8859-08c39d2ce2bb)
+2021-09-05 12:51:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:51:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:51:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:51:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel schema --system'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:51:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:51:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://us.archive.ubuntu.com/ubuntu/
+byobu_by_default: enable
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/default/locale
+ntp:
+  servers: ['ntp.ubuntu.com']
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:51:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:51:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:51:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:51:57 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=d537e57e-7779-4815-92fd-b32d3448cf20)
+2021-09-05 12:52:01 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=d537e57e-7779-4815-92fd-b32d3448cf20)
+2021-09-05 12:52:01 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:52:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:52:02 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 12:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%a, %d %b %Y"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e "/etc/byobu/autolaunch"'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:03 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/default/locale'
+2021-09-05 12:52:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'locale -a'
+2021-09-05 12:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/locale.gen | grep -v '"'"'^#'"'"' | uniq'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/status.json'
+2021-09-05 12:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /run/cloud-init/result.json'
+2021-09-05 12:52:04 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED
+tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED
+tests/integration_tests/modules/test_command_output.py::test_runcmd Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:52:13 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:52:13 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+output: { all: "| tee -a /var/log/cloud-init-test-output" }
+final_message: "should be last line in cloud-init-test-output file"
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:52:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:52:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:53:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:53:06 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=22d0e20d-e8e8-4101-acf9-e1be85399b54)
+2021-09-05 12:53:07 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=22d0e20d-e8e8-4101-acf9-e1be85399b54)
+2021-09-05 12:53:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:53:07 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:53:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:53:08 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:53:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-test-output'
+PASSED
+tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases::test_device_alias SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_when_mounted SKIPPED
+tests/integration_tests/modules/test_disk_setup.py::TestPartProbeAvailability::test_disk_setup_no_partprobe SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_hotplug_add_remove Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:53:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_in_userdata Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:53:17 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:53:17 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:53:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:53:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:54:06 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:54:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:54:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=73292073-4804-4025-a699-7abc05b213aa)
+2021-09-05 12:54:10 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=73292073-4804-4025-a699-7abc05b213aa)
+2021-09-05 12:54:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:54:11 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:54:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:54:11 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:54:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 12:54:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 12:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 12:54:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 12:54:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip --brief addr'
+2021-09-05 12:54:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init devel hotplug-hook -s net query'
+PASSED
+tests/integration_tests/modules/test_jinja_templating.py::test_runcmd_with_variable_substitution Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:54:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:54:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=## template: jinja
+#cloud-config
+runcmd:
+  - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
+  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:55:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:55:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:55:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:55:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5f1054e7-2ee0-47b1-a4f9-529c0d6b851a)
+2021-09-05 12:55:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5f1054e7-2ee0-47b1-a4f9-529c0d6b851a)
+2021-09-05 12:55:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:55:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:55:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:55:41 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 12:55:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/tmp/runcmd_output'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[DSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:55:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:55:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:56:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:56:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:56:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:56:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=886aff2a-50cd-48e7-b9bd-fbab62656f88)
+2021-09-05 12:56:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=886aff2a-50cd-48e7-b9bd-fbab62656f88)
+2021-09-05 12:56:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:56:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:56:40 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_excluded_keys[ECDSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:56:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[ED25519] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:56:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:56:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleBlacklist::test_included_keys[RSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:56:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:56:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_header_excluded Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:56:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:56:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:57:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:57:34 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:57:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:57:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=18f90974-7e97-4140-ada7-b2493cf22c9b)
+2021-09-05 12:57:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=18f90974-7e97-4140-ada7-b2493cf22c9b)
+2021-09-05 12:57:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:57:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:57:40 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:57:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestAllKeysToConsoleBlacklist::test_footer_excluded Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:57:41 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:57:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[DSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:57:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:57:50 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh:
+  emit_keys_to_console: false
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:58:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:58:40 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:58:41 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:58:43 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=7872b575-849e-4e06-bfae-9e7fd9302d70)
+2021-09-05 12:58:44 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=7872b575-849e-4e06-bfae-9e7fd9302d70)
+2021-09-05 12:58:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:58:45 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 12:58:45 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ECDSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[ED25519] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:45 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_keys_excluded[RSA] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_header_excluded Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_keys_to_console.py::TestKeysToConsoleDisabled::test_footer_excluded Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 12:58:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxc] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 12:58:57 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:58:57 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:59:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:59:47 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:59:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:59:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=67bf01ec-3f79-4004-8113-ead83cb0b18c)
+2021-09-05 13:00:18 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=67bf01ec-3f79-4004-8113-ead83cb0b18c)
+2021-09-05 13:00:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:00:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:00:19 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxc
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_binaries_installed[lxd] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:00:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- which lxd
+PASSED
+tests/integration_tests/modules/test_lxd_bridge.py::TestLxdBridge::test_bridge Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:00:19 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:00:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ip addr show lxdbr0'
+2021-09-05 13:00:20 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'lxc network show lxdbr0'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:00:28 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:00:28 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+  pools:
+      - 0.cloud-init.mypool
+      - 1.cloud-init.mypool
+      - 172.16.15.15
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:00:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:00:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:00:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:01:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:01:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:01:16 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=6c3b1307-8f4c-4bdb-87c7-0568d9a944e7)
+2021-09-05 13:01:33 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=6c3b1307-8f4c-4bdb-87c7-0568d9a944e7)
+2021-09-05 13:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:01:33 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:01:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:01:34 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:01:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ntp.conf.dist'
+SKIPPED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:01:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:01:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:01:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpq -p -w -n'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_chrony Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:01:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:01:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: chrony
+  servers:
+      - 172.16.15.14
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:02:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:02:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:02:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:02:33 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f9c444bb-a87d-45a4-9c71-aec57db3e585)
+2021-09-05 13:02:47 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f9c444bb-a87d-45a4-9c71-aec57db3e585)
+2021-09-05 13:02:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:02:48 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:02:48 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/chrony.conf'
+2021-09-05 13:02:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/chrony/chrony.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_timesyncd Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:02:58 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:02:58 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  enabled: true
+  ntp_client: systemd-timesyncd
+  servers:
+      - 172.16.15.14
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:03:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:03:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:03:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:03:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=4caf7de7-7e44-48df-ba56-c93899691aed)
+2021-09-05 13:03:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4caf7de7-7e44-48df-ba56-c93899691aed)
+2021-09-05 13:03:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:03:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:03:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:03:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:03:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/systemd/timesyncd.conf.d/cloud-init.conf'
+PASSED
+tests/integration_tests/modules/test_ntp_servers.py::test_empty_ntp Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:03:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:03:59 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ntp:
+  ntp_client: ntp
+  pools: []
+  servers: []
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:04:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:04:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:04:45 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:04:46 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c42d398a-756c-46f2-82d1-81b9aca92a29)
+2021-09-05 13:05:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c42d398a-756c-46f2-82d1-81b9aca92a29)
+2021-09-05 13:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:05:02 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:05:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:05:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ntpd --version'
+2021-09-05 13:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /etc/ntp.conf.dist'
+2021-09-05 13:05:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep -v "^#" /etc/ntp.conf'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_new_packages_are_installed Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:05:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:05:11 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+packages:
+  - sl
+  - tree
+package_update: true
+package_upgrade: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:05:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:05:56 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:05:56 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:05:58 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=9aae1721-5bee-4258-b810-65959ea0ba2f)
+2021-09-05 13:07:14 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=9aae1721-5bee-4258-b810-65959ea0ba2f)
+2021-09-05 13:07:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:07:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:07:15 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'dpkg-query --show'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_updated Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:07:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^Commandline: /var/log/apt/history.log'
+PASSED
+tests/integration_tests/modules/test_package_update_upgrade_install.py::TestPackageUpdateUpgradeInstall::test_packages_were_upgraded Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:07:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:07:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_persistence.py::test_log_message_on_missing_version_file SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[poweroff-now-10-will execute: shutdown -P now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[reboot-now-0-will execute: shutdown -r now msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff[halt-+1-0-will execute: shutdown -H +1 msg] SKIPPED
+tests/integration_tests/modules/test_power_state_change.py::TestPowerChange::test_poweroff_false_condition SKIPPED
+tests/integration_tests/modules/test_seed_random_data.py::TestSeedRandomData::test_seed_random_data Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:07:25 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:07:25 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:07:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:07:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:07:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:15 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:08:15 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:08:17 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=1ce8f53c-19a2-4140-bc87-f4f01f643511)
+2021-09-05 13:08:18 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=1ce8f53c-19a2-4140-bc87-f4f01f643511)
+2021-09-05 13:08:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:08:19 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:08:19 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:08:19 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'head -c 31 < /root/seed'
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:08:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:08:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: cloudinit2
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:08:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:08:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:09:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:09:15 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=86df7238-a69f-4c8d-871d-534377fc8045)
+2021-09-05 13:09:17 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=86df7238-a69f-4c8d-871d-534377fc8045)
+2021-09-05 13:09:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:09:18 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:09:18 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:09:18 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_fqdn Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:09:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:09:30 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: True
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:09:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:09:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:10:18 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:10:18 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:10:19 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c6ebd762-d389-4a26-9fe7-2339a524a2e7)
+2021-09-05 13:10:21 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c6ebd762-d389-4a26-9fe7-2339a524a2e7)
+2021-09-05 13:10:21 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:10:22 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:10:22 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:10:22 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_prefer_short_hostname Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:10:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:10:36 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+prefer_fqdn_over_hostname: False
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:10:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:11:23 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:11:23 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:11:25 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f574720f-bbfe-4d7e-b308-9c72a1c11d78)
+2021-09-05 13:11:26 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f574720f-bbfe-4d7e-b308-9c72a1c11d78)
+2021-09-05 13:11:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:11:27 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:11:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:11:27 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:11:27 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+PASSED
+tests/integration_tests/modules/test_set_hostname.py::TestHostname::test_hostname_and_fqdn Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:11:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:11:37 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+manage_etc_hosts: true
+hostname: cloudinit1
+fqdn: cloudinit2.i9n.cloud-init.io
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:12:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:12:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:12:26 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:12:28 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=2bd17383-170c-4b85-b0cc-1e17dae76f3d)
+2021-09-05 13:12:29 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=2bd17383-170c-4b85-b0cc-1e17dae76f3d)
+2021-09-05 13:12:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:12:30 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:12:30 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c hostname
+2021-09-05 13:12:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'hostname --fqdn'
+2021-09-05 13:12:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep ^127 /etc/hosts'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:12:39 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:12:39 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:13:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:13:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:13:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:13:32 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=49dc699c-4e54-4f5d-945a-6420517bd300)
+2021-09-05 13:13:34 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=49dc699c-4e54-4f5d-945a-6420517bd300)
+2021-09-05 13:13:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:13:35 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:13:35 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_emitted_to_serial_console Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:36 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:13:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:13:52 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:13:52 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3yUh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+
+chpasswd:
+    list: |
+      tom:mypassword123!
+      dick:RANDOM
+      harry:RANDOM
+      mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:14:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:14:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:14:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:14:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=2a3b9896-8174-46ba-a4df-11134ac01984)
+2021-09-05 13:14:40 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=2a3b9896-8174-46ba-a4df-11134ac01984)
+2021-09-05 13:14:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:14:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:14:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_not_stored_in_cloud_init_output_log Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init-output.log'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_emitted_to_serial_console Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/shadow'
+PASSED
+tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:14:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_snap.py::TestSnap::test_snap Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:14:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:14:55 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+package_update: true
+snap:
+  squashfuse_in_container: true
+  commands:
+    - snap install hello-world
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:15:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:15:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:15:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:15:45 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=e628673e-c73d-417f-a90a-9175cd82f2d0)
+2021-09-05 13:16:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=e628673e-c73d-417f-a90a-9175cd82f2d0)
+2021-09-05 13:16:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:16:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:16:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:16:26 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:16:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'snap list'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_disable Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:16:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:16:38 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+no_ssh_fingerprints: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:17:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:17:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:17:21 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:17:22 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=1b345193-744f-4957-9fda-f5ec1438178f)
+2021-09-05 13:17:24 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=1b345193-744f-4957-9fda-f5ec1438178f)
+2021-09-05 13:17:24 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:17:25 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:17:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:17:25 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:17:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py::TestSshAuthkeyFingerprints::test_ssh_authkey_fingerprints_enable Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:17:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:17:33 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:17:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:18:21 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:18:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:18:23 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=3e0c6ec6-993b-45b5-b3af-02fd3a3d3dc3)
+2021-09-05 13:18:25 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=3e0c6ec6-993b-45b5-b3af-02fd3a3d3dc3)
+2021-09-05 13:18:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:18:26 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:18:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:18:26 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:18:26 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/syslog'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key.pub] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:18:35 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:18:35 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_genkeytypes:
+  - ecdsa
+  - ed25519
+authkey_hash: sha512
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:18:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:19:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:19:25 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:19:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=0a208a29-5697-4075-aed5-0a6504cecc89)
+2021-09-05 13:19:28 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=0a208a29-5697-4075-aed5-0a6504cecc89)
+2021-09-05 13:19:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:19:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:19:29 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_dsa_key] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key.pub] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:29 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_not_generated[/etc/ssh/ssh_host_rsa_key] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -e /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key.pub] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ecdsa_key] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key.pub] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_generate.py::TestSshKeysGenerate::test_ssh_keys_generated[/etc/ssh/ssh_host_ed25519_key] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:30 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:19:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_import_id.py::TestSshImportId::test_ssh_import_id Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:19:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:19:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+ssh_import_id:
+  - gh:powersj
+  - lp:smoser
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:20:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:20:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:20:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:20:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=b2b946a0-4172-4bbd-8a01-e34b27d6f581)
+2021-09-05 13:20:35 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=b2b946a0-4172-4bbd-8a01-e34b27d6f581)
+2021-09-05 13:20:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:20:36 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:20:36 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:20:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key.pub-AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:20:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:20:47 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+disable_root: false
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXW9Gg5H7ehjdSc6qDzwNtgCy94XYHhEYlXZMO2+FJrH3wfHGiMfCwOHxcOMt2QiXItULthdeQWS9QjBSSjVRXf6731igFrqPFyS9qBlOQ5D29C4HBXFnQggGVpBNJ82IRJv7szbbe/vpgLBP4kttUza9Dr4e1YM1ln4PRnjfXea6T0m+m1ixNb5432pTXlqYOnNOxSIm1gHgMLxPuDrJvQERDKrSiKSjIdyC9Jd8t2e1tkNLY0stmckVRbhShmcJvlyofHWbc2Ca1mmtP7MlS1VQnfLkvU1IrFwkmaQmaggX6WR6coRJ6XFXdWcq/AI2K6GjSnl1dnnCxE8VCEXBlXgFzad+PMSG4yiL5j8Oo1ZVpkTdgBnw4okGqTYCXyZg6X00As9IBNQfZMFlQXlIo4FiWgj3CO5QHQOyOX6FuEumaU13GnERrSSdp9tCs1Qm3/DG2RSCQBWTfcgMcStIvKqvJ3IjFn0vGLvI3Ampnq9q1SHwmmzAPSdzcMA76HyMUA5VWaBvWHlUxzIM6unxZASnwvuCzpywSEB5J2OF+p6H+cStJwQ32XwmOG8pLp1srlVWpqZI58Du/lzrkPqONphoZx0LDV86w7RUz1ksDzAdcm0tvmNRFMN1a0frDs506oA3aWK0oDk4Nmvk8sXGTYYw3iQSkOvDUUlIsqdaO+w==
+ssh_keys:
+  rsa_private: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnj
+    o8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR9
+    9TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901Y
+    RM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHu
+    yjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+c
+    DurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQIDAQABAoIBAQCrU4IJP8dNeaj5
+    IpkY6NQvR/jfZqfogYi+MKb1IHin/4rlDfUvPcY9pt8ttLlObjYK+OcWn3Vx/sRw
+    4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm
+    lq95OrCghnG03aUsFJUZPpi5ydnwbA12ma+KHkG0EzaVlhA7X9N6z0K6U+zue2gl
+    goMLt/MH0rsYawkHrwiwXaIFQeyV4MJP0vmrZLbFk1bycu9X/xPtTYotWyWo4eKA
+    cb05uu04qwexkKHDM0KXtT0JecbTo2rOefFo8Uuab6uJY+fEHNocZ+v1vLA4aOxJ
+    ovp1JuXlAoGBAOWYNgKrlTfy5n0sKsNk+1RuL2jHJZJ3HMd0EIt7/fFQN3Fi08Hu
+    jtntqD30Wj+DJK8b8Lrt66FruxyEJm5VhVmwkukrLR5ige2f6ftZnoFCmdyy+0zP
+    dnPZSUe2H5ZPHa+qthJgHLn+al2P04tGh+1fGHC2PbP+e0Co+/ZRIOxrAoGBAMnN
+    IEen9/FRsqvnDd36I8XnJGskVRTZNjylxBmbKcuMWm+gNhOI7gsCAcqzD4BYZjjW
+    pLhrt/u9p+l4MOJy6OUUdM/okg12SnJEGryysOcVBcXyrvOfklWnANG4EAH5jt1N
+    ftTb1XTxzvWVuR/WJK0B5MZNYM71cumBdUDtPi+nAoGAYmoIXMSnxb+8xNL10aOr
+    h9ljQQp8NHgSQfyiSufvRk0YNuYh1vMnEIsqnsPrG2Zfhx/25GmvoxXGssaCorDN
+    5FAn6QK06F1ZTD5L0Y3sv4OI6G1gAuC66ZWuL6sFhyyKkQ4f1WiVZ7SCa3CHQSAO
+    i9VDaKz1bf4bXvAQcNj9v9kCgYACSOZCqW4vN0OUmqsXhkt9ZB6Pb/veno70pNPR
+    jmYsvcwQU3oJQpWfXkhy6RAV3epaXmPDCsUsfns2M3wqNC7a2R5xdCqjKGGzZX4A
+    AO3rz9se4J6Gd5oKijeCKFlWDGNHsibrdgm2pz42nZlY+O21X74dWKbt8O16I1MW
+    hxkbJQKBgAXfuen/srVkJgPuqywUYag90VWCpHsuxdn+fZJa50SyZADr+RbiDfH2
+    vek8Uo8ap8AEsv4Rfs9opUcUZevLp3g2741eOaidHVLm0l4iLIVl03otGOqvSzs+
+    A3tFPEOxauXpzCt8f8eXsz0WQXAgIKW2h8zu5QHjomioU3i27mtE
+    -----END RSA PRIVATE KEY-----
+  rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
+  rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
+  dsa_private: |
+    -----BEGIN DSA PRIVATE KEY-----
+    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
+    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
+    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
+    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
+    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
+    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
+    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
+    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
+    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
+    nCPOXEQsayANi8+Cb7BH
+    -----END DSA PRIVATE KEY-----
+  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
+  ed25519_private: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+QAAAJgwt+lcMLfp
+    XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q
+    AAAEDQlFZpz9q8+/YJHS9+jPAqy2ZT6cGEv8HTB6RZtTjd/dudAZSu4vjZpVWzId5pXmZg
+    1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
+    -----END OPENSSH PRIVATE KEY-----
+  ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ecdsa_private: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
+    AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb
+    7f/CtXuM6s2svcDJqAeXr6Wk8OJJcMxylA==
+    -----END EC PRIVATE KEY-----
+  ecdsa_public: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxUG6kdQOvdQJCYGZN42OZqWasYF+L3IG+3/wrV7jOrNrL3AyagHl6+lpPDiSXDMcpQ= root@xenial-lxd
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:21:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:21:26 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:21:27 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:21:29 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=9ed3fba2-06f5-404f-bfdb-4300dffcd3b7)
+2021-09-05 13:21:30 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=9ed3fba2-06f5-404f-bfdb-4300dffcd3b7)
+2021-09-05 13:21:30 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:21:31 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:21:31 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_dsa_key-MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_dsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key.pub-AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-4DOkqNiUGl80Zp1RgZNohHUXlJMtAbrIlAVEk+mTmg7vjfyp2unRQvLZpMRdywBm] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_rsa_key-cert.pub-AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_rsa_key-cert.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/sshd_config-HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/sshd_config'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key.pub-AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsS5Tvky/IC/dXhE/afxxU] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ecdsa_key-AwEHoUQDQgAEWxLlO+TL8gL91eET9p/HFQbqR1A691AkJgZk3jY5mpZqxgX4vcgb] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ecdsa_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key.pub-AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:32 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key.pub'
+PASSED
+tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided::test_ssh_provided_keys[/etc/ssh/ssh_host_ed25519_key-XAAAAAtzc2gtZWQyNTUxOQAAACDbnQGUruL42aVVsyHeaV5mYNTOhteXao0Nl5DVThJ2+Q] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:33 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:21:33 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/ssh_host_ed25519_key'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys_default Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:21:42 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:21:42 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - ""
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:22:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:22:24 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:24 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:22:26 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=8f890d7c-c9f1-4637-a064-7d38acce1391)
+2021-09-05 13:22:28 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=8f890d7c-c9f1-4637-a064-7d38acce1391)
+2021-09-05 13:22:28 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:22:29 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:22:29 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:22:29 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys'
+2021-09-05 13:22:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 13:22:29 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 13:22:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:30 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 13:22:30 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:31 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:31 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys'
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 13:22:31 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 13:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 13:22:32 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys'
+2021-09-05 13:22:32 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 13:22:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:34 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:34 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 13:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 13:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 13:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys'
+2021-09-05 13:22:34 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 13:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 13:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 13:22:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 13:22:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 13:22:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 13:22:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:37 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:37 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys'
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 13:22:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 13:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 13:22:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys'
+2021-09-05 13:22:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 13:22:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 13:22:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:22:40 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:40 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys'
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 13:22:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 13:22:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 13:22:42 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_authorized_keys2 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:22:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:22:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/.ssh/authorized_keys2;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:23:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:23:36 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:36 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:23:38 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=d566fd51-d694-42b3-9bb7-e0027ef9d9d6)
+2021-09-05 13:23:40 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=d566fd51-d694-42b3-9bb7-e0027ef9d9d6)
+2021-09-05 13:23:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:23:41 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:23:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:23:41 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:23:41 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 13:23:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 13:23:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 13:23:42 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 13:23:43 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:43 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 13:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 13:23:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh'
+2021-09-05 13:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/.ssh/authorized_keys2'
+2021-09-05 13:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 13:23:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 13:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 13:23:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 13:23:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 13:23:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:47 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 13:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 13:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh'
+2021-09-05 13:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/.ssh/authorized_keys2'
+2021-09-05 13:23:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 13:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 13:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 13:23:48 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 13:23:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 13:23:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:49 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 13:23:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:50 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh/authorized_keys2'
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 13:23:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 13:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 13:23:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/.ssh/authorized_keys2'
+2021-09-05 13:23:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 13:23:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:52 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 13:23:52 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:23:53 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:53 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 13:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 13:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 13:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh/authorized_keys2'
+2021-09-05 13:23:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 13:23:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 13:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 13:23:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_nested_keys Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:24:04 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:24:04 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys %h/foo/bar/ssh/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:24:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:24:48 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:48 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:24:50 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=2b01c457-7c7b-4554-aa11-f398929b68c8)
+2021-09-05 13:24:52 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=2b01c457-7c7b-4554-aa11-f398929b68c8)
+2021-09-05 13:24:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:24:53 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:24:53 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:24:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 13:24:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 13:24:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 13:24:54 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 13:24:55 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:55 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:24:55 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 13:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 13:24:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1/foo/bar/ssh/keys'
+2021-09-05 13:24:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 13:24:56 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:24:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 13:24:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 13:24:57 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 13:24:57 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 13:24:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 13:24:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 13:24:59 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:24:59 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:24:59 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 13:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 13:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2/foo/bar/ssh/keys'
+2021-09-05 13:24:59 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 13:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 13:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 13:25:00 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 13:25:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 13:25:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:01 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 13:25:01 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:02 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:25:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 13:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 13:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 13:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/foo/bar/ssh/keys'
+2021-09-05 13:25:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 13:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 13:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 13:25:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /root/foo/bar/ssh/keys'
+2021-09-05 13:25:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 13:25:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 13:25:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:25:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 13:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 13:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 13:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/foo/bar/ssh/keys'
+2021-09-05 13:25:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 13:25:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:25:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 13:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 13:25:07 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_ssh_keysfile.py::test_external_keys Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:25:15 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:25:15 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+bootcmd:
+ - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /etc/ssh/authorized_keys/%u/keys;' /etc/ssh/sshd_config
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk8bgx2RhAoPnv+qt4WuH0ZELbbLrqpk5ZlZGMLzzuutu8HM7r2FXImlMheV4kS+laIdhyMxHkbo00Wyc21nh/EOqZJzi9wWPncmwT9c2osqrqmxdp0Jvm+Q2kZvED5nlsmXMn3r0+AkggRuBzzqx6LiSBHYy49aq1ltjkaSk0JOpa4th4Ur7XigWu4DafJYf0w4hEMcr93n3umwfL4tMy3KY7tk+E7nvVpsrDqO+/CJJ4PFUT2RXsoBAi4z39LeB+2+BBCuifcYvfimCYhpt1IZ1t8eoYOiivImGVuq4lkQsE3bfoqBE1MICNW9TOONCvV5E/fGywbBU7oQIEYJAuX9piiACC3CfCP2Jeq1+IsrcTCWCOq5Tj4lDQJW0uEbeAhkH6qgxOFyjSmYdOuO19ALCvO2wEEW6dJrb8Ky25XWZDk7lmtnoAKj3I9EE2Sezr4KIp20y0K3OLeTZEPP2OliY9xqTTcuvsiR0LVOnr6MD7//I8dI7WjgKpbz0hDM0= test3@host
+
+users:
+- default
+- name: test_user1
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1GUb3ponbdRG8CA79sGy4uX6Wq5zfnRpLBX3z+Ly+W86fkZVwfJ63+tdCDiVnizSjAbeRbJAVjye9OT4b5Q1Tx83RqcDMEOL7gzOx6OQX2xyNMwWZdWsikgKpXdthA2M+/qv65tB2QPTV27d4H23n/OXziC2yGnSEF2h/LPy7X8Dbmzt9VTrsbIjs90q9pL7K8lIidmdvZ71VDN8kL6oCc3uBRlq0EqN2BS0l6JRR4NpWdpLXtvRqhP2IE7SwhxC05MGViUKMW3VMAwtnrgePdJ8ZkHtiPRn4vMUHYhZfXPOyMjrxiRg8o5Iv81iFBT17nmQlDtaeeA0dj/af8Dt00pIUOaAzlz0haB5nt+Omx8hgCgn8IDEUg0P48Qd3WAJLrGgSFpRXKHlYf9eTAq/WfHgCJnYEUIT7vmTJJEtlQn7nLSvcNTmS0xd5RHNUg/um7RHwMK6X4ZT4z/5MfJa0AQ6B5o0np9imjaKkOFuZNi3eSTaUwhqlHEYEWz7fux0= test1@host
+
+- name: test_user2
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rnQPY9Y5ziKTIdVElLq0OGrOMvlwqKK8gPinVfwFgJXDzdcAQY4uci1TJVcc0AOWHp+lWrU1joDYlW3KCg8XpkXHymHshYyaeEN2fEsvIaxuF3UzW2JckP9H7dacYdEng8qtBq8wuCodGuJ5XdBVV+MVJ6jqNf/hOu4/pma8hMxlYmtdoamHEn+k/KQR2Q6LwCYpT0U2+KiPI9Lac22P0H/rfkh2Ba+t3tV/lhyzD0xHnktZKJ3BrznpEfrZiXoukQZMebWUmIyTW7zwk9Kq+iGFpSQsqQWlxDBwHSbvpbUo7KWUmyZfxs1euVmwj5aKJgjteXm9CbbXsMS415q+08C0MzG7weZODZQnnk1rF6Ft97aXHaTmRgYbDeLU7U5U3alnb84HvUu5xh3/mrE9rPTfCzBwY4lgY+Q1zjS90RL9Jxzti3weydm7OqTI6DOfQeJQLOhhRgthOkt/7IabDFLIARjTnpo5+QKxugoc4qI6aUnE1plkVCRfV696ngM= test2@host
+
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:25:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:25:58 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:25:58 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:26:00 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=36226c6d-c51a-4280-a06a-42e8529676ad)
+2021-09-05 13:26:02 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=36226c6d-c51a-4280-a06a-42e8529676ad)
+2021-09-05 13:26:02 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:26:03 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:26:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:26:03 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:26:03 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 13:26:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:03 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user2 with key from test_user1
+2021-09-05 13:26:03 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user1
+2021-09-05 13:26:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:04 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user1
+2021-09-05 13:26:04 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:05 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:05 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user1'
+2021-09-05 13:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user1/.ssh'
+2021-09-05 13:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user1/keys'
+2021-09-05 13:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user1/.ssh'
+2021-09-05 13:26:05 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user1/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:26:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa'
+2021-09-05 13:26:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user1/.ssh/id_rsa.pub'
+2021-09-05 13:26:06 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 13:26:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from test_user2
+2021-09-05 13:26:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:07 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as ubuntu with key from test_user2
+2021-09-05 13:26:07 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as root with key from test_user2
+2021-09-05 13:26:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:08 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:08 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/test_user2'
+2021-09-05 13:26:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/test_user2/.ssh'
+2021-09-05 13:26:08 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/test_user2/keys'
+2021-09-05 13:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/test_user2/.ssh'
+2021-09-05 13:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/test_user2/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa'
+2021-09-05 13:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/test_user2/.ssh/id_rsa.pub'
+2021-09-05 13:26:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 13:26:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from ubuntu
+2021-09-05 13:26:10 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:10 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from ubuntu
+2021-09-05 13:26:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:11 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu'
+2021-09-05 13:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /home/ubuntu/.ssh'
+2021-09-05 13:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home/ubuntu/.ssh'
+2021-09-05 13:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/ubuntu/keys'
+2021-09-05 13:26:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /home/ubuntu/.ssh'
+2021-09-05 13:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /home/ubuntu/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:26:12 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa'
+2021-09-05 13:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /home/ubuntu/.ssh/id_rsa.pub'
+2021-09-05 13:26:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/ssh/authorized_keys/root/keys'
+2021-09-05 13:26:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:13 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+trying to connect as test_user1 with key from root
+2021-09-05 13:26:13 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+trying to connect as test_user2 with key from root
+2021-09-05 13:26:14 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:26:14 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) failed.
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:14 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 13:26:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root'
+2021-09-05 13:26:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -d /root/.ssh'
+2021-09-05 13:26:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /root/.ssh'
+2021-09-05 13:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /etc/ssh/authorized_keys/root/keys'
+2021-09-05 13:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mkdir /root/.ssh'
+2021-09-05 13:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N '"'"''"'"''
+2021-09-05 13:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa'
+2021-09-05 13:26:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'test -f /root/.ssh/id_rsa.pub'
+2021-09-05 13:26:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'stat -c "%U %a" /home'
+PASSED
+tests/integration_tests/modules/test_timezone.py::TestTimezone::test_timezone Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:26:26 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:26:26 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+timezone: US/Aleutian
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:26:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:26:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:26:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:26:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:26:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:26:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:08 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:27:09 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:27:11 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=c934c03a-14ea-43b7-871f-84a4e16c53d2)
+2021-09-05 13:27:13 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=c934c03a-14ea-43b7-871f-84a4e16c53d2)
+2021-09-05 13:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:27:13 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:27:13 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:27:14 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:27:14 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+PASSED
+tests/integration_tests/modules/test_user_events.py::test_boot_event_disabled_by_default Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:27:23 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:27:23 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:27:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:27:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:11 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:28:11 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:28:12 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=b2cd0604-01db-4f11-8889-31ff4debb59a)
+2021-09-05 13:28:15 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=b2cd0604-01db-4f11-8889-31ff4debb59a)
+2021-09-05 13:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:28:15 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:28:15 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:28:16 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 13:28:16 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:28:16 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 13:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/92db7815-f0db-4bf1-bbd7-a44bea3b780a.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:28:17 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 13:28:17 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:28:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:28:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:50 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:29:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:08 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:09 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:12 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:13 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:17 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:30:46 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:30:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:30:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:30:50 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 13:31:02 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_user_events.py::test_boot_event_enabled Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:31:02 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:31:02 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+updates:
+  network:
+    when: [boot]
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:31:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:31:45 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:31:46 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:31:48 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=903f0f15-dfe1-4f0b-84b7-0f884fb7f09b)
+2021-09-05 13:31:51 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=903f0f15-dfe1-4f0b-84b7-0f884fb7f09b)
+2021-09-05 13:31:51 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:31:52 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:31:52 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+2021-09-05 13:31:52 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:31:53 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] Opened sftp connection (server version 3)
+2021-09-05 13:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/ee6dbed8-b605-4ad6-a676-831d9d30acd1.tmp /etc/netplan/50-cloud-init.yaml'
+2021-09-05 13:31:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 13:31:53 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:32:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:32:31 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:32:32 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:32:34 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:32:35 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'ls /sys/class/net'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 13:32:43 INFO      paramiko.transport.sftp:sftp.py:158 [chan 7] sftp session closed.
+
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:32:43 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:32:43 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:33:06 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:10 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:33:33 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:33:33 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:33:35 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=76f2289c-f230-4271-8be7-c98e62101a29)
+2021-09-05 13:33:36 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=76f2289c-f230-4271-8be7-c98e62101a29)
+2021-09-05 13:33:36 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:33:37 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:33:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:33:37 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:37 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent group cloud-users
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd ubuntu
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd foobar
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd barfoo
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- getent passwd cloudy
+PASSED
+tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:38 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:33:38 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'groups root'
+PASSED
+tests/integration_tests/modules/test_users_groups.py::test_sudoers_includedir Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:33:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:33:46 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:34:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:36 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:34:39 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:34:39 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:34:41 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=195274ac-ed03-4156-84a0-47c1ad5d9356)
+2021-09-05 13:34:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=195274ac-ed03-4156-84a0-47c1ad5d9356)
+2021-09-05 13:34:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:34:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:34:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:34:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:34:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+SKIPPED
+tests/integration_tests/modules/test_version_change.py::test_reboot_without_version_change Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:34:54 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:34:54 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:35:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:35:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:35:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:35:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f73ba721-0239-43dc-9bb4-23c96857f0f9)
+2021-09-05 13:35:39 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f73ba721-0239-43dc-9bb4-23c96857f0f9)
+2021-09-05 13:35:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:35:40 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:35:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:35:40 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:35:40 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 13:35:40 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:36:22 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:36:22 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:36:24 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+2021-09-05 13:36:25 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] Opened sftp connection (server version 3)
+2021-09-05 13:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/31c6bb00-8936-4f45-84e5-0ecfb15dab87.tmp /var/lib/cloud/instance/obj.pkl'
+Restarting instance and waiting for boot
+2021-09-05 13:36:25 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:36:45 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:01 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:37:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:37:07 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:37:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 13:37:20 INFO      paramiko.transport.sftp:sftp.py:158 [chan 3] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_cache_purged_on_version_change Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:37:20 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:37:20 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:37:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:54 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:55 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:56 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:57 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:58 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:37:59 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:00 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:02 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:03 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:04 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:05 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:05 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:38:06 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:38:08 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=5f7e0575-87f2-43a2-b186-d62c7ee558dc)
+2021-09-05 13:38:09 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=5f7e0575-87f2-43a2-b186-d62c7ee558dc)
+2021-09-05 13:38:09 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:38:10 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:38:10 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:38:10 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:38:10 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 13:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/3b697410-7662-4db5-b33a-e9b7719df334.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 13:38:11 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'echo '"'"'1.0'"'"' > /var/lib/cloud/data/python-version'
+Restarting instance and waiting for boot
+2021-09-05 13:38:11 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:38:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:51 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:52 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:53 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:38:53 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:38:54 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:38:56 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:38:58 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 13:39:06 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_version_change.py::test_log_message_on_missing_version_file Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:39:06 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:39:06 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=None
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:39:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:42 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:43 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:44 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:46 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:47 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:48 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:49 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:39:49 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:39:50 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:39:52 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=f0015e44-ff6d-4831-a8dd-e2976273007a)
+2021-09-05 13:39:53 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=f0015e44-ff6d-4831-a8dd-e2976273007a)
+2021-09-05 13:39:53 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:39:54 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:39:54 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:39:54 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] Opened sftp connection (server version 3)
+2021-09-05 13:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'mv /var/tmp/31f736f8-2d57-4794-bd02-35edc5f9264d.tmp /var/lib/cloud/instance/obj.pkl'
+2021-09-05 13:39:54 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/lib/cloud/data/python-version'
+2021-09-05 13:39:55 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'rm /var/log/cloud-init.log'
+Restarting instance and waiting for boot
+2021-09-05 13:39:55 INFO      integration_testing:instances.py:66 Restarting instance and waiting for boot
+2021-09-05 13:40:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:40:35 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:40:35 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:40:37 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 13:40:39 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+PASSED------------------------------ live log logreport ------------------------------
+2021-09-05 13:40:49 INFO      paramiko.transport.sftp:sftp.py:158 [chan 4] sftp session closed.
+
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_b64-ASCII text] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:40:49 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:40:49 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+write_files:
+-   encoding: b64
+    content: QVNDSUkgdGV4dA==
+    owner: root:root
+    path: /root/file_b64
+    permissions: '0644'
+-   content: |
+        # My new /root/file_text
+
+        SMBDOPTIONS="-D"
+    path: /root/file_text
+-   content: !!binary |
+        /Z/xrHR4WINT0UNoKPQKbuovp6+Js+JK
+    path: /root/file_binary
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /root/file_gzip
+    permissions: '0755'
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 13:41:14 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:29 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:30 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:31 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:32 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:33 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:34 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:35 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:37 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:38 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:39 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:40 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:41 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 13:41:41 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 13:41:42 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 13:41:44 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+Launched instance: OpenstackInstance(instance_id=68da789c-81d2-481b-b8be-7fc5f44584ad)
+2021-09-05 13:41:45 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=68da789c-81d2-481b-b8be-7fc5f44584ad)
+2021-09-05 13:41:45 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:41:46 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 13:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+image serial: 20210817
+2021-09-05 13:41:46 INFO      integration_testing:clouds.py:183 image serial: 20210817
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_b64'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[md5sum </root/file_binary-3801184b97bb8c6e63fa0e1eae2920d7] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:41:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'md5sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[sha256sum </root/file_binary-2c791c4037ea5bd7e928d6a87380f8ba7a803cd83d5e4f269e28f5090f0f2c9a] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:41:46 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:41:46 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'sha256sum </root/file_binary'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_gzip-POSIX shell script, ASCII text executable] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:41:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_gzip'
+PASSED
+tests/integration_tests/modules/test_write_files.py::TestWriteFiles::test_write_files[file /root/file_text-ASCII text] Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+
+-------------------------------- live log setup --------------------------------
+2021-09-05 13:41:47 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+-------------------------------- live log call ---------------------------------
+2021-09-05 13:41:47 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'file /root/file_text'
+PASSEDDeleting snapshot image created for this testrun: 9fef3065-5074-414b-8549-34449f483d50
+
+------------------------------ live log teardown -------------------------------
+2021-09-05 13:41:56 INFO      integration_testing:clouds.py:204 Deleting snapshot image created for this testrun: 9fef3065-5074-414b-8549-34449f483d50
+
+
+=================================== FAILURES ===================================
+______________________________ test_chef_license _______________________________
+
+client = <tests.integration_tests.instances.IntegrationInstance object at 0x7fd49330c8d0>
+
+    @pytest.mark.adhoc  # Can't be regularly reaching out to chef install script
+    @pytest.mark.user_data(USERDATA)
+    def test_chef_license(client: IntegrationInstance):
+        log = client.read_from_file('/var/log/cloud-init.log')
+>       verify_clean_log(log)
+
+tests/integration_tests/bugs/test_gh868.py:22: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+log = "2021-09-05 12:36:14,722 - util.py[DEBUG]: Cloud-init v. 21.3-1-g6803368d-0ubuntu1~18.04.2 running 'init-local' at Sun...seconds (131.35)\n2021-09-05 12:38:43,366 - handlers.py[DEBUG]: finish: modules-final: FAIL: running modules for final"
+
+    def verify_clean_log(log):
+        """Assert no unexpected tracebacks or warnings in logs"""
+        warning_count = log.count('WARN')
+        expected_warnings = 0
+        traceback_count = log.count('Traceback')
+        expected_tracebacks = 0
+    
+        warning_texts = [
+            # Consistently on all Azure launches:
+            # azure.py[WARNING]: No lease found; using default endpoint
+            'No lease found; using default endpoint'
+        ]
+        traceback_texts = []
+        if 'oracle' in log:
+            # LP: #1842752
+            lease_exists_text = 'Stderr: RTNETLINK answers: File exists'
+            warning_texts.append(lease_exists_text)
+            traceback_texts.append(lease_exists_text)
+            # LP: #1833446
+            fetch_error_text = (
+                'UrlError: 404 Client Error: Not Found for url: '
+                'http://169.254.169.254/latest/meta-data/')
+            warning_texts.append(fetch_error_text)
+            traceback_texts.append(fetch_error_text)
+    
+        for warning_text in warning_texts:
+            expected_warnings += log.count(warning_text)
+        for traceback_text in traceback_texts:
+            expected_tracebacks += log.count(traceback_text)
+    
+>       assert warning_count == expected_warnings
+E       AssertionError
+
+tests/integration_tests/util.py:61: AssertionError
+------------------------------ Captured log setup ------------------------------
+2021-09-05 12:35:44 INFO      integration_testing:clouds.py:88 Detected image: image_id=87a74f70-d274-4e70-95d0-4ea36ce4dd4a os=ubuntu release=bionic
+2021-09-05 12:35:44 INFO      integration_testing:clouds.py:168 Launching instance with launch_kwargs:
+user_data=#cloud-config
+chef:
+  install_type: omnibus
+  chef_license: accept
+  server_url: https://chef.yourorg.invalid
+  validation_name: some-validator
+
+image_id=9fef3065-5074-414b-8549-34449f483d50
+2021-09-05 12:36:07 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:11 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:15 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:16 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:18 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:19 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:20 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:21 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:22 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:23 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:24 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:25 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:26 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:27 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:28 INFO      pycloudlib.instance:instance.py:175 executing: sh -c whoami
+2021-09-05 12:36:28 INFO      paramiko.transport:transport.py:1819 Connected (version 2.0, client OpenSSH_7.6p1)
+2021-09-05 12:36:29 INFO      paramiko.transport:transport.py:1819 Authentication (publickey) successful!
+2021-09-05 12:36:31 INFO      pycloudlib.instance:instance.py:175 executing: cloud-init status --wait --long
+2021-09-05 12:38:43 INFO      integration_testing:clouds.py:173 Launched instance: OpenstackInstance(instance_id=4310cbff-83da-40a5-8e69-804bf4dce8a3)
+2021-09-05 12:38:43 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cloud-init --version'
+2021-09-05 12:38:44 INFO      integration_testing:clouds.py:179 cloud-init version: /usr/bin/cloud-init 21.3-1-g6803368d-0ubuntu1~18.04.2
+2021-09-05 12:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
+2021-09-05 12:38:44 INFO      integration_testing:clouds.py:183 image serial: 20210817
+------------------------------ Captured log call -------------------------------
+2021-09-05 12:38:44 INFO      pycloudlib.instance:instance.py:175 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
+=============================== warnings summary ===============================
+../envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+
+tests/integration_tests/test_logging.py: 317 warnings
+tests/integration_tests/test_upgrade.py: 82 warnings
+tests/integration_tests/bugs/test_gh868.py: 41 warnings
+tests/integration_tests/bugs/test_lp1813396.py: 41 warnings
+tests/integration_tests/bugs/test_lp1886531.py: 41 warnings
+tests/integration_tests/bugs/test_lp1897099.py: 41 warnings
+tests/integration_tests/bugs/test_lp1900837.py: 41 warnings
+tests/integration_tests/modules/test_apt.py: 164 warnings
+tests/integration_tests/modules/test_ca_certs.py: 41 warnings
+tests/integration_tests/modules/test_cli.py: 82 warnings
+tests/integration_tests/modules/test_combined.py: 41 warnings
+tests/integration_tests/modules/test_command_output.py: 41 warnings
+tests/integration_tests/modules/test_hotplug.py: 41 warnings
+tests/integration_tests/modules/test_jinja_templating.py: 41 warnings
+tests/integration_tests/modules/test_keys_to_console.py: 123 warnings
+tests/integration_tests/modules/test_lxd_bridge.py: 41 warnings
+tests/integration_tests/modules/test_ntp_servers.py: 164 warnings
+tests/integration_tests/modules/test_package_update_upgrade_install.py: 41 warnings
+tests/integration_tests/modules/test_seed_random_data.py: 41 warnings
+tests/integration_tests/modules/test_set_hostname.py: 164 warnings
+tests/integration_tests/modules/test_set_password.py: 82 warnings
+tests/integration_tests/modules/test_snap.py: 41 warnings
+tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py: 82 warnings
+tests/integration_tests/modules/test_ssh_generate.py: 41 warnings
+tests/integration_tests/modules/test_ssh_import_id.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keys_provided.py: 41 warnings
+tests/integration_tests/modules/test_ssh_keysfile.py: 164 warnings
+tests/integration_tests/modules/test_timezone.py: 41 warnings
+tests/integration_tests/modules/test_user_events.py: 82 warnings
+tests/integration_tests/modules/test_users_groups.py: 82 warnings
+tests/integration_tests/modules/test_version_change.py: 123 warnings
+tests/integration_tests/modules/test_write_files.py: 75 warnings
+  /home/james/envs/cloud-init/lib/python3.5/site-packages/openstack/resource.py:351: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
+    len(inspect.getargspec(type_).args) > 1)
+
+-- Docs: https://docs.pytest.org/en/stable/warnings.html
+=========================== short test summary info ============================
+FAILED tests/integration_tests/bugs/test_gh868.py::test_chef_license - Assert...
+==== 1 failed, 123 passed, 25 skipped, 2525 warnings in 4461.10s (1:14:21) =====

--- a/21.3-1/integration_tests/openstack_notes.txt
+++ b/21.3-1/integration_tests/openstack_notes.txt
@@ -1,0 +1,1 @@
+chef_license failure is due to our internal openstack instance being firewalled and unable to reach the necessary URL. This is known and expected and not a problem with cloud-init.

--- a/21.3-1/maas-cloud-init-sru.txt
+++ b/21.3-1/maas-cloud-init-sru.txt
@@ -1,0 +1,10182 @@
+Started by user James Falcon
+Running as SYSTEM
+Building remotely on HP-DL360-Gen9 (ci-lab) in workspace /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual
+[SRU-proposed-cloudinit-sru-manual] $ /bin/bash -ex /tmp/jenkins941786852071772708.sh
++ rm -Rf bootloaders maas maas-ci-config maas-images results
++ export http_proxy=http://squid.internal:3128
++ http_proxy=http://squid.internal:3128
++ export https_proxy=http://squid.internal:3128
++ https_proxy=http://squid.internal:3128
++ UPDATES=-U
++ '[' '!' ']'
++ VM_RAM_SIZE=8192
++ '[' '!' ']'
++ TEST_PERFORMANCE=0
++ '[' '!' 1 ']'
++ TEST_CUSTOM_IMAGES=0
++ '[' https://git.launchpad.net/maas-images ']'
++ TEST_CUSTOM_IMAGES=1
++ git clone https://git.launchpad.net/maas-images maas-images
+Cloning into 'maas-images'...
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:./maas-images/bin
++ STREAM_ARCHES=amd64
++ '[' 0 -ge 1 ']'
++ '[' 0 -ge 1 ']'
++ STREAM_RELEASES='xenial|bionic|focal'
++ '[' '!' ']'
++ DEPLOYMENT_RELEASE=bionic
+++ dirname /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual
++ workspace_root=/home/ubuntu/workspace
++ rm -Rf /home/ubuntu/workspace/www/html/images/bionic /home/ubuntu/workspace/www/html/images/bootloaders /home/ubuntu/workspace/www/html/images/focal /home/ubuntu/workspace/www/html/images/streams /home/ubuntu/workspace/www/html/images/xenial
++ '[' '!' -d /home/ubuntu/workspace/www/html/images ']'
++ '[' 1 -eq 0 ']'
++ meph2-cloudimg-sync --config ./maas-images/conf/meph-v3.yaml --target=force --proposed --arches=amd64 --max=1 /home/ubuntu/workspace/www/html/images/ 'release~(xenial|bionic|focal)'
+Wed, 25 Aug 2021 18:52:35 +0000: getting source http://cloud-images.ubuntu.com/daily/server/xenial/20210804/xenial-server-cloudimg-amd64.squashfs
+--2021-08-25 18:52:35--  http://cloud-images.ubuntu.com/daily/server/xenial/20210804/xenial-server-cloudimg-amd64.squashfs
+Resolving squid.internal (squid.internal)... 91.189.89.11
+Connecting to squid.internal (squid.internal)|91.189.89.11|:3128... connected.
+Proxy request sent, awaiting response... 200 OK
+Length: 179834880 (172M)
+Saving to: ‘/tmp/maas-cloudimg2eph2.FjfvkO/xenial-server-cloudimg-amd64.squashfs’
+
+     0K ........ ........ ........ ........ ........ ........  1% 4.07M 41s
+  3072K ........ ........ ........ ........ ........ ........  3% 9.70M 29s
+  6144K ........ ........ ........ ........ ........ ........  5% 10.4M 24s
+  9216K ........ ........ ........ ........ ........ ........  6% 13.2M 21s
+ 12288K ........ ........ ........ ........ ........ ........  8% 14.2M 18s
+ 15360K ........ ........ ........ ........ ........ ........ 10% 17.9M 17s
+ 18432K ........ ........ ........ ........ ........ ........ 12% 19.2M 15s
+ 21504K ........ ........ ........ ........ ........ ........ 13% 20.2M 14s
+ 24576K ........ ........ ........ ........ ........ ........ 15% 22.0M 13s
+ 27648K ........ ........ ........ ........ ........ ........ 17% 23.1M 12s
+ 30720K ........ ........ ........ ........ ........ ........ 19% 29.7M 11s
+ 33792K ........ ........ ........ ........ ........ ........ 20% 26.2M 10s
+ 36864K ........ ........ ........ ........ ........ ........ 22% 30.6M 10s
+ 39936K ........ ........ ........ ........ ........ ........ 24% 34.0M 9s
+ 43008K ........ ........ ........ ........ ........ ........ 26% 24.6M 9s
+ 46080K ........ ........ ........ ........ ........ ........ 27% 27.0M 8s
+ 49152K ........ ........ ........ ........ ........ ........ 29% 27.8M 8s
+ 52224K ........ ........ ........ ........ ........ ........ 31% 28.5M 7s
+ 55296K ........ ........ ........ ........ ........ ........ 33% 26.5M 7s
+ 58368K ........ ........ ........ ........ ........ ........ 34% 28.5M 7s
+ 61440K ........ ........ ........ ........ ........ ........ 36% 26.6M 6s
+ 64512K ........ ........ ........ ........ ........ ........ 38% 28.8M 6s
+ 67584K ........ ........ ........ ........ ........ ........ 40% 25.4M 6s
+ 70656K ........ ........ ........ ........ ........ ........ 41% 29.3M 6s
+ 73728K ........ ........ ........ ........ ........ ........ 43% 27.6M 5s
+ 76800K ........ ........ ........ ........ ........ ........ 45% 26.6M 5s
+ 79872K ........ ........ ........ ........ ........ ........ 47% 28.5M 5s
+ 82944K ........ ........ ........ ........ ........ ........ 48% 26.5M 5s
+ 86016K ........ ........ ........ ........ ........ ........ 50% 28.6M 4s
+ 89088K ........ ........ ........ ........ ........ ........ 52% 26.2M 4s
+ 92160K ........ ........ ........ ........ ........ ........ 54% 29.2M 4s
+ 95232K ........ ........ ........ ........ ........ ........ 55% 26.2M 4s
+ 98304K ........ ........ ........ ........ ........ ........ 57% 28.2M 4s
+101376K ........ ........ ........ ........ ........ ........ 59% 26.7M 3s
+104448K ........ ........ ........ ........ ........ ........ 61% 28.0M 3s
+107520K ........ ........ ........ ........ ........ ........ 62% 27.5M 3s
+110592K ........ ........ ........ ........ ........ ........ 64% 27.2M 3s
+113664K ........ ........ ........ ........ ........ ........ 66% 28.9M 3s
+116736K ........ ........ ........ ........ ........ ........ 68% 26.5M 3s
+119808K ........ ........ ........ ........ ........ ........ 69% 28.4M 2s
+122880K ........ ........ ........ ........ ........ ........ 71% 26.4M 2s
+125952K ........ ........ ........ ........ ........ ........ 73% 28.7M 2s
+129024K ........ ........ ........ ........ ........ ........ 75% 27.3M 2s
+132096K ........ ........ ........ ........ ........ ........ 76% 27.9M 2s
+135168K ........ ........ ........ ........ ........ ........ 78% 26.9M 2s
+138240K ........ ........ ........ ........ ........ ........ 80% 28.7M 2s
+141312K ........ ........ ........ ........ ........ ........ 82% 26.6M 1s
+144384K ........ ........ ........ ........ ........ ........ 83% 28.3M 1s
+147456K ........ ........ ........ ........ ........ ........ 85% 27.3M 1s
+150528K ........ ........ ........ ........ ........ ........ 87% 26.6M 1s
+153600K ........ ........ ........ ........ ........ ........ 89% 28.2M 1s
+156672K ........ ........ ........ ........ ........ ........ 90% 27.7M 1s
+159744K ........ ........ ........ ........ ........ ........ 92% 28.1M 1s
+162816K ........ ........ ........ ........ ........ ........ 94% 27.9M 0s
+165888K ........ ........ ........ ........ ........ ........ 96% 27.0M 0s
+168960K ........ ........ ........ ........ ........ ........ 97% 27.0M 0s
+172032K ........ ........ ........ ........ ........ ........ 99% 23.5M 0s
+175104K ........                                             100% 16.2M=7.7s
+
+2021-08-25 18:52:43 (22.4 MB/s) - ‘/tmp/maas-cloudimg2eph2.FjfvkO/xenial-server-cloudimg-amd64.squashfs’ saved [179834880/179834880]
+
+Wed, 25 Aug 2021 18:52:43 +0000: getting .img from /tmp/maas-cloudimg2eph2.FjfvkO/xenial-server-cloudimg-amd64.squashfs fmt=auto
+determined format is squashfs-image
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.FjfvkO/root.img'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+turning squahsfs image in /tmp/maas-cloudimg2eph2.FjfvkO/xenial-server-cloudimg-amd64.squashfs to ext4 image in /tmp/maas-cloudimg2eph2.FjfvkO/root.img
+Parallel unsquashfs: Using 28 processors
+29115 inodes (32305 blocks) to write
+
+[===========================================================-] 32305/32305 100%
+
+created 24675 files
+created 2959 directories
+created 4354 symlinks
+created 79 devices
+created 0 fifos
+Wed, 25 Aug 2021 18:52:57 +0000: getting '1024M' in /tmp/maas-cloudimg2eph2.FjfvkO/root.img
+Wed, 25 Aug 2021 18:52:58 +0000: targetting 5368709120 (1310720*4096) bytes.
+Wed, 25 Aug 2021 18:52:58 +0000: fs is currently 1048576 * 4096.
+Wed, 25 Aug 2021 18:52:58 +0000: resize to 1310720. minblocks=270641. target=1310720
+Wed, 25 Aug 2021 18:52:59 +0000: starting maas-cloudimg2ephemeral --arch=amd64 --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img none /tmp/maas-cloudimg2eph2.FjfvkO/none-kernel /tmp/maas-cloudimg2eph2.FjfvkO/none-initrd /tmp/maas-cloudimg2eph2.FjfvkO/manifest
+NO_CHANGE: add additional repos.
+NO_CHANGE: images ppa for cloud-init and maas-enlist (LP: #1511482, 1515733)
+CHANGE: enable proposed [amd64 http://archive.ubuntu.com/ubuntu/]
+NO_CHANGE: ensure mellanox mlx4_en gets loaded (LP: #1115710)
+NO_CHANGE: build-only: divert newaliases (LP: #1531299)
+nothing to remove: nothing match '^linux-.*' and not '^linux-base$'.
+NO_CHANGE: removing linux kernel packages.
+CHANGE: apt-get dist-upgrade
+CHANGE: run apt-update [dist-upgrade].
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
+Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease [260 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
+Get:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease [7506 B]
+Get:8 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1648 kB]
+Get:9 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease [7475 B]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4354 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [2049 kB]
+Get:14 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security/main amd64 Packages [149 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [482 kB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1219 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [358 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [22.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8476 B]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [9812 B]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4456 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [11.3 kB]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4476 B]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 Packages [26.6 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-proposed/main Translation-en [8880 B]
+Get:26 http://archive.ubuntu.com/ubuntu xenial-proposed/universe amd64 Packages [2360 B]
+Get:27 http://archive.ubuntu.com/ubuntu xenial-proposed/universe Translation-en [3204 B]
+Get:28 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [785 kB]
+Get:29 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [225 kB]
+Get:30 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [7864 B]
+Get:31 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2672 B]
+Fetched 19.8 MB in 4s (4932 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'sudo apt autoremove' to remove it.
+The following packages will be upgraded:
+  distro-info-data libssl1.0.0 login openssl passwd uidmap
+6 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+3 standard security updates
+Need to get 2729 kB of archives.
+After this operation, 12.3 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 login amd64 1:4.2-3.1ubuntu5.5 [304 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 passwd amd64 1:4.2-3.1ubuntu5.5 [782 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 distro-info-data all 0.28ubuntu0.18 [4530 B]
+Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libssl1.0.0 amd64 1.0.2g-1ubuntu4.20 [1083 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssl amd64 1.0.2g-1ubuntu4.20 [492 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 uidmap amd64 1:4.2-3.1ubuntu5.5 [64.4 kB]
+Preconfiguring packages ...
+Fetched 2729 kB in 0s (3627 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+(Reading database ... 25907 files and directories currently installed.)
+Preparing to unpack .../login_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking login (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up login (1:4.2-3.1ubuntu5.5) ...
+(Reading database ... 25907 files and directories currently installed.)
+Preparing to unpack .../passwd_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking passwd (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Setting up passwd (1:4.2-3.1ubuntu5.5) ...
+(Reading database ... 25907 files and directories currently installed.)
+Preparing to unpack .../distro-info-data_0.28ubuntu0.18_all.deb ...
+Unpacking distro-info-data (0.28ubuntu0.18) over (0.28ubuntu0.17) ...
+Preparing to unpack .../libssl1.0.0_1.0.2g-1ubuntu4.20_amd64.deb ...
+Unpacking libssl1.0.0:amd64 (1.0.2g-1ubuntu4.20) over (1.0.2g-1ubuntu4.19) ...
+Preparing to unpack .../openssl_1.0.2g-1ubuntu4.20_amd64.deb ...
+Unpacking openssl (1.0.2g-1ubuntu4.20) over (1.0.2g-1ubuntu4.19) ...
+Preparing to unpack .../uidmap_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking uidmap (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up distro-info-data (0.28ubuntu0.18) ...
+Setting up libssl1.0.0:amd64 (1.0.2g-1ubuntu4.20) ...
+Setting up openssl (1.0.2g-1ubuntu4.20) ...
+Setting up uidmap (1:4.2-3.1ubuntu5.5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+NO_CHANGE: install missing packages
+NO_CHANGE: remove dpkg foreign architectures
+NO_CHANGE: run autoremove
+CHANGE: apt-get clean
+CHANGE: symlink ENI for cloud-initramfs-dyn-netconf (LP: #1534205)
+NO_CHANGE: touch /etc/iscsi/iscsi.initramfs for iscsi root shutdown (LP: #1536707) [systemd]
+NO_CHANGE: create /lib/modules (LP: #1543204)
+NO_CHANGE: set CRYPTSETUP=y in /etc/cryptsetup-initramfs/conf-hook (LP: #1818876)
+NO_CHANGE: update-initramfs
+NO_CHANGE: disable rescuevol (LP: #1034116)
+NO_CHANGE: package changes: add='' remove=''
+Wed, 25 Aug 2021 18:53:19 +0000: starting kpacks: linux-generic,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/ga-16.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/ga-16.04/generic/boot-initrd linux-lowlatency,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/ga-16.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/ga-16.04/lowlatency/boot-initrd linux-generic-hwe-16.04,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04/generic/boot-initrd linux-lowlatency-hwe-16.04,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04/lowlatency/boot-initrd linux-generic-hwe-16.04-edge,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04-edge/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04-edge/generic/boot-initrd linux-lowlatency-hwe-16.04-edge,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04-edge/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/hwe-16.04-edge/lowlatency/boot-initrd
+Wed, 25 Aug 2021 18:53:19 +0000: Wed, 25 Aug 2021 18:53:19 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-generic /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:6 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.4.0-210 linux-headers-4.4.0-210-generic
+  linux-headers-generic linux-image-4.4.0-210-generic linux-image-generic
+  linux-modules-4.4.0-210-generic linux-modules-extra-4.4.0-210-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.4.0
+  | linux-source-4.4.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware linux-generic
+  linux-headers-4.4.0-210 linux-headers-4.4.0-210-generic
+  linux-headers-generic linux-image-4.4.0-210-generic linux-image-generic
+  linux-modules-4.4.0-210-generic linux-modules-extra-4.4.0-210-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 124 MB of archives.
+After this operation, 564 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2020.11.20-0ubuntu1~16.04.2 [10.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.4.0-210-generic amd64 4.4.0-210.242 [12.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.4.0-210-generic amd64 4.4.0-210.242 [6954 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-extra-4.4.0-210-generic amd64 4.4.0-210.242 [36.6 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-generic amd64 4.4.0.210.216 [2496 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.4.0-210 all 4.4.0-210.242 [10.0 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.4.0-210-generic amd64 4.4.0-210.242 [786 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-generic amd64 4.4.0.210.216 [2290 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-generic amd64 4.4.0.210.216 [1784 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 124 MB in 6s (20.4 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2020.11.20-0ubuntu1~16.04.2_all.deb ...
+Unpacking wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.4.0-210-generic.
+Preparing to unpack .../linux-modules-4.4.0-210-generic_4.4.0-210.242_amd64.deb ...
+Unpacking linux-modules-4.4.0-210-generic (4.4.0-210.242) ...
+Selecting previously unselected package linux-image-4.4.0-210-generic.
+Preparing to unpack .../linux-image-4.4.0-210-generic_4.4.0-210.242_amd64.deb ...
+Unpacking linux-image-4.4.0-210-generic (4.4.0-210.242) ...
+Selecting previously unselected package linux-modules-extra-4.4.0-210-generic.
+Preparing to unpack .../linux-modules-extra-4.4.0-210-generic_4.4.0-210.242_amd64.deb ...
+Unpacking linux-modules-extra-4.4.0-210-generic (4.4.0-210.242) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic.
+Preparing to unpack .../linux-image-generic_4.4.0.210.216_amd64.deb ...
+Unpacking linux-image-generic (4.4.0.210.216) ...
+Selecting previously unselected package linux-headers-4.4.0-210.
+Preparing to unpack .../linux-headers-4.4.0-210_4.4.0-210.242_all.deb ...
+Unpacking linux-headers-4.4.0-210 (4.4.0-210.242) ...
+Selecting previously unselected package linux-headers-4.4.0-210-generic.
+Preparing to unpack .../linux-headers-4.4.0-210-generic_4.4.0-210.242_amd64.deb ...
+Unpacking linux-headers-4.4.0-210-generic (4.4.0-210.242) ...
+Selecting previously unselected package linux-headers-generic.
+Preparing to unpack .../linux-headers-generic_4.4.0.210.216_amd64.deb ...
+Unpacking linux-headers-generic (4.4.0.210.216) ...
+Selecting previously unselected package linux-generic.
+Preparing to unpack .../linux-generic_4.4.0.210.216_amd64.deb ...
+Unpacking linux-generic (4.4.0.210.216) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.4.0-210-generic (4.4.0-210.242) ...
+Setting up linux-image-4.4.0-210-generic (4.4.0-210.242) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.4.0-210-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.4.0-210-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-210-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-210-generic
+Setting up linux-modules-extra-4.4.0-210-generic (4.4.0-210.242) ...
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic (4.4.0.210.216) ...
+Setting up linux-headers-4.4.0-210 (4.4.0-210.242) ...
+Setting up linux-headers-4.4.0-210-generic (4.4.0-210.242) ...
+Setting up linux-headers-generic (4.4.0.210.216) ...
+Setting up linux-generic (4.4.0.210.216) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for linux-image-4.4.0-210-generic (4.4.0-210.242) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.4.0-210-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.4.0-210-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 18:55:01 +0000: Wed, 25 Aug 2021 18:55:01 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-lowlatency /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Get:5 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:6 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Fetched 109 kB in 1s (64.9 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.4.0-210 linux-headers-4.4.0-210-lowlatency
+  linux-headers-lowlatency linux-image-4.4.0-210-lowlatency
+  linux-image-lowlatency linux-modules-4.4.0-210-lowlatency os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.4.0
+  | linux-source-4.4.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.4.0-210 linux-headers-4.4.0-210-lowlatency
+  linux-headers-lowlatency linux-image-4.4.0-210-lowlatency
+  linux-image-lowlatency linux-lowlatency linux-modules-4.4.0-210-lowlatency
+  os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 116 MB of archives.
+After this operation, 562 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.4.0-210 all 4.4.0-210.242 [10.0 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.4.0-210-lowlatency amd64 4.4.0-210.242 [785 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-lowlatency amd64 4.4.0.210.216 [2296 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.4.0-210-lowlatency amd64 4.4.0-210.242 [41.1 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.4.0-210-lowlatency amd64 4.4.0-210.242 [6978 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-lowlatency amd64 4.4.0.210.216 [2488 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-lowlatency amd64 4.4.0.210.216 [1782 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 116 MB in 5s (21.7 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.4.0-210.
+Preparing to unpack .../linux-headers-4.4.0-210_4.4.0-210.242_all.deb ...
+Unpacking linux-headers-4.4.0-210 (4.4.0-210.242) ...
+Selecting previously unselected package linux-headers-4.4.0-210-lowlatency.
+Preparing to unpack .../linux-headers-4.4.0-210-lowlatency_4.4.0-210.242_amd64.deb ...
+Unpacking linux-headers-4.4.0-210-lowlatency (4.4.0-210.242) ...
+Selecting previously unselected package linux-headers-lowlatency.
+Preparing to unpack .../linux-headers-lowlatency_4.4.0.210.216_amd64.deb ...
+Unpacking linux-headers-lowlatency (4.4.0.210.216) ...
+Selecting previously unselected package linux-modules-4.4.0-210-lowlatency.
+Preparing to unpack .../linux-modules-4.4.0-210-lowlatency_4.4.0-210.242_amd64.deb ...
+Unpacking linux-modules-4.4.0-210-lowlatency (4.4.0-210.242) ...
+Selecting previously unselected package linux-image-4.4.0-210-lowlatency.
+Preparing to unpack .../linux-image-4.4.0-210-lowlatency_4.4.0-210.242_amd64.deb ...
+Unpacking linux-image-4.4.0-210-lowlatency (4.4.0-210.242) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency.
+Preparing to unpack .../linux-image-lowlatency_4.4.0.210.216_amd64.deb ...
+Unpacking linux-image-lowlatency (4.4.0.210.216) ...
+Selecting previously unselected package linux-lowlatency.
+Preparing to unpack .../linux-lowlatency_4.4.0.210.216_amd64.deb ...
+Unpacking linux-lowlatency (4.4.0.210.216) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.4.0-210 (4.4.0-210.242) ...
+Setting up linux-headers-4.4.0-210-lowlatency (4.4.0-210.242) ...
+Setting up linux-headers-lowlatency (4.4.0.210.216) ...
+Setting up linux-modules-4.4.0-210-lowlatency (4.4.0-210.242) ...
+Setting up linux-image-4.4.0-210-lowlatency (4.4.0-210.242) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.4.0-210-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.4.0-210-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-210-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-210-lowlatency
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency (4.4.0.210.216) ...
+Setting up linux-lowlatency (4.4.0.210.216) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for linux-image-4.4.0-210-lowlatency (4.4.0-210.242) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.4.0-210-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.4.0-210-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 18:56:35 +0000: Wed, 25 Aug 2021 18:56:35 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-generic-hwe-16.04 /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic-hwe-16.04
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Get:4 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:6 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Fetched 109 kB in 1s (64.8 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.15.0-142 linux-headers-4.15.0-142-generic
+  linux-headers-generic-hwe-16.04 linux-image-4.15.0-142-generic
+  linux-image-generic-hwe-16.04 linux-modules-4.15.0-142-generic
+  linux-modules-extra-4.15.0-142-generic os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-16.04 linux-headers-4.15.0-142
+  linux-headers-4.15.0-142-generic linux-headers-generic-hwe-16.04
+  linux-image-4.15.0-142-generic linux-image-generic-hwe-16.04
+  linux-modules-4.15.0-142-generic linux-modules-extra-4.15.0-142-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 596 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2020.11.20-0ubuntu1~16.04.2 [10.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [13.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [8014 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-extra-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [32.9 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-generic-hwe-16.04 amd64 4.15.0.142.137 [2410 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142 all 4.15.0-142.146~16.04.1 [10.9 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [1098 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-generic-hwe-16.04 amd64 4.15.0.142.137 [2356 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-generic-hwe-16.04 amd64 4.15.0.142.137 [1804 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 5s (22.1 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2020.11.20-0ubuntu1~16.04.2_all.deb ...
+Unpacking wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.15.0-142-generic.
+Preparing to unpack .../linux-modules-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-142-generic.
+Preparing to unpack .../linux-image-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-142-generic.
+Preparing to unpack .../linux-modules-extra-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic-hwe-16.04.
+Preparing to unpack .../linux-image-generic-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-image-generic-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package linux-headers-4.15.0-142.
+Preparing to unpack .../linux-headers-4.15.0-142_4.15.0-142.146~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-142-generic.
+Preparing to unpack .../linux-headers-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-16.04.
+Preparing to unpack .../linux-headers-generic-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-headers-generic-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package linux-generic-hwe-16.04.
+Preparing to unpack .../linux-generic-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-generic-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-142-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-142-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-142-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-142-generic
+Setting up linux-modules-extra-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic-hwe-16.04 (4.15.0.142.137) ...
+Setting up linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-generic-hwe-16.04 (4.15.0.142.137) ...
+Setting up linux-generic-hwe-16.04 (4.15.0.142.137) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic-hwe-16.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 18:58:16 +0000: Wed, 25 Aug 2021 18:58:16 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-lowlatency-hwe-16.04 /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency-hwe-16.04
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Get:4 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:6 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Fetched 109 kB in 1s (67.8 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-142 linux-headers-4.15.0-142-lowlatency
+  linux-headers-lowlatency-hwe-16.04 linux-image-4.15.0-142-lowlatency
+  linux-image-lowlatency-hwe-16.04 linux-modules-4.15.0-142-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-142 linux-headers-4.15.0-142-lowlatency
+  linux-headers-lowlatency-hwe-16.04 linux-image-4.15.0-142-lowlatency
+  linux-image-lowlatency-hwe-16.04 linux-lowlatency-hwe-16.04
+  linux-modules-4.15.0-142-lowlatency os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 594 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142 all 4.15.0-142.146~16.04.1 [10.9 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [1100 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-lowlatency-hwe-16.04 amd64 4.15.0.142.137 [2358 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [45.8 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [8064 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-lowlatency-hwe-16.04 amd64 4.15.0.142.137 [2398 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-lowlatency-hwe-16.04 amd64 4.15.0.142.137 [1804 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 7s (15.9 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.15.0-142.
+Preparing to unpack .../linux-headers-4.15.0-142_4.15.0-142.146~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-headers-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-headers-lowlatency-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package linux-modules-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-modules-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-image-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-image-lowlatency-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package linux-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-lowlatency-hwe-16.04_4.15.0.142.137_amd64.deb ...
+Unpacking linux-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Setting up linux-modules-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Setting up linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-142-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-142-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-142-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-142-lowlatency
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Setting up linux-lowlatency-hwe-16.04 (4.15.0.142.137) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency-hwe-16.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:00:03 +0000: Wed, 25 Aug 2021 19:00:03 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-generic-hwe-16.04-edge /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic-hwe-16.04-edge
+Hit:1 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:2 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:6 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Get:7 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Fetched 109 kB in 7s (13.8 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.15.0-142 linux-headers-4.15.0-142-generic
+  linux-headers-generic-hwe-16.04-edge linux-image-4.15.0-142-generic
+  linux-image-generic-hwe-16.04-edge linux-modules-4.15.0-142-generic
+  linux-modules-extra-4.15.0-142-generic os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-16.04-edge linux-headers-4.15.0-142
+  linux-headers-4.15.0-142-generic linux-headers-generic-hwe-16.04-edge
+  linux-image-4.15.0-142-generic linux-image-generic-hwe-16.04-edge
+  linux-modules-4.15.0-142-generic linux-modules-extra-4.15.0-142-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 596 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2020.11.20-0ubuntu1~16.04.2 [10.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [13.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [8014 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-extra-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [32.9 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-generic-hwe-16.04-edge amd64 4.15.0.142.137 [2418 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142 all 4.15.0-142.146~16.04.1 [10.9 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142-generic amd64 4.15.0-142.146~16.04.1 [1098 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-generic-hwe-16.04-edge amd64 4.15.0.142.137 [2370 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-generic-hwe-16.04-edge amd64 4.15.0.142.137 [1814 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 25s (4770 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2020.11.20-0ubuntu1~16.04.2_all.deb ...
+Unpacking wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.15.0-142-generic.
+Preparing to unpack .../linux-modules-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-142-generic.
+Preparing to unpack .../linux-image-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-142-generic.
+Preparing to unpack .../linux-modules-extra-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-image-generic-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-image-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package linux-headers-4.15.0-142.
+Preparing to unpack .../linux-headers-4.15.0-142_4.15.0-142.146~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-142-generic.
+Preparing to unpack .../linux-headers-4.15.0-142-generic_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-headers-generic-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-headers-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package linux-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-generic-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2020.11.20-0ubuntu1~16.04.2) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-142-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-142-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-142-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-142-generic
+Setting up linux-modules-extra-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up linux-generic-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
+Processing triggers for linux-image-4.15.0-142-generic (4.15.0-142.146~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-generic-hwe-16.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:02:13 +0000: Wed, 25 Aug 2021 19:02:13 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.FjfvkO/root.img linux-lowlatency-hwe-16.04-edge /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency-hwe-16.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Get:4 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:6 https://esm.ubuntu.com/infra/ubuntu xenial-infra-security InRelease
+Hit:7 https://esm.ubuntu.com/infra/ubuntu xenial-infra-updates InRelease
+Fetched 109 kB in 1s (70.0 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-142 linux-headers-4.15.0-142-lowlatency
+  linux-headers-lowlatency-hwe-16.04-edge linux-image-4.15.0-142-lowlatency
+  linux-image-lowlatency-hwe-16.04-edge linux-modules-4.15.0-142-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-142 linux-headers-4.15.0-142-lowlatency
+  linux-headers-lowlatency-hwe-16.04-edge linux-image-4.15.0-142-lowlatency
+  linux-image-lowlatency-hwe-16.04-edge linux-lowlatency-hwe-16.04-edge
+  linux-modules-4.15.0-142-lowlatency os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 594 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.32 [1709 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.32 [513 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.32 [892 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.32 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142 all 4.15.0-142.146~16.04.1 [10.9 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [1100 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-headers-lowlatency-hwe-16.04-edge amd64 4.15.0.142.137 [2372 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [45.8 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.15.0-142-lowlatency amd64 4.15.0-142.146~16.04.1 [8064 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20210216.0ubuntu0.16.04.1 [2747 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-lowlatency-hwe-16.04-edge amd64 4.15.0.142.137 [2404 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-lowlatency-hwe-16.04-edge amd64 4.15.0.142.137 [1814 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 34s (3573 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25909 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.32_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.32) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.15.0-142.
+Preparing to unpack .../linux-headers-4.15.0-142_4.15.0-142.146~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-headers-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-headers-lowlatency-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package linux-modules-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-modules-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-142-lowlatency.
+Preparing to unpack .../linux-image-4.15.0-142-lowlatency_4.15.0-142.146~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20210216.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-image-lowlatency-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package linux-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-lowlatency-hwe-16.04-edge_4.15.0.142.137_amd64.deb ...
+Unpacking linux-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.32) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.32) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.32) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.15.0-142 (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Setting up linux-headers-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up linux-modules-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+Setting up linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-142-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-142-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-142-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-142-lowlatency
+Setting up intel-microcode (3.20210216.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up linux-lowlatency-hwe-16.04-edge (4.15.0.142.137) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.32) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.31) ...
+Processing triggers for linux-image-4.15.0-142-lowlatency (4.15.0-142.146~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.17) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-142-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.6) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.FjfvkO/linux-lowlatency-hwe-16.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:04:25 +0000: kpacks done
+Wed, 25 Aug 2021 19:04:25 +0000: copying working img into new fs of 1400M (pad=)
+src image uuid=8d2e4800-bbe9-4e36-970b-bb84c9dcd251 label=cloudimg-rootfs fstype=ext4
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.FjfvkO/root.img.fs_img_size'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+Wed, 25 Aug 2021 19:04:43 +0000: zeroing img
+e2fsck 1.45.5 (07-Jan-2020)
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+cloudimg-rootfs: 32103/327680 files (0.1% non-contiguous), 233517/1310720 blocks
+creating a new squash image in /home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/squashfs with ./maas-images/bin/img2squashfs from /tmp/maas-cloudimg2eph2.FjfvkO/root.img
+format of '/tmp/maas-cloudimg2eph2.FjfvkO/root.img' is 'root-image'
+got format 'fs-image' at temp path '/tmp/img2squashfs.cnV9r6/fs-image'
+calling mount-image-callback /tmp/img2squashfs.cnV9r6/fs-image -- ./maas-images/bin/img2squashfs dir2squashfs _MOUNTPOINT_ /home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/squashfs
+Wed, 25 Aug 2021 19:04:46 +0000: starting: mksquashfs /tmp/mount-image-callback.SLI7T8/mp /home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/squashfs.img2squashfs.3754323 -xattrs -comp xz
+Parallel mksquashfs: Using 28 processors
+Creating 4.0 filesystem on /home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/squashfs.img2squashfs.3754323, block size 131072.
+[===-                                                        ]  1700/28517   5%[====/                                                       ]  2300/28517   8%[===========================================================/] 28517/28517 100%
+
+Exportable Squashfs 4.0 filesystem, xz compressed, data block size 131072
+	compressed data, compressed metadata, compressed fragments,
+	compressed xattrs, compressed ids
+	duplicates are removed
+Filesystem size 192570.40 Kbytes (188.06 Mbytes)
+	27.55% of uncompressed filesystem size (698975.69 Kbytes)
+Inode table size 277198 bytes (270.70 Kbytes)
+	25.54% of uncompressed inode table size (1085512 bytes)
+Directory table size 274282 bytes (267.85 Kbytes)
+	39.49% of uncompressed directory table size (694493 bytes)
+Xattr table size 78 bytes (0.08 Kbytes)
+	97.50% of uncompressed xattr table size (80 bytes)
+Number of duplicate files found 1217
+Number of inodes 32094
+Number of files 24700
+Number of fragments 1477
+Number of symbolic links  4355
+Number of device nodes 79
+Number of fifo nodes 0
+Number of socket nodes 0
+Number of directories 2960
+Number of ids (unique uids + gids) 21
+Number of uids 7
+	root (0)
+	man (6)
+	daemon (1)
+	pollinate (111)
+	_apt (105)
+	lxd (106)
+	syslog (104)
+Number of gids 18
+	root (0)
+	video (44)
+	audio (29)
+	tty (5)
+	kmem (15)
+	disk (6)
+	daemon (1)
+	shadow (42)
+	crontab (107)
+	ssh (114)
+	utmp (43)
+	mlocate (113)
+	messagebus (111)
+	staff (50)
+	nogroup (65534)
+	adm (4)
+	syslog (108)
+	mail (8)
+Wed, 25 Aug 2021 19:05:09 +0000: finished: returned 0
+output in /home/ubuntu/workspace/www/html/images/xenial/amd64/20210804/squashfs. took 23s.
+Wed, 25 Aug 2021 19:05:09 +0000: finished
+Wed, 25 Aug 2021 19:05:12 +0000: getting source http://cloud-images.ubuntu.com/daily/server/bionic/20210818/bionic-server-cloudimg-amd64.squashfs
+--2021-08-25 19:05:12--  http://cloud-images.ubuntu.com/daily/server/bionic/20210818/bionic-server-cloudimg-amd64.squashfs
+Resolving squid.internal (squid.internal)... 91.189.89.11
+Connecting to squid.internal (squid.internal)|91.189.89.11|:3128... connected.
+Proxy request sent, awaiting response... 200 OK
+Length: 203202560 (194M)
+Saving to: ‘/tmp/maas-cloudimg2eph2.0kl1Cp/bionic-server-cloudimg-amd64.squashfs’
+
+     0K ........ ........ ........ ........ ........ ........  1% 1.16M 2m44s
+  3072K ........ ........ ........ ........ ........ ........  3% 5.39M 98s
+  6144K ........ ........ ........ ........ ........ ........  4% 5.97M 75s
+  9216K ........ ........ ........ ........ ........ ........  6% 9.64M 60s
+ 12288K ........ ........ ........ ........ ........ ........  7% 9.44M 51s
+ 15360K ........ ........ ........ ........ ........ ........  9% 12.5M 44s
+ 18432K ........ ........ ........ ........ ........ ........ 10% 14.9M 39s
+ 21504K ........ ........ ........ ........ ........ ........ 12% 16.6M 35s
+ 24576K ........ ........ ........ ........ ........ ........ 13% 17.2M 31s
+ 27648K ........ ........ ........ ........ ........ ........ 15% 13.2M 29s
+ 30720K ........ ........ ........ ........ ........ ........ 17% 13.6M 27s
+ 33792K ........ ........ ........ ........ ........ ........ 18% 13.9M 25s
+ 36864K ........ ........ ........ ........ ........ ........ 20% 13.8M 24s
+ 39936K ........ ........ ........ ........ ........ ........ 21% 14.7M 22s
+ 43008K ........ ........ ........ ........ ........ ........ 23% 12.9M 21s
+ 46080K ........ ........ ........ ........ ........ ........ 24% 10.1M 20s
+ 49152K ........ ........ ........ ........ ........ ........ 26% 11.0M 19s
+ 52224K ........ ........ ........ ........ ........ ........ 27% 10.9M 19s
+ 55296K ........ ........ ........ ........ ........ ........ 29% 11.0M 18s
+ 58368K ........ ........ ........ ........ ........ ........ 30% 10.3M 17s
+ 61440K ........ ........ ........ ........ ........ ........ 32% 11.2M 17s
+ 64512K ........ ........ ........ ........ ........ ........ 34% 11.9M 16s
+ 67584K ........ ........ ........ ........ ........ ........ 35% 10.5M 16s
+ 70656K ........ ........ ........ ........ ........ ........ 37% 12.0M 15s
+ 73728K ........ ........ ........ ........ ........ ........ 38% 11.4M 14s
+ 76800K ........ ........ ........ ........ ........ ........ 40% 10.3M 14s
+ 79872K ........ ........ ........ ........ ........ ........ 41% 11.5M 13s
+ 82944K ........ ........ ........ ........ ........ ........ 43% 11.9M 13s
+ 86016K ........ ........ ........ ........ ........ ........ 44% 12.1M 12s
+ 89088K ........ ........ ........ ........ ........ ........ 46% 12.6M 12s
+ 92160K ........ ........ ........ ........ ........ ........ 47% 11.6M 12s
+ 95232K ........ ........ ........ ........ ........ ........ 49% 11.9M 11s
+ 98304K ........ ........ ........ ........ ........ ........ 51% 11.8M 11s
+101376K ........ ........ ........ ........ ........ ........ 52% 12.6M 10s
+104448K ........ ........ ........ ........ ........ ........ 54% 12.4M 10s
+107520K ........ ........ ........ ........ ........ ........ 55% 12.2M 9s
+110592K ........ ........ ........ ........ ........ ........ 57% 12.6M 9s
+113664K ........ ........ ........ ........ ........ ........ 58% 11.4M 9s
+116736K ........ ........ ........ ........ ........ ........ 60% 12.3M 8s
+119808K ........ ........ ........ ........ ........ ........ 61% 12.5M 8s
+122880K ........ ........ ........ ........ ........ ........ 63% 12.4M 8s
+125952K ........ ........ ........ ........ ........ ........ 65% 12.8M 7s
+129024K ........ ........ ........ ........ ........ ........ 66% 12.4M 7s
+132096K ........ ........ ........ ........ ........ ........ 68% 12.2M 6s
+135168K ........ ........ ........ ........ ........ ........ 69% 11.6M 6s
+138240K ........ ........ ........ ........ ........ ........ 71% 11.9M 6s
+141312K ........ ........ ........ ........ ........ ........ 72% 12.3M 5s
+144384K ........ ........ ........ ........ ........ ........ 74% 12.8M 5s
+147456K ........ ........ ........ ........ ........ ........ 75% 12.9M 5s
+150528K ........ ........ ........ ........ ........ ........ 77% 13.0M 4s
+153600K ........ ........ ........ ........ ........ ........ 78% 13.1M 4s
+156672K ........ ........ ........ ........ ........ ........ 80% 12.0M 4s
+159744K ........ ........ ........ ........ ........ ........ 82% 13.0M 4s
+162816K ........ ........ ........ ........ ........ ........ 83% 12.3M 3s
+165888K ........ ........ ........ ........ ........ ........ 85% 12.3M 3s
+168960K ........ ........ ........ ........ ........ ........ 86% 13.0M 3s
+172032K ........ ........ ........ ........ ........ ........ 88% 13.4M 2s
+175104K ........ ........ ........ ........ ........ ........ 89% 13.2M 2s
+178176K ........ ........ ........ ........ ........ ........ 91% 13.3M 2s
+181248K ........ ........ ........ ........ ........ ........ 92% 13.5M 1s
+184320K ........ ........ ........ ........ ........ ........ 94% 13.2M 1s
+187392K ........ ........ ........ ........ ........ ........ 95% 12.5M 1s
+190464K ........ ........ ........ ........ ........ ........ 97% 13.9M 0s
+193536K ........ ........ ........ ........ ........ ........ 99% 14.9M 0s
+196608K ........ ........ ........ ....                      100% 13.4M=19s
+
+2021-08-25 19:05:31 (10.4 MB/s) - ‘/tmp/maas-cloudimg2eph2.0kl1Cp/bionic-server-cloudimg-amd64.squashfs’ saved [203202560/203202560]
+
+Wed, 25 Aug 2021 19:05:31 +0000: getting .img from /tmp/maas-cloudimg2eph2.0kl1Cp/bionic-server-cloudimg-amd64.squashfs fmt=auto
+determined format is squashfs-image
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.0kl1Cp/root.img'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+turning squahsfs image in /tmp/maas-cloudimg2eph2.0kl1Cp/bionic-server-cloudimg-amd64.squashfs to ext4 image in /tmp/maas-cloudimg2eph2.0kl1Cp/root.img
+Parallel unsquashfs: Using 28 processors
+32850 inodes (36435 blocks) to write
+
+[===========================================================\] 36435/36435 100%
+
+created 28152 files
+created 3320 directories
+created 4685 symlinks
+created 7 devices
+created 0 fifos
+Wed, 25 Aug 2021 19:05:50 +0000: getting '1024M' in /tmp/maas-cloudimg2eph2.0kl1Cp/root.img
+Wed, 25 Aug 2021 19:05:50 +0000: targetting 5368709120 (1310720*4096) bytes.
+Wed, 25 Aug 2021 19:05:50 +0000: fs is currently 1048576 * 4096.
+Wed, 25 Aug 2021 19:05:50 +0000: resize to 1310720. minblocks=261764. target=1310720
+Wed, 25 Aug 2021 19:05:51 +0000: starting maas-cloudimg2ephemeral --arch=amd64 --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img none /tmp/maas-cloudimg2eph2.0kl1Cp/none-kernel /tmp/maas-cloudimg2eph2.0kl1Cp/none-initrd /tmp/maas-cloudimg2eph2.0kl1Cp/manifest
+NO_CHANGE: add additional repos.
+NO_CHANGE: images ppa for cloud-init and maas-enlist (LP: #1511482, 1515733)
+CHANGE: enable proposed [amd64 http://archive.ubuntu.com/ubuntu/]
+NO_CHANGE: ensure mellanox mlx4_en gets loaded (LP: #1115710)
+NO_CHANGE: build-only: divert newaliases (LP: #1531299)
+nothing to remove: nothing match '^linux-.*' and not '^linux-base$'.
+NO_CHANGE: removing linux kernel packages.
+CHANGE: apt-get dist-upgrade
+CHANGE: run apt-update [dist-upgrade].
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
+Get:7 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [1845 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
+Get:9 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1136 kB]
+Get:10 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [258 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2191 kB]
+Get:14 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [20.9 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1747 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [375 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [27.3 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6808 B]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [10.0 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [10.3 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4588 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [104 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [25.2 kB]
+Get:25 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [4732 B]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-proposed/universe amd64 Packages [18.5 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-proposed/universe Translation-en [9144 B]
+Fetched 22.1 MB in 5s (4708 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'sudo apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init libparted2 libssl1.1 linux-base login openssl parted passwd
+  python3-software-properties python3-update-manager snapd
+  software-properties-common uidmap update-manager-core update-notifier-common
+15 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+2 standard security updates
+Need to get 26.6 MB of archives.
+After this operation, 50.2 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 login amd64 1:4.5-1ubuntu2.1 [307 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 update-manager-core all 1:18.04.11.14 [8496 B]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 python3-update-manager all 1:18.04.11.14 [35.0 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 update-notifier-common all 3.192.1.12 [133 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 passwd amd64 1:4.5-1ubuntu2.1 [819 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.13 [1302 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-base all 4.5ubuntu1.7 [17.9 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssl amd64 1.1.1-1ubuntu2.1~18.04.13 [614 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 parted amd64 3.2-20ubuntu0.3 [42.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 libparted2 amd64 3.2-20ubuntu0.3 [123 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 software-properties-common all 0.96.24.32.16 [10.1 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 python3-software-properties all 0.96.24.32.16 [23.8 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 snapd amd64 2.51.1+18.04 [22.6 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 uidmap amd64 1:4.5-1ubuntu2.1 [65.6 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 21.3-1-g6803368d-0ubuntu1~18.04.1 [477 kB]
+Preconfiguring packages ...
+Fetched 26.6 MB in 2s (15.3 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+(Reading database ... 28944 files and directories currently installed.)
+Preparing to unpack .../login_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking login (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Setting up login (1:4.5-1ubuntu2.1) ...
+(Reading database ... 28944 files and directories currently installed.)
+Preparing to unpack .../update-manager-core_1%3a18.04.11.14_all.deb ...
+Unpacking update-manager-core (1:18.04.11.14) over (1:18.04.11.13) ...
+Preparing to unpack .../python3-update-manager_1%3a18.04.11.14_all.deb ...
+Unpacking python3-update-manager (1:18.04.11.14) over (1:18.04.11.13) ...
+Preparing to unpack .../update-notifier-common_3.192.1.12_all.deb ...
+Unpacking update-notifier-common (3.192.1.12) over (3.192.1.11) ...
+Preparing to unpack .../passwd_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking passwd (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Setting up passwd (1:4.5-1ubuntu2.1) ...
+(Reading database ... 28944 files and directories currently installed.)
+Preparing to unpack .../0-libssl1.1_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.10) ...
+Preparing to unpack .../1-linux-base_4.5ubuntu1.7_all.deb ...
+Unpacking linux-base (4.5ubuntu1.7) over (4.5ubuntu1.6) ...
+Preparing to unpack .../2-openssl_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking openssl (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.10) ...
+Preparing to unpack .../3-parted_3.2-20ubuntu0.3_amd64.deb ...
+Unpacking parted (3.2-20ubuntu0.3) over (3.2-20ubuntu0.2) ...
+Preparing to unpack .../4-libparted2_3.2-20ubuntu0.3_amd64.deb ...
+Unpacking libparted2:amd64 (3.2-20ubuntu0.3) over (3.2-20ubuntu0.2) ...
+Preparing to unpack .../5-software-properties-common_0.96.24.32.16_all.deb ...
+Unpacking software-properties-common (0.96.24.32.16) over (0.96.24.32.14) ...
+Preparing to unpack .../6-python3-software-properties_0.96.24.32.16_all.deb ...
+Unpacking python3-software-properties (0.96.24.32.16) over (0.96.24.32.14) ...
+Preparing to unpack .../7-snapd_2.51.1+18.04_amd64.deb ...
+Unpacking snapd (2.51.1+18.04) over (2.49.2+18.04) ...
+Preparing to unpack .../8-uidmap_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking uidmap (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Preparing to unpack .../9-cloud-init_21.3-1-g6803368d-0ubuntu1~18.04.1_all.deb ...
+Unpacking cloud-init (21.3-1-g6803368d-0ubuntu1~18.04.1) over (21.2-3-g899bfaa9-0ubuntu2~18.04.1) ...
+Setting up libparted2:amd64 (3.2-20ubuntu0.3) ...
+Setting up python3-update-manager (1:18.04.11.14) ...
+Setting up linux-base (4.5ubuntu1.7) ...
+Setting up parted (3.2-20ubuntu0.3) ...
+Setting up uidmap (1:4.5-1ubuntu2.1) ...
+Setting up snapd (2.51.1+18.04) ...
+Installing new version of config file /etc/profile.d/apps-bin-path.sh ...
+Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up openssl (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up python3-software-properties (0.96.24.32.16) ...
+Setting up cloud-init (21.3-1-g6803368d-0ubuntu1~18.04.1) ...
+Installing new version of config file /etc/cloud/cloud.cfg ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Created symlink /etc/systemd/system/cloud-init.target.wants/cloud-init-hotplugd.socket -> /lib/systemd/system/cloud-init-hotplugd.socket.
+Setting up software-properties-common (0.96.24.32.16) ...
+Setting up update-manager-core (1:18.04.11.14) ...
+Setting up update-notifier-common (3.192.1.12) ...
+Installing new version of config file /etc/cron.weekly/update-notifier-common ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of try-restart.
+Processing triggers for mime-support (3.60ubuntu1) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+NO_CHANGE: install missing packages
+NO_CHANGE: remove dpkg foreign architectures
+NO_CHANGE: run autoremove
+CHANGE: apt-get clean
+NO_CHANGE: symlink ENI for cloud-initramfs-dyn-netconf (LP: #1534205)
+NO_CHANGE: touch /etc/iscsi/iscsi.initramfs for iscsi root shutdown (LP: #1536707) [systemd]
+NO_CHANGE: create /lib/modules (LP: #1543204)
+CHANGE: set CRYPTSETUP=y in /etc/cryptsetup-initramfs/conf-hook (LP: #1818876)
+NO_CHANGE: update-initramfs
+NO_CHANGE: disable rescuevol (LP: #1034116)
+NO_CHANGE: package changes: add='' remove=''
+Wed, 25 Aug 2021 19:06:23 +0000: starting kpacks: linux-generic,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/ga-18.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/ga-18.04/generic/boot-initrd linux-lowlatency,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/ga-18.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/ga-18.04/lowlatency/boot-initrd linux-generic-hwe-18.04,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04/generic/boot-initrd linux-lowlatency-hwe-18.04,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04/lowlatency/boot-initrd linux-generic-hwe-18.04-edge,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04-edge/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04-edge/generic/boot-initrd linux-lowlatency-hwe-18.04-edge,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04-edge/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/hwe-18.04-edge/lowlatency/boot-initrd
+Wed, 25 Aug 2021 19:06:23 +0000: Wed, 25 Aug 2021 19:06:23 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-generic /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-4.15.0-156
+  linux-headers-4.15.0-156-generic linux-headers-generic
+  linux-image-4.15.0-156-generic linux-image-generic
+  linux-modules-4.15.0-156-generic linux-modules-extra-4.15.0-156-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.15.0
+  | linux-source-4.15.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic linux-headers-4.15.0-156 linux-headers-4.15.0-156-generic
+  linux-headers-generic linux-image-4.15.0-156-generic linux-image-generic
+  linux-modules-4.15.0-156-generic linux-modules-extra-4.15.0-156-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 150 MB of archives.
+After this operation, 710 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~18.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-4.15.0-156-generic amd64 4.15.0-156.163 [13.4 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-4.15.0-156-generic amd64 4.15.0-156.163 [8091 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-extra-4.15.0-156-generic amd64 4.15.0-156.163 [33.7 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-generic amd64 4.15.0.156.145 [2544 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-156 all 4.15.0-156.163 [10.9 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-156-generic amd64 4.15.0-156.163 [1258 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-generic amd64 4.15.0.156.145 [2440 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-generic amd64 4.15.0.156.145 [1864 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 150 MB in 13s (11.8 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-modules-4.15.0-156-generic.
+Preparing to unpack .../13-linux-modules-4.15.0-156-generic_4.15.0-156.163_amd64.deb ...
+Unpacking linux-modules-4.15.0-156-generic (4.15.0-156.163) ...
+Selecting previously unselected package linux-image-4.15.0-156-generic.
+Preparing to unpack .../14-linux-image-4.15.0-156-generic_4.15.0-156.163_amd64.deb ...
+Unpacking linux-image-4.15.0-156-generic (4.15.0-156.163) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-156-generic.
+Preparing to unpack .../15-linux-modules-extra-4.15.0-156-generic_4.15.0-156.163_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-156-generic (4.15.0-156.163) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic.
+Preparing to unpack .../18-linux-image-generic_4.15.0.156.145_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.156.145) ...
+Selecting previously unselected package linux-headers-4.15.0-156.
+Preparing to unpack .../19-linux-headers-4.15.0-156_4.15.0-156.163_all.deb ...
+Unpacking linux-headers-4.15.0-156 (4.15.0-156.163) ...
+Selecting previously unselected package linux-headers-4.15.0-156-generic.
+Preparing to unpack .../20-linux-headers-4.15.0-156-generic_4.15.0-156.163_amd64.deb ...
+Unpacking linux-headers-4.15.0-156-generic (4.15.0-156.163) ...
+Selecting previously unselected package linux-headers-generic.
+Preparing to unpack .../21-linux-headers-generic_4.15.0.156.145_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.156.145) ...
+Selecting previously unselected package linux-generic.
+Preparing to unpack .../22-linux-generic_4.15.0.156.145_amd64.deb ...
+Unpacking linux-generic (4.15.0.156.145) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-modules-4.15.0-156-generic (4.15.0-156.163) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Setting up linux-image-4.15.0-156-generic (4.15.0-156.163) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-156-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-156-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-156-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-156-generic
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up linux-headers-4.15.0-156 (4.15.0-156.163) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up linux-headers-4.15.0-156-generic (4.15.0-156.163) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up iw (4.14-0.1) ...
+Setting up linux-headers-generic (4.15.0.156.145) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-4.15.0-156-generic (4.15.0-156.163) ...
+Setting up linux-image-generic (4.15.0.156.145) ...
+Setting up linux-generic (4.15.0.156.145) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-4.15.0-156-generic (4.15.0-156.163) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-156-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-156-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:08:11 +0000: Wed, 25 Aug 2021 19:08:11 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-lowlatency /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-4.15.0-156 linux-headers-4.15.0-156-lowlatency
+  linux-headers-lowlatency linux-image-4.15.0-156-lowlatency
+  linux-image-lowlatency linux-modules-4.15.0-156-lowlatency os-prober
+  thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.15.0
+  | linux-source-4.15.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-4.15.0-156
+  linux-headers-4.15.0-156-lowlatency linux-headers-lowlatency
+  linux-image-4.15.0-156-lowlatency linux-image-lowlatency linux-lowlatency
+  linux-modules-4.15.0-156-lowlatency os-prober thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 150 MB of archives.
+After this operation, 709 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-156 all 4.15.0-156.163 [10.9 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-156-lowlatency amd64 4.15.0-156.163 [1259 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-lowlatency amd64 4.15.0.156.145 [2444 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-4.15.0-156-lowlatency amd64 4.15.0-156.163 [47.0 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-4.15.0-156-lowlatency amd64 4.15.0-156.163 [8144 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-lowlatency amd64 4.15.0.156.145 [2540 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-lowlatency amd64 4.15.0.156.145 [1864 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 150 MB in 8s (19.0 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-headers-4.15.0-156.
+Preparing to unpack .../08-linux-headers-4.15.0-156_4.15.0-156.163_all.deb ...
+Unpacking linux-headers-4.15.0-156 (4.15.0-156.163) ...
+Selecting previously unselected package linux-headers-4.15.0-156-lowlatency.
+Preparing to unpack .../09-linux-headers-4.15.0-156-lowlatency_4.15.0-156.163_amd64.deb ...
+Unpacking linux-headers-4.15.0-156-lowlatency (4.15.0-156.163) ...
+Selecting previously unselected package linux-headers-lowlatency.
+Preparing to unpack .../10-linux-headers-lowlatency_4.15.0.156.145_amd64.deb ...
+Unpacking linux-headers-lowlatency (4.15.0.156.145) ...
+Selecting previously unselected package linux-modules-4.15.0-156-lowlatency.
+Preparing to unpack .../11-linux-modules-4.15.0-156-lowlatency_4.15.0-156.163_amd64.deb ...
+Unpacking linux-modules-4.15.0-156-lowlatency (4.15.0-156.163) ...
+Selecting previously unselected package linux-image-4.15.0-156-lowlatency.
+Preparing to unpack .../12-linux-image-4.15.0-156-lowlatency_4.15.0-156.163_amd64.deb ...
+Unpacking linux-image-4.15.0-156-lowlatency (4.15.0-156.163) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency.
+Preparing to unpack .../15-linux-image-lowlatency_4.15.0.156.145_amd64.deb ...
+Unpacking linux-image-lowlatency (4.15.0.156.145) ...
+Selecting previously unselected package linux-lowlatency.
+Preparing to unpack .../16-linux-lowlatency_4.15.0.156.145_amd64.deb ...
+Unpacking linux-lowlatency (4.15.0.156.145) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-modules-4.15.0-156-lowlatency (4.15.0-156.163) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up linux-image-4.15.0-156-lowlatency (4.15.0-156.163) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-156-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-156-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-156-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-156-lowlatency
+Setting up linux-headers-4.15.0-156 (4.15.0-156.163) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-headers-4.15.0-156-lowlatency (4.15.0-156.163) ...
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-image-lowlatency (4.15.0.156.145) ...
+Setting up linux-headers-lowlatency (4.15.0.156.145) ...
+Setting up linux-lowlatency (4.15.0.156.145) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+Processing triggers for linux-image-4.15.0-156-lowlatency (4.15.0-156.163) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-156-lowlatency
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:09:27 +0000: Wed, 25 Aug 2021 19:09:27 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-generic-hwe-18.04 /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic-hwe-18.04
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-5.4.0-81-generic
+  linux-headers-generic-hwe-18.04 linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-generic linux-image-generic-hwe-18.04
+  linux-modules-5.4.0-81-generic linux-modules-extra-5.4.0-81-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-18.04 linux-headers-5.4.0-81-generic
+  linux-headers-generic-hwe-18.04 linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-generic linux-image-generic-hwe-18.04
+  linux-modules-5.4.0-81-generic linux-modules-extra-5.4.0-81-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 157 MB of archives.
+After this operation, 727 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~18.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [14.7 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [9047 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [38.8 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [2696 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-81 all 5.4.0-81.91~18.04.1 [11.0 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [1343 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [2564 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [1940 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 157 MB in 8s (20.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-modules-5.4.0-81-generic.
+Preparing to unpack .../13-linux-modules-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-81-generic.
+Preparing to unpack .../14-linux-image-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.4.0-81-generic.
+Preparing to unpack .../15-linux-modules-extra-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic-hwe-18.04.
+Preparing to unpack .../18-linux-image-generic-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-image-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-81.
+Preparing to unpack .../19-linux-hwe-5.4-headers-5.4.0-81_5.4.0-81.91~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-81-generic.
+Preparing to unpack .../20-linux-headers-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-18.04.
+Preparing to unpack .../21-linux-headers-generic-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-headers-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-generic-hwe-18.04.
+Preparing to unpack .../22-linux-generic-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Setting up linux-modules-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-81-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-81-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-81-generic
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-81-generic
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-headers-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up linux-headers-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up iw (4.14-0.1) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up linux-generic-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic-hwe-18.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:11:20 +0000: Wed, 25 Aug 2021 19:11:20 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-lowlatency-hwe-18.04 /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency-hwe-18.04
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-5.4.0-81-lowlatency linux-headers-lowlatency-hwe-18.04
+  linux-hwe-5.4-headers-5.4.0-81 linux-image-5.4.0-81-lowlatency
+  linux-image-lowlatency-hwe-18.04 linux-modules-5.4.0-81-lowlatency os-prober
+  thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-5.4.0-81-lowlatency
+  linux-headers-lowlatency-hwe-18.04 linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-lowlatency linux-image-lowlatency-hwe-18.04
+  linux-lowlatency-hwe-18.04 linux-modules-5.4.0-81-lowlatency os-prober
+  thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 157 MB of archives.
+After this operation, 725 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-81 all 5.4.0-81.91~18.04.1 [11.0 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [1344 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-lowlatency-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [2560 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [53.4 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [9115 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-lowlatency-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [2696 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-lowlatency-hwe-18.04 amd64 5.4.0.81.91~18.04.73 [1916 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 157 MB in 7s (21.4 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-81.
+Preparing to unpack .../08-linux-hwe-5.4-headers-5.4.0-81_5.4.0-81.91~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-81-lowlatency.
+Preparing to unpack .../09-linux-headers-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-18.04.
+Preparing to unpack .../10-linux-headers-lowlatency-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-modules-5.4.0-81-lowlatency.
+Preparing to unpack .../11-linux-modules-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-81-lowlatency.
+Preparing to unpack .../12-linux-image-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-18.04.
+Preparing to unpack .../15-linux-image-lowlatency-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-lowlatency-hwe-18.04.
+Preparing to unpack .../16-linux-lowlatency-hwe-18.04_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up linux-modules-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-headers-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-81-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-81-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-81-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-81-lowlatency
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up linux-headers-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-image-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up linux-lowlatency-hwe-18.04 (5.4.0.81.91~18.04.73) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+Processing triggers for linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-lowlatency
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency-hwe-18.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:12:37 +0000: Wed, 25 Aug 2021 19:12:37 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-generic-hwe-18.04-edge /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic-hwe-18.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-5.4.0-81-generic
+  linux-headers-generic-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-generic linux-image-generic-hwe-18.04-edge
+  linux-modules-5.4.0-81-generic linux-modules-extra-5.4.0-81-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-18.04-edge linux-headers-5.4.0-81-generic
+  linux-headers-generic-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-generic linux-image-generic-hwe-18.04-edge
+  linux-modules-5.4.0-81-generic linux-modules-extra-5.4.0-81-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 157 MB of archives.
+After this operation, 727 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~18.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [14.7 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [9047 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [38.8 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [2704 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-81 all 5.4.0-81.91~18.04.1 [11.0 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-81-generic amd64 5.4.0-81.91~18.04.1 [1343 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [2572 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [1892 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 157 MB in 7s (21.3 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-modules-5.4.0-81-generic.
+Preparing to unpack .../13-linux-modules-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-81-generic.
+Preparing to unpack .../14-linux-image-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.4.0-81-generic.
+Preparing to unpack .../15-linux-modules-extra-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic-hwe-18.04-edge.
+Preparing to unpack .../18-linux-image-generic-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-image-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-81.
+Preparing to unpack .../19-linux-hwe-5.4-headers-5.4.0-81_5.4.0-81.91~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-81-generic.
+Preparing to unpack .../20-linux-headers-5.4.0-81-generic_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-18.04-edge.
+Preparing to unpack .../21-linux-headers-generic-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-headers-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-generic-hwe-18.04-edge.
+Preparing to unpack .../22-linux-generic-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Setting up linux-modules-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-81-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-81-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-81-generic
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-81-generic
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-headers-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up linux-headers-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up iw (4.14-0.1) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up linux-generic-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-5.4.0-81-generic (5.4.0-81.91~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-generic
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-generic-hwe-18.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:14:26 +0000: Wed, 25 Aug 2021 19:14:26 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.0kl1Cp/root.img linux-lowlatency-hwe-18.04-edge /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency-hwe-18.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-5.4.0-81-lowlatency linux-headers-lowlatency-hwe-18.04-edge
+  linux-hwe-5.4-headers-5.4.0-81 linux-image-5.4.0-81-lowlatency
+  linux-image-lowlatency-hwe-18.04-edge linux-modules-5.4.0-81-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-5.4.0-81-lowlatency
+  linux-headers-lowlatency-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-81
+  linux-image-5.4.0-81-lowlatency linux-image-lowlatency-hwe-18.04-edge
+  linux-lowlatency-hwe-18.04-edge linux-modules-5.4.0-81-lowlatency os-prober
+  thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 157 MB of archives.
+After this operation, 725 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.23 [1772 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.23 [534 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.23 [901 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.23 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.20 [74.8 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-81 all 5.4.0-81.91~18.04.1 [11.0 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [1344 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-lowlatency-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [2572 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [53.4 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-81-lowlatency amd64 5.4.0-81.91~18.04.1 [9115 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.18.04.1 [3809 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-lowlatency-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [2704 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-lowlatency-hwe-18.04-edge amd64 5.4.0.81.91~18.04.73 [1892 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 157 MB in 7s (21.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28963 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.23_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.20_all.deb ...
+Unpacking linux-firmware (1.173.20) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-81.
+Preparing to unpack .../08-linux-hwe-5.4-headers-5.4.0-81_5.4.0-81.91~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-81-lowlatency.
+Preparing to unpack .../09-linux-headers-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../10-linux-headers-lowlatency-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-modules-5.4.0-81-lowlatency.
+Preparing to unpack .../11-linux-modules-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-81-lowlatency.
+Preparing to unpack .../12-linux-image-5.4.0-81-lowlatency_5.4.0-81.91~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20210608.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../15-linux-image-lowlatency-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package linux-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../16-linux-lowlatency-hwe-18.04-edge_5.4.0.81.91~18.04.73_amd64.deb ...
+Unpacking linux-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up linux-modules-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up linux-hwe-5.4-headers-5.4.0-81 (5.4.0-81.91~18.04.1) ...
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.20) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-headers-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+Setting up linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-81-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-81-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-81-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-81-lowlatency
+Setting up grub-pc-bin (2.02-2ubuntu8.23) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up linux-headers-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up grub2-common (2.02-2ubuntu8.23) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-image-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up linux-lowlatency-hwe-18.04-edge (5.4.0.81.91~18.04.73) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.23) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+Processing triggers for linux-image-5.4.0-81-lowlatency (5.4.0-81.91~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-81-lowlatency
+Warning: couldn't identify filesystem type for fsck hook, ignoring.
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.0kl1Cp/linux-lowlatency-hwe-18.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:15:45 +0000: kpacks done
+Wed, 25 Aug 2021 19:15:45 +0000: copying working img into new fs of 1400M (pad=)
+src image uuid=2db0815b-9090-4312-8148-7442602b7370 label=cloudimg-rootfs fstype=ext4
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.0kl1Cp/root.img.fs_img_size'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+Wed, 25 Aug 2021 19:16:06 +0000: zeroing img
+e2fsck 1.45.5 (07-Jan-2020)
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+cloudimg-rootfs: 36228/327680 files (0.1% non-contiguous), 262126/1310720 blocks
+creating a new squash image in /home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/squashfs with ./maas-images/bin/img2squashfs from /tmp/maas-cloudimg2eph2.0kl1Cp/root.img
+format of '/tmp/maas-cloudimg2eph2.0kl1Cp/root.img' is 'root-image'
+got format 'fs-image' at temp path '/tmp/img2squashfs.kCgJwU/fs-image'
+calling mount-image-callback /tmp/img2squashfs.kCgJwU/fs-image -- ./maas-images/bin/img2squashfs dir2squashfs _MOUNTPOINT_ /home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/squashfs
+Wed, 25 Aug 2021 19:16:13 +0000: starting: mksquashfs /tmp/mount-image-callback.6WetYZ/mp /home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/squashfs.img2squashfs.3888331 -xattrs -comp xz
+Parallel mksquashfs: Using 28 processors
+Creating 4.0 filesystem on /home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/squashfs.img2squashfs.3888331, block size 131072.
+[===========================================================-] 32579/32579 100%
+
+Exportable Squashfs 4.0 filesystem, xz compressed, data block size 131072
+	compressed data, compressed metadata, compressed fragments,
+	compressed xattrs, compressed ids
+	duplicates are removed
+Filesystem size 218591.84 Kbytes (213.47 Mbytes)
+	27.20% of uncompressed filesystem size (803576.71 Kbytes)
+Inode table size 306122 bytes (298.95 Kbytes)
+	25.10% of uncompressed inode table size (1219745 bytes)
+Directory table size 308552 bytes (301.32 Kbytes)
+	38.57% of uncompressed directory table size (799927 bytes)
+Xattr table size 40 bytes (0.04 Kbytes)
+	100.00% of uncompressed xattr table size (40 bytes)
+Number of duplicate files found 1380
+Number of inodes 36219
+Number of files 28205
+Number of fragments 1719
+Number of symbolic links  4686
+Number of device nodes 7
+Number of fifo nodes 0
+Number of socket nodes 0
+Number of directories 3321
+Number of ids (unique uids + gids) 22
+Number of uids 8
+	root (0)
+	daemon (1)
+	_apt (105)
+	syslog (104)
+	man (6)
+	sshd (110)
+	uuidd (108)
+	systemd-resolve (102)
+Number of gids 17
+	root (0)
+	daemon (1)
+	shadow (42)
+	uuidd (112)
+	tty (5)
+	rdma (105)
+	netdev (109)
+	messagebus (111)
+	crontab (107)
+	utmp (43)
+	staff (50)
+	man (12)
+	nogroup (65534)
+	adm (4)
+	systemd-journal (101)
+	input (106)
+	mail (8)
+Wed, 25 Aug 2021 19:16:35 +0000: finished: returned 0
+output in /home/ubuntu/workspace/www/html/images/bionic/amd64/20210818/squashfs. took 24s.
+Wed, 25 Aug 2021 19:16:36 +0000: finished
+Wed, 25 Aug 2021 19:16:39 +0000: getting source http://cloud-images.ubuntu.com/daily/server/focal/20210824/focal-server-cloudimg-amd64.squashfs
+--2021-08-25 19:16:39--  http://cloud-images.ubuntu.com/daily/server/focal/20210824/focal-server-cloudimg-amd64.squashfs
+Resolving squid.internal (squid.internal)... 91.189.89.11
+Connecting to squid.internal (squid.internal)|91.189.89.11|:3128... connected.
+Proxy request sent, awaiting response... 200 OK
+Length: 384159744 (366M)
+Saving to: ‘/tmp/maas-cloudimg2eph2.lBmwq1/focal-server-cloudimg-amd64.squashfs’
+
+     0K ........ ........ ........ ........ ........ ........  0% 5.10M 71s
+  3072K ........ ........ ........ ........ ........ ........  1% 26.2M 42s
+  6144K ........ ........ ........ ........ ........ ........  2% 23.6M 33s
+  9216K ........ ........ ........ ........ ........ ........  3% 27.1M 28s
+ 12288K ........ ........ ........ ........ ........ ........  4% 30.5M 24s
+ 15360K ........ ........ ........ ........ ........ ........  4% 26.4M 22s
+ 18432K ........ ........ ........ ........ ........ ........  5% 12.3M 23s
+ 21504K ........ ........ ........ ........ ........ ........  6% 30.2M 21s
+ 24576K ........ ........ ........ ........ ........ ........  7% 14.2M 21s
+ 27648K ........ ........ ........ ........ ........ ........  8% 24.9M 20s
+ 30720K ........ ........ ........ ........ ........ ........  9% 13.7M 21s
+ 33792K ........ ........ ........ ........ ........ ........  9% 15.9M 21s
+ 36864K ........ ........ ........ ........ ........ ........ 10% 11.0M 21s
+ 39936K ........ ........ ........ ........ ........ ........ 11% 10.9M 22s
+ 43008K ........ ........ ........ ........ ........ ........ 12% 11.9M 22s
+ 46080K ........ ........ ........ ........ ........ ........ 13% 9.04M 22s
+ 49152K ........ ........ ........ ........ ........ ........ 13% 9.26M 23s
+ 52224K ........ ........ ........ ........ ........ ........ 14% 9.27M 23s
+ 55296K ........ ........ ........ ........ ........ ........ 15% 9.61M 23s
+ 58368K ........ ........ ........ ........ ........ ........ 16% 9.66M 24s
+ 61440K ........ ........ ........ ........ ........ ........ 17% 9.64M 24s
+ 64512K ........ ........ ........ ........ ........ ........ 18% 9.68M 24s
+ 67584K ........ ........ ........ ........ ........ ........ 18% 10.4M 24s
+ 70656K ........ ........ ........ ........ ........ ........ 19% 10.2M 24s
+ 73728K ........ ........ ........ ........ ........ ........ 20% 9.51M 24s
+ 76800K ........ ........ ........ ........ ........ ........ 21% 9.72M 24s
+ 79872K ........ ........ ........ ........ ........ ........ 22% 10.7M 24s
+ 82944K ........ ........ ........ ........ ........ ........ 22% 9.69M 24s
+ 86016K ........ ........ ........ ........ ........ ........ 23% 9.50M 24s
+ 89088K ........ ........ ........ ........ ........ ........ 24% 9.80M 24s
+ 92160K ........ ........ ........ ........ ........ ........ 25% 11.4M 23s
+ 95232K ........ ........ ........ ........ ........ ........ 26% 9.56M 23s
+ 98304K ........ ........ ........ ........ ........ ........ 27% 9.88M 23s
+101376K ........ ........ ........ ........ ........ ........ 27% 11.3M 23s
+104448K ........ ........ ........ ........ ........ ........ 28% 9.53M 23s
+107520K ........ ........ ........ ........ ........ ........ 29% 10.2M 23s
+110592K ........ ........ ........ ........ ........ ........ 30% 10.6M 22s
+113664K ........ ........ ........ ........ ........ ........ 31% 9.84M 22s
+116736K ........ ........ ........ ........ ........ ........ 31% 10.9M 22s
+119808K ........ ........ ........ ........ ........ ........ 32% 9.34M 22s
+122880K ........ ........ ........ ........ ........ ........ 33% 11.1M 22s
+125952K ........ ........ ........ ........ ........ ........ 34% 9.76M 21s
+129024K ........ ........ ........ ........ ........ ........ 35% 10.9M 21s
+132096K ........ ........ ........ ........ ........ ........ 36% 9.51M 21s
+135168K ........ ........ ........ ........ ........ ........ 36% 11.6M 21s
+138240K ........ ........ ........ ........ ........ ........ 37% 9.57M 20s
+141312K ........ ........ ........ ........ ........ ........ 38% 10.5M 20s
+144384K ........ ........ ........ ........ ........ ........ 39% 11.3M 20s
+147456K ........ ........ ........ ........ ........ ........ 40% 10.4M 20s
+150528K ........ ........ ........ ........ ........ ........ 40% 11.7M 19s
+153600K ........ ........ ........ ........ ........ ........ 41% 10.5M 19s
+156672K ........ ........ ........ ........ ........ ........ 42% 11.1M 19s
+159744K ........ ........ ........ ........ ........ ........ 43% 10.4M 19s
+162816K ........ ........ ........ ........ ........ ........ 44% 11.5M 18s
+165888K ........ ........ ........ ........ ........ ........ 45% 11.8M 18s
+168960K ........ ........ ........ ........ ........ ........ 45% 10.8M 18s
+172032K ........ ........ ........ ........ ........ ........ 46% 11.9M 18s
+175104K ........ ........ ........ ........ ........ ........ 47% 12.2M 17s
+178176K ........ ........ ........ ........ ........ ........ 48% 12.3M 17s
+181248K ........ ........ ........ ........ ........ ........ 49% 11.9M 17s
+184320K ........ ........ ........ ........ ........ ........ 49% 12.5M 16s
+187392K ........ ........ ........ ........ ........ ........ 50% 13.0M 16s
+190464K ........ ........ ........ ........ ........ ........ 51% 12.6M 16s
+193536K ........ ........ ........ ........ ........ ........ 52% 13.5M 15s
+196608K ........ ........ ........ ........ ........ ........ 53% 13.5M 15s
+199680K ........ ........ ........ ........ ........ ........ 54% 14.4M 15s
+202752K ........ ........ ........ ........ ........ ........ 54% 14.3M 15s
+205824K ........ ........ ........ ........ ........ ........ 55% 13.8M 14s
+208896K ........ ........ ........ ........ ........ ........ 56% 15.9M 14s
+211968K ........ ........ ........ ........ ........ ........ 57% 14.0M 14s
+215040K ........ ........ ........ ........ ........ ........ 58% 16.7M 13s
+218112K ........ ........ ........ ........ ........ ........ 58% 14.4M 13s
+221184K ........ ........ ........ ........ ........ ........ 59% 16.8M 13s
+224256K ........ ........ ........ ........ ........ ........ 60% 16.4M 12s
+227328K ........ ........ ........ ........ ........ ........ 61% 15.4M 12s
+230400K ........ ........ ........ ........ ........ ........ 62% 17.2M 12s
+233472K ........ ........ ........ ........ ........ ........ 63% 17.9M 11s
+236544K ........ ........ ........ ........ ........ ........ 63% 18.0M 11s
+239616K ........ ........ ........ ........ ........ ........ 64% 17.4M 11s
+242688K ........ ........ ........ ........ ........ ........ 65% 17.6M 11s
+245760K ........ ........ ........ ........ ........ ........ 66% 17.2M 10s
+248832K ........ ........ ........ ........ ........ ........ 67% 19.5M 10s
+251904K ........ ........ ........ ........ ........ ........ 67% 20.6M 10s
+254976K ........ ........ ........ ........ ........ ........ 68% 19.0M 9s
+258048K ........ ........ ........ ........ ........ ........ 69% 21.3M 9s
+261120K ........ ........ ........ ........ ........ ........ 70% 19.7M 9s
+264192K ........ ........ ........ ........ ........ ........ 71% 19.2M 9s
+267264K ........ ........ ........ ........ ........ ........ 72% 20.2M 8s
+270336K ........ ........ ........ ........ ........ ........ 72% 23.8M 8s
+273408K ........ ........ ........ ........ ........ ........ 73% 21.0M 8s
+276480K ........ ........ ........ ........ ........ ........ 74% 20.6M 7s
+279552K ........ ........ ........ ........ ........ ........ 75% 24.3M 7s
+282624K ........ ........ ........ ........ ........ ........ 76% 21.5M 7s
+285696K ........ ........ ........ ........ ........ ........ 76% 26.0M 7s
+288768K ........ ........ ........ ........ ........ ........ 77% 23.9M 6s
+291840K ........ ........ ........ ........ ........ ........ 78% 25.9M 6s
+294912K ........ ........ ........ ........ ........ ........ 79% 25.2M 6s
+297984K ........ ........ ........ ........ ........ ........ 80% 24.7M 6s
+301056K ........ ........ ........ ........ ........ ........ 81% 26.8M 5s
+304128K ........ ........ ........ ........ ........ ........ 81% 27.3M 5s
+307200K ........ ........ ........ ........ ........ ........ 82% 26.7M 5s
+310272K ........ ........ ........ ........ ........ ........ 83% 28.8M 5s
+313344K ........ ........ ........ ........ ........ ........ 84% 28.1M 4s
+316416K ........ ........ ........ ........ ........ ........ 85% 26.4M 4s
+319488K ........ ........ ........ ........ ........ ........ 85% 30.5M 4s
+322560K ........ ........ ........ ........ ........ ........ 86% 26.5M 4s
+325632K ........ ........ ........ ........ ........ ........ 87% 24.2M 3s
+328704K ........ ........ ........ ........ ........ ........ 88% 24.6M 3s
+331776K ........ ........ ........ ........ ........ ........ 89% 17.7M 3s
+334848K ........ ........ ........ ........ ........ ........ 90% 22.5M 3s
+337920K ........ ........ ........ ........ ........ ........ 90% 18.3M 2s
+340992K ........ ........ ........ ........ ........ ........ 91% 22.3M 2s
+344064K ........ ........ ........ ........ ........ ........ 92% 22.2M 2s
+347136K ........ ........ ........ ........ ........ ........ 93% 22.4M 2s
+350208K ........ ........ ........ ........ ........ ........ 94% 23.2M 2s
+353280K ........ ........ ........ ........ ........ ........ 94% 20.5M 1s
+356352K ........ ........ ........ ........ ........ ........ 95% 25.7M 1s
+359424K ........ ........ ........ ........ ........ ........ 96% 20.8M 1s
+362496K ........ ........ ........ ........ ........ ........ 97% 25.0M 1s
+365568K ........ ........ ........ ........ ........ ........ 98% 21.5M 0s
+368640K ........ ........ ........ ........ ........ ........ 99% 21.2M 0s
+371712K ........ ........ ........ ........ ........ ........ 99% 25.9M 0s
+374784K .....                                                100% 33.4M=26s
+
+2021-08-25 19:17:05 (14.3 MB/s) - ‘/tmp/maas-cloudimg2eph2.lBmwq1/focal-server-cloudimg-amd64.squashfs’ saved [384159744/384159744]
+
+Wed, 25 Aug 2021 19:17:05 +0000: getting .img from /tmp/maas-cloudimg2eph2.lBmwq1/focal-server-cloudimg-amd64.squashfs fmt=auto
+determined format is squashfs-image
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.lBmwq1/root.img'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+turning squahsfs image in /tmp/maas-cloudimg2eph2.lBmwq1/focal-server-cloudimg-amd64.squashfs to ext4 image in /tmp/maas-cloudimg2eph2.lBmwq1/root.img
+Parallel unsquashfs: Using 28 processors
+36246 inodes (40997 blocks) to write
+
+[===========================================================\] 40997/40997 100%
+
+created 31536 files
+created 3702 directories
+created 4589 symlinks
+created 9 devices
+created 0 fifos
+Wed, 25 Aug 2021 19:17:30 +0000: getting '1024M' in /tmp/maas-cloudimg2eph2.lBmwq1/root.img
+Wed, 25 Aug 2021 19:17:30 +0000: targetting 5368709120 (1310720*4096) bytes.
+Wed, 25 Aug 2021 19:17:30 +0000: fs is currently 1048576 * 4096.
+Wed, 25 Aug 2021 19:17:30 +0000: resize to 1310720. minblocks=380646. target=1310720
+Wed, 25 Aug 2021 19:17:31 +0000: starting maas-cloudimg2ephemeral --arch=amd64 --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img none /tmp/maas-cloudimg2eph2.lBmwq1/none-kernel /tmp/maas-cloudimg2eph2.lBmwq1/none-initrd /tmp/maas-cloudimg2eph2.lBmwq1/manifest
+NO_CHANGE: add additional repos.
+NO_CHANGE: images ppa for cloud-init and maas-enlist (LP: #1511482, 1515733)
+CHANGE: enable proposed [amd64 http://archive.ubuntu.com/ubuntu/]
+NO_CHANGE: ensure mellanox mlx4_en gets loaded (LP: #1115710)
+NO_CHANGE: build-only: divert newaliases (LP: #1531299)
+nothing to remove: nothing match '^linux-.*' and not '^linux-base$'.
+NO_CHANGE: removing linux kernel packages.
+CHANGE: apt-get dist-upgrade
+CHANGE: run apt-update [dist-upgrade].
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Get:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+Get:3 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease [101 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal-proposed InRelease [267 kB]
+Get:6 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [8628 kB]
+Get:7 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [828 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal/universe Translation-en [5124 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal/universe amd64 c-n-f Metadata [265 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]
+Get:11 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 c-n-f Metadata [9136 B]
+Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1170 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [13.9 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [411 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [58.8 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [500 B]
+Get:18 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [851 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [179 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [18.6 kB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [24.6 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [6776 B]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [620 B]
+Get:24 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [2568 B]
+Get:25 http://archive.ubuntu.com/ubuntu focal-backports/main Translation-en [1120 B]
+Get:26 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [400 B]
+Get:27 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [5812 B]
+Get:29 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [2068 B]
+Get:30 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [288 B]
+Get:31 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]
+Get:32 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 Packages [96.4 kB]
+Get:33 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [8440 B]
+Get:34 http://archive.ubuntu.com/ubuntu focal-proposed/main Translation-en [26.3 kB]
+Get:35 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 c-n-f Metadata [1580 B]
+Get:36 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 Packages [39.9 kB]
+Get:37 http://archive.ubuntu.com/ubuntu focal-proposed/universe Translation-en [19.4 kB]
+Get:38 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 c-n-f Metadata [1736 B]
+Get:39 http://archive.ubuntu.com/ubuntu focal-proposed/multiverse amd64 Packages [3424 B]
+Get:40 http://archive.ubuntu.com/ubuntu focal-proposed/multiverse Translation-en [4360 B]
+Get:41 http://archive.ubuntu.com/ubuntu focal-proposed/multiverse amd64 c-n-f Metadata [348 B]
+Get:42 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [374 kB]
+Get:43 http://security.ubuntu.com/ubuntu focal-security/restricted Translation-en [53.6 kB]
+Get:44 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 c-n-f Metadata [500 B]
+Get:45 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [640 kB]
+Get:46 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [100 kB]
+Get:47 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [12.3 kB]
+Get:48 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [21.9 kB]
+Get:49 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [4948 B]
+Get:50 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [540 B]
+Fetched 19.9 MB in 4s (5341 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'sudo apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init linux-base open-vm-tools python-apt-common python3-apt
+  python3-software-properties python3-update-manager secureboot-db snapd
+  software-properties-common update-manager-core
+11 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Need to get 31.8 MB of archives.
+After this operation, 506 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 python-apt-common all 2.0.0ubuntu0.20.04.6 [17.1 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 python3-apt amd64 2.0.0ubuntu0.20.04.6 [154 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 python3-update-manager all 1:20.04.10.8 [38.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 update-manager-core all 1:20.04.10.8 [11.3 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-base all 4.5ubuntu3.7 [17.6 kB]
+Get:6 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 software-properties-common all 0.99.9.6 [10.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 python3-software-properties all 0.99.9.6 [25.1 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 secureboot-db amd64 1.6~20.04.1 [14.2 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 snapd amd64 2.51.1+20.04 [30.4 MB]
+Get:10 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 21.3-1-g6803368d-0ubuntu1~20.04.1 [476 kB]
+Get:11 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 open-vm-tools amd64 2:11.2.5-2ubuntu1~ubuntu20.04.1 [604 kB]
+Preconfiguring packages ...
+Fetched 31.8 MB in 2s (17.2 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+(Reading database ... 31621 files and directories currently installed.)
+Preparing to unpack .../00-python-apt-common_2.0.0ubuntu0.20.04.6_all.deb ...
+Unpacking python-apt-common (2.0.0ubuntu0.20.04.6) over (2.0.0ubuntu0.20.04.5) ...
+Preparing to unpack .../01-python3-apt_2.0.0ubuntu0.20.04.6_amd64.deb ...
+Unpacking python3-apt (2.0.0ubuntu0.20.04.6) over (2.0.0ubuntu0.20.04.5) ...
+Preparing to unpack .../02-python3-update-manager_1%3a20.04.10.8_all.deb ...
+Unpacking python3-update-manager (1:20.04.10.8) over (1:20.04.10.7) ...
+Preparing to unpack .../03-update-manager-core_1%3a20.04.10.8_all.deb ...
+Unpacking update-manager-core (1:20.04.10.8) over (1:20.04.10.7) ...
+Preparing to unpack .../04-linux-base_4.5ubuntu3.7_all.deb ...
+Unpacking linux-base (4.5ubuntu3.7) over (4.5ubuntu3.6) ...
+Preparing to unpack .../05-software-properties-common_0.99.9.6_all.deb ...
+Unpacking software-properties-common (0.99.9.6) over (0.98.9.5) ...
+Preparing to unpack .../06-python3-software-properties_0.99.9.6_all.deb ...
+Unpacking python3-software-properties (0.99.9.6) over (0.98.9.5) ...
+Preparing to unpack .../07-secureboot-db_1.6~20.04.1_amd64.deb ...
+Unpacking secureboot-db (1.6~20.04.1) over (1.5) ...
+Preparing to unpack .../08-snapd_2.51.1+20.04_amd64.deb ...
+Unpacking snapd (2.51.1+20.04) over (2.49.2+20.04) ...
+Preparing to unpack .../09-cloud-init_21.3-1-g6803368d-0ubuntu1~20.04.1_all.deb ...
+Unpacking cloud-init (21.3-1-g6803368d-0ubuntu1~20.04.1) over (21.2-3-g899bfaa9-0ubuntu2~20.04.1) ...
+Preparing to unpack .../10-open-vm-tools_2%3a11.2.5-2ubuntu1~ubuntu20.04.1_amd64.deb ...
+Unpacking open-vm-tools (2:11.2.5-2ubuntu1~ubuntu20.04.1) over (2:11.0.5-4) ...
+Setting up snapd (2.51.1+20.04) ...
+Installing new version of config file /etc/profile.d/apps-bin-path.sh ...
+Setting up cloud-init (21.3-1-g6803368d-0ubuntu1~20.04.1) ...
+Installing new version of config file /etc/cloud/cloud.cfg ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Created symlink /etc/systemd/system/cloud-init.target.wants/cloud-init-hotplugd.socket -> /lib/systemd/system/cloud-init-hotplugd.socket.
+Setting up linux-base (4.5ubuntu3.7) ...
+Setting up secureboot-db (1.6~20.04.1) ...
+Setting up python-apt-common (2.0.0ubuntu0.20.04.6) ...
+Setting up open-vm-tools (2:11.2.5-2ubuntu1~ubuntu20.04.1) ...
+Installing new version of config file /etc/vmware-tools/tools.conf.example ...
+Installing new version of config file /etc/vmware-tools/vgauth.conf ...
+Running in chroot, ignoring request.
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Setting up python3-apt (2.0.0ubuntu0.20.04.6) ...
+Setting up python3-software-properties (0.99.9.6) ...
+Setting up python3-update-manager (1:20.04.10.8) ...
+Setting up software-properties-common (0.99.9.6) ...
+Setting up update-manager-core (1:20.04.10.8) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for rsyslog (8.2001.0-1ubuntu1.1) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of try-restart.
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for mime-support (3.64ubuntu1) ...
+NO_CHANGE: install missing packages
+NO_CHANGE: remove dpkg foreign architectures
+NO_CHANGE: run autoremove
+CHANGE: apt-get clean
+NO_CHANGE: symlink ENI for cloud-initramfs-dyn-netconf (LP: #1534205)
+NO_CHANGE: touch /etc/iscsi/iscsi.initramfs for iscsi root shutdown (LP: #1536707) [systemd]
+NO_CHANGE: create /lib/modules (LP: #1543204)
+CHANGE: set CRYPTSETUP=y in /etc/cryptsetup-initramfs/conf-hook (LP: #1818876)
+NO_CHANGE: update-initramfs
+NO_CHANGE: disable rescuevol (LP: #1034116)
+NO_CHANGE: package changes: add='' remove=''
+Wed, 25 Aug 2021 19:18:01 +0000: starting kpacks: linux-generic,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/ga-20.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/ga-20.04/generic/boot-initrd linux-image-lowlatency,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/ga-20.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/ga-20.04/lowlatency/boot-initrd linux-generic-hwe-20.04,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04/generic/boot-initrd linux-lowlatency-hwe-20.04,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04/lowlatency/boot-initrd linux-generic-hwe-20.04-edge,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04-edge/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04-edge/generic/boot-initrd linux-lowlatency-hwe-20.04-edge,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04-edge/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/focal/amd64/20210824/hwe-20.04-edge/lowlatency/boot-initrd
+Wed, 25 Aug 2021 19:18:01 +0000: Wed, 25 Aug 2021 19:18:01 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-generic /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu focal-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libnl-3-200 libnl-genl-3-200 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-headers-5.4.0-83
+  linux-headers-5.4.0-83-generic linux-headers-generic
+  linux-image-5.4.0-83-generic linux-image-generic
+  linux-modules-5.4.0-83-generic linux-modules-extra-5.4.0-83-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-source-5.4.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libevdev2 libimobiledevice6 libnl-3-200
+  libnl-genl-3-200 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-generic linux-headers-5.4.0-83 linux-headers-5.4.0-83-generic
+  linux-headers-generic linux-image-5.4.0-83-generic linux-image-generic
+  linux-modules-5.4.0-83-generic linux-modules-extra-5.4.0-83-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+0 upgraded, 33 newly installed, 0 to remove and 0 not upgraded.
+Need to get 194 MB of archives.
+After this operation, 993 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-3-200 amd64 3.4.0-1 [53.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-genl-3-200 amd64 3.4.0-1 [11.1 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~20.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 iw amd64 5.4-1 [94.0 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:13 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:18 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-modules-5.4.0-83-generic amd64 5.4.0-83.93 [14.8 MB]
+Get:19 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-image-5.4.0-83-generic amd64 5.4.0-83.93 [8988 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-modules-extra-5.4.0-83-generic amd64 5.4.0-83.93 [39.4 MB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-image-generic amd64 5.4.0.83.87 [2568 B]
+Get:24 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-headers-5.4.0-83 all 5.4.0-83.93 [11.0 MB]
+Get:25 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-headers-5.4.0-83-generic amd64 5.4.0-83.93 [1406 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-headers-generic amd64 5.4.0.83.87 [2436 B]
+Get:27 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-generic amd64 5.4.0.83.87 [1900 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:29 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:30 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:31 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:32 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:33 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 194 MB in 10s (20.3 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~20.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_5.4-1_amd64.deb ...
+Unpacking iw (5.4-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../12-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../13-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../14-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../15-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../16-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-modules-5.4.0-83-generic.
+Preparing to unpack .../17-linux-modules-5.4.0-83-generic_5.4.0-83.93_amd64.deb ...
+Unpacking linux-modules-5.4.0-83-generic (5.4.0-83.93) ...
+Selecting previously unselected package linux-image-5.4.0-83-generic.
+Preparing to unpack .../18-linux-image-5.4.0-83-generic_5.4.0-83.93_amd64.deb ...
+Unpacking linux-image-5.4.0-83-generic (5.4.0-83.93) ...
+Selecting previously unselected package linux-modules-extra-5.4.0-83-generic.
+Preparing to unpack .../19-linux-modules-extra-5.4.0-83-generic_5.4.0-83.93_amd64.deb ...
+Unpacking linux-modules-extra-5.4.0-83-generic (5.4.0-83.93) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../20-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../21-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-generic.
+Preparing to unpack .../22-linux-image-generic_5.4.0.83.87_amd64.deb ...
+Unpacking linux-image-generic (5.4.0.83.87) ...
+Selecting previously unselected package linux-headers-5.4.0-83.
+Preparing to unpack .../23-linux-headers-5.4.0-83_5.4.0-83.93_all.deb ...
+Unpacking linux-headers-5.4.0-83 (5.4.0-83.93) ...
+Selecting previously unselected package linux-headers-5.4.0-83-generic.
+Preparing to unpack .../24-linux-headers-5.4.0-83-generic_5.4.0-83.93_amd64.deb ...
+Unpacking linux-headers-5.4.0-83-generic (5.4.0-83.93) ...
+Selecting previously unselected package linux-headers-generic.
+Preparing to unpack .../25-linux-headers-generic_5.4.0.83.87_amd64.deb ...
+Unpacking linux-headers-generic (5.4.0.83.87) ...
+Selecting previously unselected package linux-generic.
+Preparing to unpack .../26-linux-generic_5.4.0.83.87_amd64.deb ...
+Unpacking linux-generic (5.4.0.83.87) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../27-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../28-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../29-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../30-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../31-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../32-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up linux-headers-5.4.0-83 (5.4.0-83.93) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-modules-5.4.0-83-generic (5.4.0-83.93) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up linux-image-5.4.0-83-generic (5.4.0-83.93) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.4.0-83-generic
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.4.0-83-generic
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.4.0-83-generic
+I: /boot/initrd.img is now a symlink to initrd.img-5.4.0-83-generic
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libnl-3-200:amd64 (3.4.0-1) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up linux-headers-5.4.0-83-generic (5.4.0-83.93) ...
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up linux-headers-generic (5.4.0.83.87) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up libnl-genl-3-200:amd64 (3.4.0-1) ...
+Setting up iw (5.4-1) ...
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-5.4.0-83-generic (5.4.0-83.93) ...
+Setting up linux-image-generic (5.4.0.83.87) ...
+Setting up linux-generic (5.4.0.83.87) ...
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.4.0-83-generic (5.4.0-83.93) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-83-generic
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.lrTdA0/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:19:33 +0000: Wed, 25 Aug 2021 19:19:33 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-image-lowlatency /tmp/maas-cloudimg2eph2.lBmwq1/linux-image-lowlatency
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-image-5.4.0-83-lowlatency linux-modules-5.4.0-83-lowlatency os-prober
+  thermald upower usbmuxd
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-source-5.4.0 linux-tools linux-headers-5.4.0-83-lowlatency
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 libevdev2 libimobiledevice6 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-image-5.4.0-83-lowlatency
+  linux-image-lowlatency linux-modules-5.4.0-83-lowlatency os-prober thermald
+  upower usbmuxd
+0 upgraded, 23 newly installed, 0 to remove and 0 not upgraded.
+Need to get 181 MB of archives.
+After this operation, 905 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:13 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-modules-5.4.0-83-lowlatency amd64 5.4.0-83.93 [54.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-image-5.4.0-83-lowlatency amd64 5.4.0-83.93 [9059 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 linux-image-lowlatency amd64 5.4.0.83.87 [2568 B]
+Get:18 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:21 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 181 MB in 15s (12.4 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../07-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../08-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../09-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../10-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../11-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-modules-5.4.0-83-lowlatency.
+Preparing to unpack .../12-linux-modules-5.4.0-83-lowlatency_5.4.0-83.93_amd64.deb ...
+Unpacking linux-modules-5.4.0-83-lowlatency (5.4.0-83.93) ...
+Selecting previously unselected package linux-image-5.4.0-83-lowlatency.
+Preparing to unpack .../13-linux-image-5.4.0-83-lowlatency_5.4.0-83.93_amd64.deb ...
+Unpacking linux-image-5.4.0-83-lowlatency (5.4.0-83.93) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../14-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../15-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-lowlatency.
+Preparing to unpack .../16-linux-image-lowlatency_5.4.0.83.87_amd64.deb ...
+Unpacking linux-image-lowlatency (5.4.0.83.87) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../18-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../19-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../20-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../21-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../22-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up linux-modules-5.4.0-83-lowlatency (5.4.0-83.93) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up linux-image-5.4.0-83-lowlatency (5.4.0-83.93) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.4.0-83-lowlatency
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.4.0-83-lowlatency
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.4.0-83-lowlatency
+I: /boot/initrd.img is now a symlink to initrd.img-5.4.0-83-lowlatency
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up linux-image-lowlatency (5.4.0.83.87) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.4.0-83-lowlatency (5.4.0-83.93) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-83-lowlatency
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.XmB0FI/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-image-lowlatency
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:21:06 +0000: Wed, 25 Aug 2021 19:21:06 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-generic-hwe-20.04 /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic-hwe-20.04
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libnl-3-200 libnl-genl-3-200 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-headers-5.11.0-27-generic
+  linux-headers-generic-hwe-20.04 linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-generic linux-image-generic-hwe-20.04
+  linux-modules-5.11.0-27-generic linux-modules-extra-5.11.0-27-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-hwe-5.11-source-5.11.0 linux-hwe-5.11-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libevdev2 libimobiledevice6 libnl-3-200
+  libnl-genl-3-200 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-generic-hwe-20.04 linux-headers-5.11.0-27-generic
+  linux-headers-generic-hwe-20.04 linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-generic linux-image-generic-hwe-20.04
+  linux-modules-5.11.0-27-generic linux-modules-extra-5.11.0-27-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+0 upgraded, 33 newly installed, 0 to remove and 0 not upgraded.
+Need to get 199 MB of archives.
+After this operation, 1017 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-3-200 amd64 3.4.0-1 [53.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-genl-3-200 amd64 3.4.0-1 [11.1 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~20.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 iw amd64 5.4-1 [94.0 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:13 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [15.8 MB]
+Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [9897 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-extra-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [42.0 MB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-generic-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [2620 B]
+Get:24 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-hwe-5.11-headers-5.11.0-27 all 5.11.0-27.29~20.04.1 [11.6 MB]
+Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [1461 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-generic-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [2512 B]
+Get:27 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-generic-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [1932 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:29 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:30 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:31 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:32 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:33 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 199 MB in 10s (20.3 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~20.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_5.4-1_amd64.deb ...
+Unpacking iw (5.4-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../12-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../13-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../14-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../15-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../16-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-modules-5.11.0-27-generic.
+Preparing to unpack .../17-linux-modules-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-image-5.11.0-27-generic.
+Preparing to unpack .../18-linux-image-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.11.0-27-generic.
+Preparing to unpack .../19-linux-modules-extra-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../20-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../21-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-generic-hwe-20.04.
+Preparing to unpack .../22-linux-image-generic-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-image-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-hwe-5.11-headers-5.11.0-27.
+Preparing to unpack .../23-linux-hwe-5.11-headers-5.11.0-27_5.11.0-27.29~20.04.1_all.deb ...
+Unpacking linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-5.11.0-27-generic.
+Preparing to unpack .../24-linux-headers-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-headers-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-20.04.
+Preparing to unpack .../25-linux-headers-generic-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-headers-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-generic-hwe-20.04.
+Preparing to unpack .../26-linux-generic-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../27-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../28-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../29-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../30-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../31-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../32-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up linux-headers-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libnl-3-200:amd64 (3.4.0-1) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up linux-headers-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up libnl-genl-3-200:amd64 (3.4.0-1) ...
+Setting up iw (5.4-1) ...
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up crda (3.18-1build1) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.11.0-27-generic
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.11.0-27-generic
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.11.0-27-generic
+I: /boot/initrd.img is now a symlink to initrd.img-5.11.0-27-generic
+Setting up linux-modules-extra-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up linux-modules-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up linux-image-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Setting up linux-generic-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.11.0-27-generic
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.YQJuQN/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic-hwe-20.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:22:42 +0000: Wed, 25 Aug 2021 19:22:42 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-lowlatency-hwe-20.04 /tmp/maas-cloudimg2eph2.lBmwq1/linux-lowlatency-hwe-20.04
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu focal-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-headers-5.11.0-27-lowlatency linux-headers-lowlatency-hwe-20.04
+  linux-hwe-5.11-headers-5.11.0-27 linux-image-5.11.0-27-lowlatency
+  linux-image-lowlatency-hwe-20.04 linux-modules-5.11.0-27-lowlatency
+  os-prober thermald upower usbmuxd
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-hwe-5.11-source-5.11.0 linux-hwe-5.11-tools
+  linux-modules-extra-5.11.0-27-lowlatency
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 libevdev2 libimobiledevice6 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-headers-5.11.0-27-lowlatency
+  linux-headers-lowlatency-hwe-20.04 linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-lowlatency linux-image-lowlatency-hwe-20.04
+  linux-lowlatency-hwe-20.04 linux-modules-5.11.0-27-lowlatency os-prober
+  thermald upower usbmuxd
+0 upgraded, 27 newly installed, 0 to remove and 0 not upgraded.
+Need to get 198 MB of archives.
+After this operation, 1015 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-hwe-5.11-headers-5.11.0-27 all 5.11.0-27.29~20.04.1 [11.6 MB]
+Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [1462 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-lowlatency-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [2512 B]
+Get:16 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [57.6 MB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [9938 kB]
+Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-lowlatency-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [2612 B]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-lowlatency-hwe-20.04 amd64 5.11.0.27.29~20.04.11 [1916 B]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:24 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:25 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:27 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 198 MB in 44s (4505 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../07-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../08-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../09-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../10-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../11-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-hwe-5.11-headers-5.11.0-27.
+Preparing to unpack .../12-linux-hwe-5.11-headers-5.11.0-27_5.11.0-27.29~20.04.1_all.deb ...
+Unpacking linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-5.11.0-27-lowlatency.
+Preparing to unpack .../13-linux-headers-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-headers-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-20.04.
+Preparing to unpack .../14-linux-headers-lowlatency-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-modules-5.11.0-27-lowlatency.
+Preparing to unpack .../15-linux-modules-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-image-5.11.0-27-lowlatency.
+Preparing to unpack .../16-linux-image-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../17-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../18-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-20.04.
+Preparing to unpack .../19-linux-image-lowlatency-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-lowlatency-hwe-20.04.
+Preparing to unpack .../20-linux-lowlatency-hwe-20.04_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../21-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../22-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../23-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../24-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../25-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../26-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up linux-headers-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up linux-headers-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.11.0-27-lowlatency
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.11.0-27-lowlatency
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.11.0-27-lowlatency
+I: /boot/initrd.img is now a symlink to initrd.img-5.11.0-27-lowlatency
+Setting up linux-image-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Setting up linux-modules-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Setting up linux-lowlatency-hwe-20.04 (5.11.0.27.29~20.04.11) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.11.0-27-lowlatency
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.JlsjMo/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-lowlatency-hwe-20.04
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:24:51 +0000: Wed, 25 Aug 2021 19:24:51 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-generic-hwe-20.04-edge /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic-hwe-20.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libnl-3-200 libnl-genl-3-200 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-headers-5.11.0-27-generic
+  linux-headers-generic-hwe-20.04-edge linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-generic linux-image-generic-hwe-20.04-edge
+  linux-modules-5.11.0-27-generic linux-modules-extra-5.11.0-27-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-hwe-5.11-source-5.11.0 linux-hwe-5.11-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libevdev2 libimobiledevice6 libnl-3-200
+  libnl-genl-3-200 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-generic-hwe-20.04-edge linux-headers-5.11.0-27-generic
+  linux-headers-generic-hwe-20.04-edge linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-generic linux-image-generic-hwe-20.04-edge
+  linux-modules-5.11.0-27-generic linux-modules-extra-5.11.0-27-generic
+  os-prober thermald upower usbmuxd wireless-regdb
+0 upgraded, 33 newly installed, 0 to remove and 0 not upgraded.
+Need to get 199 MB of archives.
+After this operation, 1017 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-3-200 amd64 3.4.0-1 [53.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libnl-genl-3-200 amd64 3.4.0-1 [11.1 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~20.04.1 [10.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 iw amd64 5.4-1 [94.0 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:13 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [15.8 MB]
+Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [9897 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-extra-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [42.0 MB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-generic-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [2632 B]
+Get:24 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-hwe-5.11-headers-5.11.0-27 all 5.11.0-27.29~20.04.1 [11.6 MB]
+Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-5.11.0-27-generic amd64 5.11.0-27.29~20.04.1 [1461 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-generic-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [2528 B]
+Get:27 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-generic-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [1904 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:29 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:30 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:31 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:32 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:33 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 199 MB in 10s (19.0 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.4.0-1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.4.0-1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2021.07.14-0ubuntu1~20.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_5.4-1_amd64.deb ...
+Unpacking iw (5.4-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../12-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../13-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../14-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../15-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../16-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-modules-5.11.0-27-generic.
+Preparing to unpack .../17-linux-modules-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-image-5.11.0-27-generic.
+Preparing to unpack .../18-linux-image-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.11.0-27-generic.
+Preparing to unpack .../19-linux-modules-extra-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../20-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../21-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-generic-hwe-20.04-edge.
+Preparing to unpack .../22-linux-image-generic-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-image-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-hwe-5.11-headers-5.11.0-27.
+Preparing to unpack .../23-linux-hwe-5.11-headers-5.11.0-27_5.11.0-27.29~20.04.1_all.deb ...
+Unpacking linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-5.11.0-27-generic.
+Preparing to unpack .../24-linux-headers-5.11.0-27-generic_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-headers-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-20.04-edge.
+Preparing to unpack .../25-linux-headers-generic-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-headers-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-generic-hwe-20.04-edge.
+Preparing to unpack .../26-linux-generic-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../27-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../28-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../29-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../30-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../31-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../32-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~20.04.1) ...
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up linux-headers-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libnl-3-200:amd64 (3.4.0-1) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up linux-headers-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up libnl-genl-3-200:amd64 (3.4.0-1) ...
+Setting up iw (5.4-1) ...
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up crda (3.18-1build1) ...
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.11.0-27-generic
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.11.0-27-generic
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.11.0-27-generic
+I: /boot/initrd.img is now a symlink to initrd.img-5.11.0-27-generic
+Setting up linux-modules-extra-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up linux-image-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Setting up linux-modules-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+Setting up linux-generic-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.11.0-27-generic (5.11.0-27.29~20.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.11.0-27-generic
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.LH71at/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-generic-hwe-20.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:26:30 +0000: Wed, 25 Aug 2021 19:26:30 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.lBmwq1/root.img linux-lowlatency-hwe-20.04-edge /tmp/maas-cloudimg2eph2.lBmwq1/linux-lowlatency-hwe-20.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu focal-backports InRelease
+Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu focal-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 libevdev2
+  libimobiledevice6 libplist3 libupower-glib3 libusbmuxd6 linux-firmware
+  linux-headers-5.11.0-27-lowlatency linux-headers-lowlatency-hwe-20.04-edge
+  linux-hwe-5.11-headers-5.11.0-27 linux-image-5.11.0-27-lowlatency
+  linux-image-lowlatency-hwe-20.04-edge linux-modules-5.11.0-27-lowlatency
+  os-prober thermald upower usbmuxd
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base libusbmuxd-tools fdutils
+  linux-doc | linux-hwe-5.11-source-5.11.0 linux-hwe-5.11-tools
+  linux-modules-extra-5.11.0-27-lowlatency
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 libevdev2 libimobiledevice6 libplist3 libupower-glib3
+  libusbmuxd6 linux-firmware linux-headers-5.11.0-27-lowlatency
+  linux-headers-lowlatency-hwe-20.04-edge linux-hwe-5.11-headers-5.11.0-27
+  linux-image-5.11.0-27-lowlatency linux-image-lowlatency-hwe-20.04-edge
+  linux-lowlatency-hwe-20.04-edge linux-modules-5.11.0-27-lowlatency os-prober
+  thermald upower usbmuxd
+0 upgraded, 27 newly installed, 0 to remove and 0 not upgraded.
+Need to get 198 MB of archives.
+After this operation, 1015 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-common amd64 2.04-1ubuntu26.13 [1875 kB]
+Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub2-common amd64 2.04-1ubuntu26.13 [590 kB]
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc-bin amd64 2.04-1ubuntu26.13 [971 kB]
+Get:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 grub-pc amd64 2.04-1ubuntu26.13 [125 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu focal/main amd64 libdbus-glib-1-2 amd64 0.110-5fakssync1 [59.1 kB]
+Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 libplist3 amd64 2.1.0-4build2 [31.6 kB]
+Get:9 http://archive.ubuntu.com/ubuntu focal/main amd64 libusbmuxd6 amd64 2.0.1-2 [19.1 kB]
+Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libimobiledevice6 amd64 1.2.1~git20191129.9f79242-1build1 [65.2 kB]
+Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 libupower-glib3 amd64 0.99.11-1build2 [43.2 kB]
+Get:12 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-firmware all 1.187.16 [110 MB]
+Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-hwe-5.11-headers-5.11.0-27 all 5.11.0-27.29~20.04.1 [11.6 MB]
+Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [1462 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-headers-lowlatency-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [2524 B]
+Get:16 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-modules-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [57.6 MB]
+Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-5.11.0-27-lowlatency amd64 5.11.0-27.29~20.04.1 [9938 kB]
+Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 intel-microcode amd64 3.20210608.0ubuntu0.20.04.1 [3809 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal/main amd64 amd64-microcode amd64 3.20191218.1ubuntu1 [31.8 kB]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-image-lowlatency-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [2620 B]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-lowlatency-hwe-20.04-edge amd64 5.11.0.27.29~20.04.11 [1896 B]
+Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 os-prober amd64 1.74ubuntu2 [20.1 kB]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev2 amd64 1.9.0+dfsg-1ubuntu0.1 [31.6 kB]
+Get:24 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 thermald amd64 1.9.1-1ubuntu0.5 [233 kB]
+Get:25 http://archive.ubuntu.com/ubuntu focal/main amd64 upower amd64 0.99.11-1build2 [104 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal/main amd64 usbmuxd amd64 1.1.1~git20191130.9af2b12-1 [38.4 kB]
+Get:27 http://archive.ubuntu.com/ubuntu focal/main amd64 cloud-initramfs-rooturl all 0.45ubuntu1 [4420 B]
+Preconfiguring packages ...
+Fetched 198 MB in 11s (17.9 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 31653 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub2-common (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc-bin (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.04-1ubuntu26.13_amd64.deb ...
+Unpacking grub-pc (2.04-1ubuntu26.13) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-5fakssync1_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Selecting previously unselected package libplist3:amd64.
+Preparing to unpack .../07-libplist3_2.1.0-4build2_amd64.deb ...
+Unpacking libplist3:amd64 (2.1.0-4build2) ...
+Selecting previously unselected package libusbmuxd6:amd64.
+Preparing to unpack .../08-libusbmuxd6_2.0.1-2_amd64.deb ...
+Unpacking libusbmuxd6:amd64 (2.0.1-2) ...
+Selecting previously unselected package libimobiledevice6:amd64.
+Preparing to unpack .../09-libimobiledevice6_1.2.1~git20191129.9f79242-1build1_amd64.deb ...
+Unpacking libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Selecting previously unselected package libupower-glib3:amd64.
+Preparing to unpack .../10-libupower-glib3_0.99.11-1build2_amd64.deb ...
+Unpacking libupower-glib3:amd64 (0.99.11-1build2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../11-linux-firmware_1.187.16_all.deb ...
+Unpacking linux-firmware (1.187.16) ...
+Selecting previously unselected package linux-hwe-5.11-headers-5.11.0-27.
+Preparing to unpack .../12-linux-hwe-5.11-headers-5.11.0-27_5.11.0-27.29~20.04.1_all.deb ...
+Unpacking linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-5.11.0-27-lowlatency.
+Preparing to unpack .../13-linux-headers-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-headers-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-20.04-edge.
+Preparing to unpack .../14-linux-headers-lowlatency-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-modules-5.11.0-27-lowlatency.
+Preparing to unpack .../15-linux-modules-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-modules-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package linux-image-5.11.0-27-lowlatency.
+Preparing to unpack .../16-linux-image-5.11.0-27-lowlatency_5.11.0-27.29~20.04.1_amd64.deb ...
+Unpacking linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../17-intel-microcode_3.20210608.0ubuntu0.20.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../18-amd64-microcode_3.20191218.1ubuntu1_amd64.deb ...
+Unpacking amd64-microcode (3.20191218.1ubuntu1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-20.04-edge.
+Preparing to unpack .../19-linux-image-lowlatency-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package linux-lowlatency-hwe-20.04-edge.
+Preparing to unpack .../20-linux-lowlatency-hwe-20.04-edge_5.11.0.27.29~20.04.11_amd64.deb ...
+Unpacking linux-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../21-os-prober_1.74ubuntu2_amd64.deb ...
+Unpacking os-prober (1.74ubuntu2) ...
+Selecting previously unselected package libevdev2:amd64.
+Preparing to unpack .../22-libevdev2_1.9.0+dfsg-1ubuntu0.1_amd64.deb ...
+Unpacking libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../23-thermald_1.9.1-1ubuntu0.5_amd64.deb ...
+Unpacking thermald (1.9.1-1ubuntu0.5) ...
+Selecting previously unselected package upower.
+Preparing to unpack .../24-upower_0.99.11-1build2_amd64.deb ...
+Unpacking upower (0.99.11-1build2) ...
+Selecting previously unselected package usbmuxd.
+Preparing to unpack .../25-usbmuxd_1.1.1~git20191130.9af2b12-1_amd64.deb ...
+Unpacking usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../26-cloud-initramfs-rooturl_0.45ubuntu1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up libplist3:amd64 (2.1.0-4build2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up linux-firmware (1.187.16) ...
+Setting up intel-microcode (3.20210608.0ubuntu0.20.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up linux-hwe-5.11-headers-5.11.0-27 (5.11.0-27.29~20.04.1) ...
+Setting up amd64-microcode (3.20191218.1ubuntu1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up grub-common (2.04-1ubuntu26.13) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-common.service -> /lib/systemd/system/grub-common.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/rescue.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/emergency.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+Created symlink /etc/systemd/system/sleep.target.wants/grub-initrd-fallback.service -> /lib/systemd/system/grub-initrd-fallback.service.
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.45ubuntu1) ...
+Setting up os-prober (1.74ubuntu2) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-5fakssync1) ...
+Setting up libusbmuxd6:amd64 (2.0.1-2) ...
+Setting up libupower-glib3:amd64 (0.99.11-1build2) ...
+Setting up libimobiledevice6:amd64 (1.2.1~git20191129.9f79242-1build1) ...
+Setting up libevdev2:amd64 (1.9.0+dfsg-1ubuntu0.1) ...
+Setting up linux-headers-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Setting up grub2-common (2.04-1ubuntu26.13) ...
+Setting up upower (0.99.11-1build2) ...
+Setting up grub-pc-bin (2.04-1ubuntu26.13) ...
+Setting up usbmuxd (1.1.1~git20191130.9af2b12-1) ...
+Warning: The home dir /var/lib/usbmux you specified can't be accessed: No such file or directory
+Adding system user `usbmux' (UID 112) ...
+Adding new user `usbmux' (UID 112) with group `plugdev' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/lib/usbmux'.
+Setting up thermald (1.9.1-1ubuntu0.5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up linux-headers-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Setting up linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+I: /boot/vmlinuz.old is now a symlink to vmlinuz-5.11.0-27-lowlatency
+I: /boot/initrd.img.old is now a symlink to initrd.img-5.11.0-27-lowlatency
+I: /boot/vmlinuz is now a symlink to vmlinuz-5.11.0-27-lowlatency
+I: /boot/initrd.img is now a symlink to initrd.img-5.11.0-27-lowlatency
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up linux-modules-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+Setting up linux-image-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Setting up grub-pc (2.04-1ubuntu26.13) ...
+
+Creating config file /etc/default/grub with new version
+Setting up linux-lowlatency-hwe-20.04-edge (5.11.0.27.29~20.04.11) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Processing triggers for systemd (245.4-4ubuntu3.11) ...
+Processing triggers for man-db (2.9.1-1) ...
+Processing triggers for dbus (1.12.16-2ubuntu2.1) ...
+Processing triggers for install-info (6.7.0.dfsg.2-5) ...
+Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
+Processing triggers for linux-image-5.11.0-27-lowlatency (5.11.0-27.29~20.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.11.0-27-lowlatency
+cryptsetup: ERROR: Couldn't resolve device 
+    /tmp/mount-image-callback.ZF5Bgk/underlay
+cryptsetup: WARNING: Couldn't determine root device
+W: Couldn't identify type of root file system for fsck hook
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.lBmwq1/linux-lowlatency-hwe-20.04-edge
+   config initrd kernel System.map verflav
+Wed, 25 Aug 2021 19:28:16 +0000: kpacks done
+Wed, 25 Aug 2021 19:28:16 +0000: copying working img into new fs of 1400M (pad=)
+src image uuid=5b31e7f8-0c97-4238-86e0-0f3e7ea0c637 label=cloudimg-rootfs fstype=ext4
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.lBmwq1/root.img.fs_img_size'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+Wed, 25 Aug 2021 19:28:56 +0000: zeroing img
+e2fsck 1.45.5 (07-Jan-2020)
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+cloudimg-rootfs: 39926/327680 files (0.1% non-contiguous), 313450/1310720 blocks
+creating a new squash image in /home/ubuntu/workspace/www/html/images/focal/amd64/20210824/squashfs with ./maas-images/bin/img2squashfs from /tmp/maas-cloudimg2eph2.lBmwq1/root.img
+format of '/tmp/maas-cloudimg2eph2.lBmwq1/root.img' is 'root-image'
+got format 'fs-image' at temp path '/tmp/img2squashfs.mquPl5/fs-image'
+calling mount-image-callback /tmp/img2squashfs.mquPl5/fs-image -- ./maas-images/bin/img2squashfs dir2squashfs _MOUNTPOINT_ /home/ubuntu/workspace/www/html/images/focal/amd64/20210824/squashfs
+Wed, 25 Aug 2021 19:29:04 +0000: starting: mksquashfs /tmp/mount-image-callback.KBR6y8/mp /home/ubuntu/workspace/www/html/images/focal/amd64/20210824/squashfs.img2squashfs.3998942 -xattrs -comp xz
+Parallel mksquashfs: Using 28 processors
+Creating 4.0 filesystem on /home/ubuntu/workspace/www/html/images/focal/amd64/20210824/squashfs.img2squashfs.3998942, block size 131072.
+[===========================================================\] 37188/37188 100%
+
+Exportable Squashfs 4.0 filesystem, xz compressed, data block size 131072
+	compressed data, compressed metadata, compressed fragments,
+	compressed xattrs, compressed ids
+	duplicates are removed
+Filesystem size 394069.25 Kbytes (384.83 Mbytes)
+	39.44% of uncompressed filesystem size (999159.95 Kbytes)
+Inode table size 335954 bytes (328.08 Kbytes)
+	25.00% of uncompressed inode table size (1343918 bytes)
+Directory table size 344966 bytes (336.88 Kbytes)
+	38.23% of uncompressed directory table size (902295 bytes)
+Xattr table size 78 bytes (0.08 Kbytes)
+	97.50% of uncompressed xattr table size (80 bytes)
+Number of duplicate files found 1887
+Number of inodes 39917
+Number of files 31615
+Number of fragments 2034
+Number of symbolic links  4590
+Number of device nodes 9
+Number of fifo nodes 0
+Number of socket nodes 0
+Number of directories 3703
+Number of ids (unique uids + gids) 18
+Number of uids 8
+	root (0)
+	daemon (1)
+	_apt (105)
+	lxd (106)
+	man (6)
+	pollinate (111)
+	sshd (110)
+	syslog (104)
+Number of gids 16
+	root (0)
+	daemon (1)
+	shadow (42)
+	admin (115)
+	tty (5)
+	rdma (105)
+	ssh (114)
+	input (106)
+	utmp (43)
+	staff (50)
+	man (12)
+	messagebus (111)
+	lxd (110)
+	adm (4)
+	systemd-journal (101)
+	mail (8)
+Wed, 25 Aug 2021 19:29:32 +0000: finished: returned 0
+output in /home/ubuntu/workspace/www/html/images/focal/amd64/20210824/squashfs. took 28s.
+Wed, 25 Aug 2021 19:29:32 +0000: finished
+/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-images/meph2/commands/cloudimg_sync.py:273: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
+  cfgdata = yaml.load(fp)
++ meph2-import --proposed --no-sign ./maas-images/conf/bootloaders.yaml ./bootloaders
+Searching focal-proposed, focal-updates, focal-security, focal in components main, universe for pxelinux
+Found pxelinux-3:6.04~git20190206.bf6db5b4+dfsg1-2 in focal
+Searching focal-proposed, focal-updates, focal-security, focal in components main, universe for syslinux-common
+Found syslinux-common-3:6.04~git20190206.bf6db5b4+dfsg1-2 in focal
+Searching focal-proposed, focal-updates, focal-security, focal in components main, universe for pxelinux
+Found pxelinux-3:6.04~git20190206.bf6db5b4+dfsg1-2 in focal
+Searching focal-proposed, focal-updates, focal-security, focal in components main, universe for syslinux-common
+Found syslinux-common-3:6.04~git20190206.bf6db5b4+dfsg1-2 in focal
+Searching focal-proposed, focal-updates, focal-security, focal in components main for shim-signed
+Found shim-signed-1.40.7+15.4-0ubuntu9 in focal-updates
+Searching focal-proposed, focal-updates, focal-security, focal in components main for grub-efi-amd64-signed
+Found grub-efi-amd64-signed-1.167.2+2.04-1ubuntu44.2 in focal-updates
+Found grub-efi-amd64-signed-1.167.2+2.04-1ubuntu44.2 in focal-security
+Searching focal-proposed, focal-updates, focal-security, focal in components main for shim-signed
+Found shim-signed-1.40.7+15.4-0ubuntu9 in focal-updates
+Searching focal-proposed, focal-updates, focal-security, focal in components main for grub-efi-amd64-signed
+Found grub-efi-amd64-signed-1.167.2+2.04-1ubuntu44.2 in focal-updates
+Found grub-efi-amd64-signed-1.167.2+2.04-1ubuntu44.2 in focal-security
+Searching focal-proposed, focal-updates, focal-security, focal in components main for shim-signed
+Found shim-signed-1.40.7+15.4-0ubuntu9 in focal-updates
+Searching focal-proposed, focal-updates, focal-security, focal in components main for grub-efi-arm64-signed
+Found grub-efi-arm64-signed-1.167.2+2.04-1ubuntu44.2 in focal-updates
+Found grub-efi-arm64-signed-1.167.2+2.04-1ubuntu44.2 in focal-security
+Searching focal-proposed, focal-updates, focal-security, focal in components main for shim-signed
+Found shim-signed-1.40.7+15.4-0ubuntu9 in focal-updates
+Searching focal-proposed, focal-updates, focal-security, focal in components main for grub-efi-arm64-signed
+Found grub-efi-arm64-signed-1.167.2+2.04-1ubuntu44.2 in focal-updates
+Found grub-efi-arm64-signed-1.167.2+2.04-1ubuntu44.2 in focal-security
+Searching xenial-proposed, xenial-updates, xenial-security, xenial in components main for grub-ieee1275-bin
+Found grub-ieee1275-bin-2.02~beta2-36ubuntu3.32 in xenial-updates
+Searching xenial-proposed, xenial-updates, xenial-security, xenial in components main for grub-ieee1275-bin
+Found grub-ieee1275-bin-2.02~beta2-36ubuntu3.32 in xenial-updates
+Creating new product com.ubuntu.maas.candidate:1:pxelinux:pxe:i386
+Downloading and creating com.ubuntu.maas.candidate:1:pxelinux:pxe:i386 version 20210825.0
+
+Creating new product com.ubuntu.maas.candidate:1:grub-efi-signed:uefi:amd64
+Downloading and creating com.ubuntu.maas.candidate:1:grub-efi-signed:uefi:amd64 version 20210825.0
+
+Creating new product com.ubuntu.maas.candidate:1:grub-efi:uefi:arm64
+Downloading and creating com.ubuntu.maas.candidate:1:grub-efi:uefi:arm64 version 20210825.0
+
+Creating new product com.ubuntu.maas.candidate:1:grub-ieee1275:open-firmware:ppc64el
+Downloading and creating com.ubuntu.maas.candidate:1:grub-ieee1275:open-firmware:ppc64el version 20210825.0
+
++ meph2-util merge --no-sign ./bootloaders /home/ubuntu/workspace/www/html/images
++ '[' 0 -ge 1 ']'
++ bzr checkout --lightweight 'lp:~maas-maintainers/maas/qa-lab-tests' qa-lab-tests
+The file '/home/ubuntu/.bazaar/authentication.conf' has insecure file permissions. Saved passwords may be accessible by other users.
++ '[' 0 -ge 1 ']'
++ '[' -eq 1 ']'
+/tmp/jenkins941786852071772708.sh: line 94: [: -eq: unary operator expected
++ '[' '!' ']'
++ mv qa-lab-tests/dummy maas
++ UNBUILT_MAAS_TREE=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
++ grep '^package-tree' /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/Makefile
+grep: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/Makefile: No such file or directory
++ mv qa-lab-tests /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/tests
+++ git -C maas rev-list --count
+fatal: not a git repository (or any of the parent directories): .git
++ export MAAS_BRANCH_REVNO_COUNT=
++ MAAS_BRANCH_REVNO_COUNT=
+++ git -C maas rev-parse --short
+fatal: not a git repository (or any of the parent directories): .git
++ export MAAS_BRANCH_REVNO=
++ MAAS_BRANCH_REVNO=
++ export VER_FOR_PKG=-g
++ VER_FOR_PKG=-g
++ git clone git+ssh://git.launchpad.net/~maas-committers/maas-ci/+git/maas-ci-config
+Cloning into 'maas-ci-config'...
++ source maas-ci-config/maas-ci-common
+++ AUTOPKGTEST_ROOT=/home/ubuntu/autopkgtest
+++ MAAS_CI_ROOT=/home/ubuntu/maas-ci
+++ ADT_IMAGES_ROOT=/home/ubuntu/images
++ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/tests/update_changelog.py /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/changelog -g ci
++ SETUP_COMMANDS='export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128'
++ '[' '!' -z ']'
++ '[' '!' -z ']'
++ '[' '!' -z ']'
++ SETUP_COMMANDS='export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'
++ PACKAGES_FROM_PROPOSED=
++ '[' -eq 1 ']'
+/tmp/jenkins941786852071772708.sh: line 153: [: -eq: unary operator expected
++ '[' -eq 1 ']'
+/tmp/jenkins941786852071772708.sh: line 155: [: -eq: unary operator expected
++ '[' -eq 0 ']'
+/tmp/jenkins941786852071772708.sh: line 157: [: -eq: unary operator expected
++ QEMU_CFG=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg
++ QEMU_IMG=/home/ubuntu/images/autopkgtest-bionic-amd64.img
++ '[' ']'
++ echo running with Curtin from archive
+running with Curtin from archive
++ /home/ubuntu/autopkgtest/runner/autopkgtest -U -ddd --output-dir /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results --env DEPLOYMENT_RELEASE=bionic --env TEST_JUJU= --env TEST_CENTOS=0 --env TEST_RHEL= --env TEST_WINDOWS= --env TEST_CUSTOM_IMAGES=1 --env USE_PPC_NODES=0 --env USE_ARM64_NODES=0 --env KEEP_CI_RUNNING=0 --env PAUSE_CI=0 --env TEST_PERFORMANCE=0 --env DEBUG= --env SLAVE_NODE=HP-DL360-Gen9 '--setup-commands=export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update' --timeout-test=20000 /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas -- /home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu -d --show-boot --ram-size 8192 --qemu-options '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg' /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest: DBG: autopkgtest options: Namespace(add_apt_releases=[], add_apt_sources=[], apt_default_release=None, apt_pocket=[], auto_control=True, build_parallel=None, built_binaries=True, copy=[], enable_apt_fallback=True, env=['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9'], gainroot=None, ignore_restrictions=[], installed_click=None, logfile=None, needs_internet='run', output_dir='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results', override_control=None, packages=['/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas'], pin_packages=[], set_lang=None, setup_commands=['(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew" && $(which eatmydata || true) apt-get --purge autoremove -y', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], setup_commands_boot=[], shell=False, shell_fail=False, summary=None, testname=None, timeout_build=None, timeout_copy=None, timeout_factor=1.0, timeout_install=None, timeout_short=None, timeout_test=20000, user=None, validate=False, verbosity=2)
+autopkgtest: DBG: virt-runner arguments: ['/home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu', '-d', '--show-boot', '--ram-size', '8192', '--qemu-options', '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg', '/home/ubuntu/images/autopkgtest-bionic-amd64.img']
+autopkgtest: DBG: actions: [('unbuilt-tree', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas', True)]
+autopkgtest: DBG: build binaries: True
+autopkgtest: DBG: testbed init
+autopkgtest [19:30:50]: starting date: 2021-08-25
+autopkgtest [19:30:50]: git checkout: d4b51aa setup-testbed: Setup Acquire::Retries 10, like debci does
+autopkgtest [19:30:50]: host jenkins-slave-2; command line: /home/ubuntu/autopkgtest/runner/autopkgtest -U -ddd --output-dir /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results --env DEPLOYMENT_RELEASE=bionic --env TEST_JUJU= --env TEST_CENTOS=0 --env TEST_RHEL= --env TEST_WINDOWS= --env TEST_CUSTOM_IMAGES=1 --env USE_PPC_NODES=0 --env USE_ARM64_NODES=0 --env KEEP_CI_RUNNING=0 --env PAUSE_CI=0 --env TEST_PERFORMANCE=0 --env DEBUG= --env SLAVE_NODE=HP-DL360-Gen9 '--setup-commands=export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update' --timeout-test=20000 /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas -- /home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu -d --show-boot --ram-size 8192 --qemu-options '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg' /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed open, scratch=None
+autopkgtest: DBG: sending command to testbed: open
+autopkgtest-virt-qemu: DBG: executing open
+autopkgtest-virt-qemu: DBG: find_free_port: trying 10022
+autopkgtest-virt-qemu: DBG: find_free_port: 10022 is free
+autopkgtest-virt-qemu: DBG: qemu architecture: x86_64
+autopkgtest-virt-qemu: DBG: qemu command: qemu-system-x86_64
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img info --output=json /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest-virt-qemu: DBG: Creating temporary overlay image in /tmp/autopkgtest-qemu.18dmni1z/overlay.img
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img create -f qcow2 -F qcow2 -b /home/ubuntu/images/autopkgtest-bionic-amd64.img /tmp/autopkgtest-qemu.18dmni1z/overlay.img
+autopkgtest-virt-qemu: DBG: Forwarding local port 10022 to VM ssh port 22
+autopkgtest-virt-qemu: DBG: Assuming nothing special needs to be done to set up firmware to boot this machine (boot method: bios)
+autopkgtest-virt-qemu: DBG: Detected KVM capable Intel host CPU, enabling nested KVM
+autopkgtest-virt-qemu: DBG: full qemu command-line: ['qemu-system-x86_64', '-m', '8192', '-smp', '1', '-nographic', '-net', 'nic,model=virtio', '-net', 'user,hostfwd=tcp:127.0.0.1:10022-:22', '-object', 'rng-random,filename=/dev/urandom,id=rng0', '-device', 'virtio-rng-pci,rng=rng0,id=rng-device0', '-monitor', 'unix:/tmp/autopkgtest-qemu.18dmni1z/monitor,server,nowait', '-virtfs', 'local,id=autopkgtest,path=/tmp/autopkgtest-qemu.18dmni1z/shared,security_model=none,mount_tag=autopkgtest', '-chardev', 'socket,path=/tmp/autopkgtest-qemu.18dmni1z/hvc0,server,nowait,id=hvc0', '-device', 'virtio-serial', '-device', 'virtconsole,chardev=hvc0', '-chardev', 'socket,path=/tmp/autopkgtest-qemu.18dmni1z/hvc1,server,nowait,id=hvc1', '-device', 'virtio-serial', '-device', 'virtconsole,chardev=hvc1', '-serial', 'unix:/tmp/autopkgtest-qemu.18dmni1z/ttyS0,server,nowait', '-serial', 'unix:/tmp/autopkgtest-qemu.18dmni1z/ttyS1,server,nowait', '-drive', 'index=0,file=/tmp/autopkgtest-qemu.18dmni1z/overlay.img,cache=unsafe,if=virtio,discard=unmap,format=qcow2', '-enable-kvm', '-cpu', 'kvm64,+vmx,+lahf_lm', '-readconfig', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg']
+autopkgtest-virt-qemu: DBG: expect: b' login: '
+c[?7l[2J[0mSeaBIOS (version 1.13.0-1ubuntu1.1)
+
+
+iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+BFF8C740+BFECC740 CA00
+Press Ctrl-B to configure iPXE (PCI 00:03.0)...                                                                               
+
+
+
+
+iPXE (http://ipxe.org) 00:08.0 CB00 PCI2.10 PnP PMM BFF8C740 BFECC740 CB00
+Press Ctrl-B to configure iPXE (PCI 00:08.0)...                                                                               
+
+
+Booting from Hard Disk...
+[    0.000000] Linux version 4.15.0-144-generic (buildd@lgw01-amd64-031) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #148-Ubuntu SMP Sat May 8 02:33:43 UTC 2021 (Ubuntu 4.15.0-144.148-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-144-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffdcfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffdd000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000023fffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.13.0-1ubuntu1.1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0x240000 max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] e820: last_pfn = 0xbffdd max_arch_pfn = 0x400000000
+[    0.000000] found SMP MP-table at [mem 0x000f5c70-0x000f5c7f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x32e6d000-0x3572dfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F5A80 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE17FE 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE16A2 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001662 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE1716 0000B0 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE17C6 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x000000023fffffff]
+[    0.000000] NODE_DATA(0) allocated [mem 0x23ffd1000-0x23fffbfff]
+[    0.000000] kvm-clock: cpu 0, msr 2:3ff50001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 6367386057 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffdcfff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x000000023fffffff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xbffdd000-0xbfffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xc0000000-0xfeffbfff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfeffc000-0xfeffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xff000000-0xfffbffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfffc0000-0xffffffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x500 with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:8 nr_cpu_ids:8 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u262144
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr 23fc23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2064230
+[    0.000000] Policy zone: Normal
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-144-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 8118728K/8388076K available (12300K kernel code, 2483K rwdata, 4316K rodata, 2448K init, 2724K bss, 269348K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39453 entries in 155 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=8.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+[    0.004000] NR_IRQS: 524544, nr_irqs: 488, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [tty0] enabled
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004020] APIC: Switch to symmetric I/O mode setup
+[    0.005308] x2apic enabled
+[    0.006243] Switched APIC routing to physical x2apic.
+[    0.008000] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.202 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.40 BogoMIPS (lpj=9588808)
+[    0.008003] pid_max: default: 32768 minimum: 301
+[    0.009008] Security Framework initialized
+[    0.009844] Yama: becoming mindful.
+[    0.010626] AppArmor: AppArmor initialized
+[    0.013568] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.016195] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.017728] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.019230] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.020280] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.021345] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.022509] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.024003] Spectre V2 : Mitigation: Full generic retpoline
+[    0.025087] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.028002] Speculative Store Bypass: Vulnerable
+[    0.028964] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.030360] Freeing SMP alternatives memory: 36K
+[    0.141733] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.143407] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.144000] Hierarchical SRCU implementation.
+[    0.144604] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.145976] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.147250] smp: Bringing up secondary CPUs ...
+[    0.148096] x86: Booting SMP configuration:
+[    0.148898] .... node  #0, CPUs:      #1
+[    0.004000] kvm-clock: cpu 1, msr 2:3ff50041, secondary cpu clock
+[    0.164049] KVM setup async PF for cpu 1
+[    0.165818] kvm-stealtime: cpu 1, msr 23fc63040
+[    0.168099]  #2
+[    0.004000] kvm-clock: cpu 2, msr 2:3ff50081, secondary cpu clock
+[    0.184025] KVM setup async PF for cpu 2
+[    0.185402] kvm-stealtime: cpu 2, msr 23fca3040
+[    0.186944]  #3
+[    0.004000] kvm-clock: cpu 3, msr 2:3ff500c1, secondary cpu clock
+[    0.202175] KVM setup async PF for cpu 3
+[    0.202175] kvm-stealtime: cpu 3, msr 23fce3040
+[    0.204157]  #4
+[    0.004000] kvm-clock: cpu 4, msr 2:3ff50101, secondary cpu clock
+[    0.220033] KVM setup async PF for cpu 4
+[    0.222071] kvm-stealtime: cpu 4, msr 23fd23040
+[    0.224170]  #5
+[    0.004000] kvm-clock: cpu 5, msr 2:3ff50141, secondary cpu clock
+[    0.240033] KVM setup async PF for cpu 5
+[    0.242120] kvm-stealtime: cpu 5, msr 23fd63040
+[    0.244106]  #6
+[    0.004000] kvm-clock: cpu 6, msr 2:3ff50181, secondary cpu clock
+[    0.260032] KVM setup async PF for cpu 6
+[    0.261951] kvm-stealtime: cpu 6, msr 23fda3040
+[    0.264105]  #7
+[    0.004000] kvm-clock: cpu 7, msr 2:3ff501c1, secondary cpu clock
+[    0.280017] KVM setup async PF for cpu 7
+[    0.280973] kvm-stealtime: cpu 7, msr 23fde3040
+[    0.282035] smp: Brought up 1 node, 8 CPUs
+[    0.284005] smpboot: Max logical packages: 1
+[    0.284822] smpboot: Total of 8 processors activated (38355.23 BogoMIPS)
+[    0.288096] devtmpfs: initialized
+[    0.288728] x86/mm: Memory block size: 128MB
+[    0.290065] evm: security.selinux
+[    0.290727] evm: security.SMACK64
+[    0.291395] evm: security.SMACK64EXEC
+[    0.292008] evm: security.SMACK64TRANSMUTE
+[    0.292794] evm: security.SMACK64MMAP
+[    0.293527] evm: security.apparmor
+[    0.294199] evm: security.ima
+[    0.294802] evm: security.capability
+[    0.296076] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.300039] futex hash table entries: 2048 (order: 5, 131072 bytes)
+[    0.300101] pinctrl core: initialized pinctrl subsystem
+[    0.304161] RTC time: 19:30:58, date: 08/25/21
+[    0.305579] NET: Registered protocol family 16
+[    0.306734] audit: initializing netlink subsys (disabled)
+[    0.312070] audit: type=2000 audit(1629919858.575:1): state=initialized audit_enabled=0 res=1
+[    0.316027] cpuidle: using governor ladder
+[    0.317498] cpuidle: using governor menu
+[    0.317722] ACPI: bus type PCI registered
+[    0.318848] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.320130] PCI: Using configuration type 1 for base access
+[    0.324599] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.328153] ACPI: Added _OSI(Module Device)
+[    0.329555] ACPI: Added _OSI(Processor Device)
+[    0.331090] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.332013] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.333758] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.336006] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.337697] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.342610] ACPI: Interpreter enabled
+[    0.344033] ACPI: (supports S0 S3 S4 S5)
+[    0.345389] ACPI: Using IOAPIC for interrupt routing
+[    0.346923] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.348281] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.357717] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.359620] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.360016] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.362051] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.368576] acpiphp: Slot [3] registered
+[    0.368576] acpiphp: Slot [4] registered
+[    0.369389] acpiphp: Slot [5] registered
+[    0.370880] acpiphp: Slot [6] registered
+[    0.372077] acpiphp: Slot [7] registered
+[    0.373457] acpiphp: Slot [8] registered
+[    0.376084] acpiphp: Slot [9] registered
+[    0.377537] acpiphp: Slot [10] registered
+[    0.379052] acpiphp: Slot [11] registered
+[    0.380080] acpiphp: Slot [12] registered
+[    0.381531] acpiphp: Slot [13] registered
+[    0.382850] acpiphp: Slot [14] registered
+[    0.384079] acpiphp: Slot [15] registered
+[    0.385504] acpiphp: Slot [16] registered
+[    0.387002] acpiphp: Slot [17] registered
+[    0.388099] acpiphp: Slot [18] registered
+[    0.389945] acpiphp: Slot [19] registered
+[    0.392099] acpiphp: Slot [20] registered
+[    0.393994] acpiphp: Slot [21] registered
+[    0.396110] acpiphp: Slot [22] registered
+[    0.398120] acpiphp: Slot [23] registered
+[    0.400086] acpiphp: Slot [24] registered
+[    0.402106] acpiphp: Slot [25] registered
+[    0.404045] acpiphp: Slot [26] registered
+[    0.405021] acpiphp: Slot [27] registered
+[    0.405979] acpiphp: Slot [28] registered
+[    0.408043] acpiphp: Slot [29] registered
+[    0.409022] acpiphp: Slot [30] registered
+[    0.409978] acpiphp: Slot [31] registered
+[    0.410924] PCI host bridge to bus 0000:00
+[    0.412014] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.413603] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.415164] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.416003] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.417806] pci_bus 0000:00: root bus resource [mem 0x240000000-0x2bfffffff window]
+[    0.420004] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.428439] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.430088] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.432006] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.434406] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.434406] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.435372] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.526501] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.528160] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.529685] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.531325] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.532081] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.534228] SCSI subsystem initialized
+[    0.536174] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.537681] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.540006] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.541315] vgaarb: loaded
+[    0.542035] ACPI: bus type USB registered
+[    0.543045] usbcore: registered new interface driver usbfs
+[    0.544018] usbcore: registered new interface driver hub
+[    0.545272] usbcore: registered new device driver usb
+[    0.548030] EDAC MC: Ver: 3.0.0
+[    0.548267] PCI: Using ACPI for IRQ routing
+[    0.549449] NetLabel: Initializing
+[    0.550284] NetLabel:  domain hash size = 128
+[    0.552003] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.553586] NetLabel:  unlabeled traffic allowed by default
+[    0.556076] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.557706] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.558861] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.564131] clocksource: Switched to clocksource kvm-clock
+[    0.577281] VFS: Disk quotas dquot_6.6.0
+[    0.578309] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.579980] AppArmor: AppArmor Filesystem Enabled
+[    0.581171] pnp: PnP ACPI init
+[    0.582516] pnp: PnP ACPI: found 7 devices
+[    0.590841] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.592843] NET: Registered protocol family 2
+[    0.594041] TCP established hash table entries: 65536 (order: 7, 524288 bytes)
+[    0.595732] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
+[    0.597222] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.598636] UDP hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.599943] UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.601702] NET: Registered protocol family 1
+[    0.602697] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.603962] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.605219] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.606579] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.608668] Unpacking initramfs...
+[    1.227261] Freeing initrd memory: 41732K
+[    1.228352] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.229746] software IO TLB: mapped [mem 0xbbfdd000-0xbffdd000] (64MB)
+[    1.231196] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228de43df3e, max_idle_ns: 440795235278 ns
+[    1.233549] Scanning for low memory corruption every 60 seconds
+[    1.235725] Initialise system trusted keyrings
+[    1.236766] Key type blacklist registered
+[    1.238070] workingset: timestamp_bits=36 max_order=21 bucket_order=0
+[    1.240503] zbud: loaded
+[    1.241874] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.243519] fuse init (API version 7.26)
+[    1.247922] Key type asymmetric registered
+[    1.248904] Asymmetric key parser 'x509' registered
+[    1.250044] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    1.251870] io scheduler noop registered
+[    1.252823] io scheduler deadline registered
+[    1.253921] io scheduler cfq registered (default)
+[    1.255614] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    1.257491] ACPI: Power Button [PWRF]
+[    1.284530] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    1.312332] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    1.340602] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    1.368931] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    1.447379] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.472962] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.499692] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.528465] console [hvc0] enabled
+[    1.577113] Linux agpgart interface v0.103
+[    1.583471] loop: module loaded
+[    1.586597] scsi host0: ata_piix
+[    1.587832] scsi host1: ata_piix
+[    1.588750] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc1a0 irq 14
+[    1.590280] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc1a8 irq 15
+[    1.591928] libphy: Fixed MDIO Bus: probed
+[    1.593009] tun: Universal TUN/TAP device driver, 1.6
+[    1.594402] PPP generic driver version 2.4.2
+[    1.595585] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.597150] ehci-pci: EHCI PCI platform driver
+[    1.598178] ehci-platform: EHCI generic platform driver
+[    1.599374] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.600728] ohci-pci: OHCI PCI platform driver
+[    1.601809] ohci-platform: OHCI generic platform driver
+[    1.603015] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.604521] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.607102] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.608309] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.609699] mousedev: PS/2 mouse device common for all mice
+[    1.611559] rtc_cmos 00:00: RTC can wake from S4
+[    1.611580] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    1.614793] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    1.618606] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    1.621220] i2c /dev entries driver
+[    1.622636] device-mapper: uevent: version 1.0.3
+[    1.624512] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    1.632715] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.635276] NET: Registered protocol family 10
+[    1.644210] Segment Routing with IPv6
+[    1.646330] NET: Registered protocol family 17
+[    1.648896] Key type dns_resolver registered
+[    1.651547] mce: Using 10 MCE banks
+[    1.652779] RAS: Correctable Errors collector initialized.
+[    1.654479] sched_clock: Marking stable (1652745849, 0)->(2005111289, -352365440)
+[    1.657591] registered taskstats version 1
+[    1.659063] Loading compiled-in X.509 certificates
+[    1.665621] Loaded X.509 cert 'Build time autogenerated kernel key: 1e5516648b223d94d04ce7d99e6048c9b3ebcb77'
+[    1.668915] Loaded X.509 cert 'Canonical Ltd. Live Patch Signing: 14df34d1a87cf37625abec039ef2bf521249b969'
+[    1.672034] Loaded X.509 cert 'Canonical Ltd. Kernel Module Signing: 88f752e560a1e0737e31163a466ad7b70a850c19'
+[    1.674602] zswap: loaded using pool lzo/zbud
+[    1.682449] Key type big_key registered
+[    1.683688] Key type trusted registered
+[    1.688474] Key type encrypted registered
+[    1.689699] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.691358] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    1.693255] ima: Allocated hash algorithm: sha1
+[    1.694563] evm: HMAC attrs: 0x1
+[    1.696231]   Magic number: 1:386:547
+[    1.697375] tty ttyS23: hash matches
+[    1.698601] rtc_cmos 00:00: setting system clock to 2021-08-25 19:30:59 UTC (1629919859)
+[    1.701054] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    1.702641] EDD information not available.
+[    1.754001] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.758142] ata2.00: configured for MWDMA2
+[    1.761877] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.793090] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.795640] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.798061] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.806353] Freeing unused kernel image memory: 2448K
+[    1.816104] Write protecting the kernel read-only data: 20480k
+[    1.821626] Freeing unused kernel image memory: 2008K
+[    1.824049] Freeing unused kernel image memory: 1828K
+[    1.835666] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.837531] x86/mm: Checking user space page tables
+[    1.846276] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.949040] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.953308] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.958293]  vda: vda1 vda14 vda15
+[    1.960753] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.963417] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.969266] FDC 0 is a S82078B
+[    1.975380] virtio_net virtio0 ens3: renamed from eth0
+[    1.996375] virtio_net virtio5 ens8: renamed from eth1
+[    2.048154] print_req_error: I/O error, dev fd0, sector 0
+[    2.050984] floppy: error 10 while reading block 0
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    2.164077] raid6: sse2x1   gen()  5931 MB/s
+[    2.212038] raid6: sse2x1   xor()  2795 MB/s
+[    2.260107] raid6: sse2x2   gen()  4845 MB/s
+[    2.308081] raid6: sse2x2   xor()  6052 MB/s
+[    2.356085] raid6: sse2x4   gen() 11530 MB/s
+[    2.404081] raid6: sse2x4   xor()  7165 MB/s
+[    2.405306] raid6: using algorithm sse2x4 gen() 11530 MB/s
+[    2.406684] raid6: .... xor() 7165 MB/s, rmw enabled
+[    2.407974] raid6: using intx1 recovery algorithm
+[    2.412770] xor: measuring software checksum speed
+[    2.452077]    prefetch64-sse: 14613.000 MB/sec
+[    2.492074]    generic_sse: 13399.000 MB/sec
+[    2.493313] xor: using function: prefetch64-sse (14613.000 MB/sec)
+[    2.512915] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    2.652135] print_req_error: I/O error, dev fd0, sector 0
+[    2.654394] floppy: error 10 while reading block 0
+done.
+Begin: Will now check root file system ... fsck from util-linux 2.31.1
+[/sbin/fsck.ext4 (1) -- /dev/vda1] fsck.ext4 -a -C0 /dev/vda1 
+cloudimg-rootfs: clean, 67053/8015616 files, 1399457/16276731 blocks
+done.
+[    2.697892] random: fast init done
+[    2.699976] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+[    2.700830] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+[    2.702365] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... [    2.708077] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+done.
+[    3.300839] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    3.324292] random: crng init done
+[    3.353632] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    3.362457] systemd[1]: Detected virtualization kvm.
+[    3.363850] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.5 LTS[0m!
+
+[    3.372582] systemd[1]: Set hostname to <autopkgtest>.
+[    3.603416] systemd[1]: Reached target Swap.
+[[0;32m  OK  [0m] Reached target Swap.
+[    3.606668] systemd[1]: Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[    3.611696] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[    3.617899] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    3.620677] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    3.623138] systemd[1]: Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Created slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Created slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Starting Create list of required st…ce nodes for the current kernel...
+         Starting Set the console keyboard layout...
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Listening on fsck to fsckd communication Socket.
+         Starting Uncomplicated firewall...
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+         Mounting Kernel Debug File System...
+         Mounting POSIX Message Queue File System...
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+         Starting Remount Root and Kernel File Systems...
+[[0;32m  OK  [0m] Set up automount Arbitrary Executab…rmats File System Automount Point.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[    3.667055] EXT4-fs (vda1): re-mounted. Opts: (null)
+         Starting Journal Service...
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+         Starting udev Coldplug all Devices...
+         Mounting Huge Pages File System...
+[[0;32m  OK  [0m] Started Create list of required sta…vice nodes for the current kernel.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+         Starting Load/Save Random Seed...
+         Mounting Kernel Configuration File System...
+         Mounting FUSE Control File System...
+         Starting Apply Kernel Variables...
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Started Journal Service.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[    3.904050] print_req_error: I/O error, dev fd0, sector 0
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+         Starting File System Check on /dev/disk/by-label/UEFI...
+[[0;32m  OK  [0m] Found device /dev/hvc0.
+[[0;32m  OK  [0m] Started File System Check Daemon to report status.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started File System Check on /dev/disk/by-label/UEFI.
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting AppArmor initialization...
+         Starting Create Volatile Files and Directories...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting Set console font and keymap...
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Network Name Resolution...
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Started Ubuntu Advantage update messaging.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+[[0;32m  OK  [0m] Started autopkgtest root shell on hvc1.
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting LSB: Record successful boot for GRUB...
+         Starting LSB: automatic crash report generation...
+[[0;32m  OK  [0m] Started irqbalance daemon.
+         Starting OpenBSD Secure Shell server...
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting Thermal Daemon Service...
+         Starting Permit User Sessions...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+         Starting rng-tools.service...
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Reached target Timers.
+         Starting System Logging Service...
+         Starting Login Service...
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started rng-tools.service.
+         Starting Message of the Day...
+         Starting Daily apt download activities...
+         Starting Discard unused blocks...
+         Starting Ubuntu Advantage APT and MOTD Messages...
+         Starting Terminate Plymouth Boot Screen...
+         Starting Hold until boot process finishes up...
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started Discard unused blocks.
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Login Service.
+[[0;32m  OK  [0m] Started Serial Getty on hvc0.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+         Starting Daily apt upgrade and clean activities...
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Started Ubuntu Advantage APT and MOTD Messages.
+
+Ubuntu 18.04.5 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found "'login prompt on serial console'"
+autopkgtest-virt-qemu: DBG: expect: b'ok'
+autopkgtest-virt-qemu: DBG: expect: found "b'ok'"
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on hvc1
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[1]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[1]'"
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[2]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[2]'"
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[3]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[3]'"
+autopkgtest-virt-qemu: DBG: Copying host timezone Etc/UTC to VM
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[4]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[4]'"
+autopkgtest-virt-qemu: DBG: expect: b'/python'
+autopkgtest-virt-qemu: DBG: expect: found "b'/python'"
+autopkgtest-virt-qemu: DBG: expect: b'# '
+autopkgtest-virt-qemu: DBG: expect: found "b'# '"
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[5]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[5]'"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd true
+autopkgtest-virt-qemu: DBG: can connect to autopkgtest sh in VM
+autopkgtest-virt-qemu: DBG: expect: b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[6]'
+autopkgtest-virt-qemu: DBG: expect: found "b'fc5a656a-fdc1-42b2-b6c5-0e8f916c2cca[6]'"
+autopkgtest-virt-qemu: DBG: determine_normal_user: got user "ubuntu"
+autopkgtest-virt-qemu: DBG: auxverb = ['/tmp/autopkgtest-qemu.18dmni1z/runcmd'], downtmp = None
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd mktemp --directory --tmpdir autopkgtest.XXXXXX
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd chmod 1777 /tmp/autopkgtest.dn9EKj
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest.dn9EKj
+autopkgtest: DBG: sending command to testbed: print-execute-command
+autopkgtest-virt-qemu: DBG: executing print-execute-command
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest-qemu.18dmni1z/runcmd
+autopkgtest: DBG: sending command to testbed: capabilities
+autopkgtest-virt-qemu: DBG: executing capabilities
+autopkgtest: DBG: got reply from testbed: ok revert revert-full-system root-on-testbed isolation-machine reboot suggested-normal-user=ubuntu
+autopkgtest: DBG: testbed capabilities: ['revert', 'revert-full-system', 'root-on-testbed', 'isolation-machine', 'reboot', 'suggested-normal-user=ubuntu', 'has_internet']
+autopkgtest [19:31:12]: @@@@@@@@@@@@@@@@@@@@ test bed setup
+autopkgtest: DBG: testbed command ['bash', '-ec', 'for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do [ ! -d $d ] || touch -r $d /tmp/autopkgtest.dn9EKj/${d//\\//_}.stamp; done'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew" && $(which eatmydata || true) apt-get --purge autoremove -y'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [419 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2,191 kB]
+Get:7 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [20.9 kB]
+Get:8 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [1,845 kB]
+Get:9 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1,136 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [443 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,747 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [27.3 kB]
+Fetched 8,081 kB in 8s (1,048 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following packages were automatically installed and are no longer required:
+  python3-configobj python3-serial
+Use 'apt autoremove' to remove them.
+The following NEW packages will be installed:
+  linux-headers-4.15.0-154 linux-headers-4.15.0-154-generic
+  linux-image-4.15.0-154-generic linux-modules-4.15.0-154-generic
+  linux-modules-extra-4.15.0-154-generic
+The following packages will be upgraded:
+  apt apt-utils curl distro-info-data grub-efi-amd64-bin grub-efi-amd64-signed
+  gzip initramfs-tools initramfs-tools-bin initramfs-tools-core libapt-inst2.0
+  libapt-pkg5.0 libcurl4 libhogweed4 libnettle6 libnss-systemd libpam-systemd
+  libssl1.1 libsystemd0 libudev1 libxml2 linux-base linux-generic
+  linux-headers-generic linux-headers-virtual linux-image-generic
+  linux-image-virtual linux-virtual openssh-client openssh-server
+  openssh-sftp-server openssl systemd systemd-sysv ubuntu-advantage-tools udev
+  wireless-regdb
+37 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
+Need to get 80.5 MB of archives.
+After this operation, 351 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gzip amd64 1.6-5ubuntu1.1 [89.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss-systemd amd64 237-3ubuntu10.51 [105 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsystemd0 amd64 237-3ubuntu10.51 [207 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpam-systemd amd64 237-3ubuntu10.51 [107 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd amd64 237-3ubuntu10.51 [2,913 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 udev amd64 237-3ubuntu10.51 [1,102 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libudev1 amd64 237-3ubuntu10.51 [56.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools all 0.130ubuntu3.13 [9,608 B]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-core all 0.130ubuntu3.13 [49.0 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-bin amd64 0.130ubuntu3.13 [10.9 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-base all 4.5ubuntu1.6 [17.9 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd-sysv amd64 237-3ubuntu10.51 [13.9 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-pkg5.0 amd64 1.6.14 [809 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-inst2.0 amd64 1.6.14 [57.3 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt amd64 1.6.14 [1,207 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt-utils amd64 1.6.14 [209 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnettle6 amd64 3.4.1-0ubuntu0.18.04.1 [111 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libhogweed4 amd64 3.4.1-0ubuntu0.18.04.1 [140 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.11 [4,652 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.13 [1,302 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxml2 amd64 2.9.4+dfsg1-6.1ubuntu1.4 [664 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssl amd64 1.1.1-1ubuntu2.1~18.04.13 [614 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ubuntu-advantage-tools amd64 27.2.2~18.04.1 [686 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-sftp-server amd64 1:7.6p1-4ubuntu0.5 [45.5 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-server amd64 1:7.6p1-4ubuntu0.5 [332 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-client amd64 1:7.6p1-4ubuntu0.5 [612 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 curl amd64 7.58.0-2ubuntu3.14 [159 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4 amd64 7.58.0-2ubuntu3.14 [219 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-signed amd64 1.167~18.04.5+2.04-1ubuntu44.1.2 [481 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-bin amd64 2.04-1ubuntu44.1.2 [726 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-4.15.0-154-generic amd64 4.15.0-154.161 [13.4 MB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-4.15.0-154-generic amd64 4.15.0-154.161 [8,092 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-4.15.0-154-generic amd64 4.15.0-154.161 [33.7 MB]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic amd64 4.15.0.154.143 [1,864 B]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic amd64 4.15.0.154.143 [2,536 B]
+Get:36 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-virtual amd64 4.15.0.154.143 [1,860 B]
+Get:37 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-virtual amd64 4.15.0.154.143 [2,512 B]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-virtual amd64 4.15.0.154.143 [1,840 B]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-154 all 4.15.0-154.161 [10.9 MB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-154-generic amd64 4.15.0-154.161 [1,256 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic amd64 4.15.0.154.143 [2,440 B]
+Get:42 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~18.04.1 [10.1 kB]
+Preconfiguring packages ...
+Fetched 80.5 MB in 4s (20.8 MB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../gzip_1.6-5ubuntu1.1_amd64.deb ...
+Unpacking gzip (1.6-5ubuntu1.1) over (1.6-5ubuntu1) ...
+Setting up gzip (1.6-5ubuntu1.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../libnss-systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking libnss-systemd:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libsystemd0_237-3ubuntu10.51_amd64.deb ...
+Unpacking libsystemd0:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Setting up libsystemd0:amd64 (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../libpam-systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking libpam-systemd:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking systemd (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../udev_237-3ubuntu10.51_amd64.deb ...
+Unpacking udev (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libudev1_237-3ubuntu10.51_amd64.deb ...
+Unpacking libudev1:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Setting up libudev1:amd64 (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../initramfs-tools_0.130ubuntu3.13_all.deb ...
+Unpacking initramfs-tools (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../initramfs-tools-core_0.130ubuntu3.13_all.deb ...
+Unpacking initramfs-tools-core (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../initramfs-tools-bin_0.130ubuntu3.13_amd64.deb ...
+Unpacking initramfs-tools-bin (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../linux-base_4.5ubuntu1.6_all.deb ...
+Unpacking linux-base (4.5ubuntu1.6) over (4.5ubuntu1.2) ...
+Setting up systemd (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../systemd-sysv_237-3ubuntu10.51_amd64.deb ...
+Unpacking systemd-sysv (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libapt-pkg5.0_1.6.14_amd64.deb ...
+Unpacking libapt-pkg5.0:amd64 (1.6.14) over (1.6.13) ...
+Setting up libapt-pkg5.0:amd64 (1.6.14) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../libapt-inst2.0_1.6.14_amd64.deb ...
+Unpacking libapt-inst2.0:amd64 (1.6.14) over (1.6.13) ...
+Preparing to unpack .../archives/apt_1.6.14_amd64.deb ...
+Unpacking apt (1.6.14) over (1.6.13) ...
+Setting up apt (1.6.14) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../apt-utils_1.6.14_amd64.deb ...
+Unpacking apt-utils (1.6.14) over (1.6.13) ...
+Preparing to unpack .../libnettle6_3.4.1-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libnettle6:amd64 (3.4.1-0ubuntu0.18.04.1) over (3.4-1ubuntu0.1) ...
+Setting up libnettle6:amd64 (3.4.1-0ubuntu0.18.04.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../libhogweed4_3.4.1-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libhogweed4:amd64 (3.4.1-0ubuntu0.18.04.1) over (3.4-1ubuntu0.1) ...
+Setting up libhogweed4:amd64 (3.4.1-0ubuntu0.18.04.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../00-distro-info-data_0.37ubuntu0.11_all.deb ...
+Unpacking distro-info-data (0.37ubuntu0.11) over (0.37ubuntu0.10) ...
+Preparing to unpack .../01-libssl1.1_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.9) ...
+Preparing to unpack .../02-libxml2_2.9.4+dfsg1-6.1ubuntu1.4_amd64.deb ...
+Unpacking libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.4) over (2.9.4+dfsg1-6.1ubuntu1.3) ...
+Preparing to unpack .../03-openssl_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking openssl (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.9) ...
+Preparing to unpack .../04-ubuntu-advantage-tools_27.2.2~18.04.1_amd64.deb ...
+Unpacking ubuntu-advantage-tools (27.2.2~18.04.1) over (27.0.2~18.04.1) ...
+Preparing to unpack .../05-openssh-sftp-server_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-sftp-server (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../06-openssh-server_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-server (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../07-openssh-client_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-client (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../08-curl_7.58.0-2ubuntu3.14_amd64.deb ...
+Unpacking curl (7.58.0-2ubuntu3.14) over (7.58.0-2ubuntu3.13) ...
+Preparing to unpack .../09-libcurl4_7.58.0-2ubuntu3.14_amd64.deb ...
+Unpacking libcurl4:amd64 (7.58.0-2ubuntu3.14) over (7.58.0-2ubuntu3.13) ...
+Preparing to unpack .../10-grub-efi-amd64-signed_1.167~18.04.5+2.04-1ubuntu44.1.2_amd64.deb ...
+Unpacking grub-efi-amd64-signed (1.167~18.04.5+2.04-1ubuntu44.1.2) over (1.167~18.04.3+2.04-1ubuntu44.1) ...
+Preparing to unpack .../11-grub-efi-amd64-bin_2.04-1ubuntu44.1.2_amd64.deb ...
+Unpacking grub-efi-amd64-bin (2.04-1ubuntu44.1.2) over (2.04-1ubuntu44.1) ...
+Selecting previously unselected package linux-modules-4.15.0-154-generic.
+Preparing to unpack .../12-linux-modules-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-modules-4.15.0-154-generic (4.15.0-154.161) ...
+Selecting previously unselected package linux-image-4.15.0-154-generic.
+Preparing to unpack .../13-linux-image-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-154-generic.
+Preparing to unpack .../14-linux-modules-extra-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-154-generic (4.15.0-154.161) ...
+Preparing to unpack .../15-linux-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../16-linux-image-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../17-linux-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../18-linux-image-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-image-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../19-linux-headers-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-headers-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Selecting previously unselected package linux-headers-4.15.0-154.
+Preparing to unpack .../20-linux-headers-4.15.0-154_4.15.0-154.161_all.deb ...
+Unpacking linux-headers-4.15.0-154 (4.15.0-154.161) ...
+Selecting previously unselected package linux-headers-4.15.0-154-generic.
+Preparing to unpack .../21-linux-headers-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-headers-4.15.0-154-generic (4.15.0-154.161) ...
+Preparing to unpack .../22-linux-headers-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../23-wireless-regdb_2021.07.14-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~18.04.1) over (2020.11.20-0ubuntu1~18.04.1) ...
+Setting up linux-modules-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up libapt-inst2.0:amd64 (1.6.14) ...
+Setting up libnss-systemd:amd64 (237-3ubuntu10.51) ...
+Setting up grub-efi-amd64-bin (2.04-1ubuntu44.1.2) ...
+Setting up apt-utils (1.6.14) ...
+Setting up systemd-sysv (237-3ubuntu10.51) ...
+Setting up linux-base (4.5ubuntu1.6) ...
+Setting up linux-headers-4.15.0-154 (4.15.0-154.161) ...
+Setting up distro-info-data (0.37ubuntu0.11) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Setting up libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.4) ...
+Setting up grub-efi-amd64-signed (1.167~18.04.5+2.04-1ubuntu44.1.2) ...
+Installing for x86_64-efi platform.
+EFI variables are not supported on this system.
+Installation finished. No error reported.
+Setting up udev (237-3ubuntu10.51) ...
+update-initramfs: deferring update (trigger activated)
+Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up linux-headers-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up openssl (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up initramfs-tools-bin (0.130ubuntu3.13) ...
+Setting up openssh-client (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-154-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-154-generic
+Setting up linux-headers-generic (4.15.0.154.143) ...
+Setting up ubuntu-advantage-tools (27.2.2~18.04.1) ...
+Installing new version of config file /etc/apt/apt.conf.d/20apt-esm-hook.conf ...
+Installing new version of config file /etc/ubuntu-advantage/uaclient.conf ...
+Setting up libpam-systemd:amd64 (237-3ubuntu10.51) ...
+Setting up initramfs-tools-core (0.130ubuntu3.13) ...
+Setting up libcurl4:amd64 (7.58.0-2ubuntu3.14) ...
+Setting up initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: deferring update (trigger activated)
+Setting up linux-image-virtual (4.15.0.154.143) ...
+Setting up linux-modules-extra-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up openssh-sftp-server (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-headers-virtual (4.15.0.154.143) ...
+Setting up linux-virtual (4.15.0.154.143) ...
+Setting up linux-image-generic (4.15.0.154.143) ...
+Setting up curl (7.58.0-2ubuntu3.14) ...
+Setting up openssh-server (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-generic (4.15.0.154.143) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-154-generic
+/etc/kernel/postinst.d/x-grub-legacy-ec2:
+Searching for GRUB installation directory ... found: /boot/grub
+Searching for default file ... found: /boot/grub/default
+Testing for an existing GRUB menu.lst file ... found: /boot/grub/menu.lst
+Searching for splash image ... none found, skipping ...
+Found kernel: /boot/vmlinuz-4.15.0-144-generic
+Found kernel: /boot/vmlinuz-4.15.0-154-generic
+Found kernel: /boot/vmlinuz-4.15.0-144-generic
+Replacing config file /run/grub/menu.lst with new version
+Updating /boot/grub/menu.lst ... done
+
+/etc/kernel/postinst.d/zz-update-grub:
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-154-generic
+Found initrd image: /boot/initrd.img-4.15.0-154-generic
+Found linux image: /boot/vmlinuz-4.15.0-144-generic
+Found initrd image: /boot/initrd.img-4.15.0-144-generic
+done
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-154-generic
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following packages will be REMOVED:
+  python3-configobj* python3-serial*
+0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
+After this operation, 563 kB disk space will be freed.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 96897 files and directories currently installed.)
+Removing python3-configobj (5.0.6-2) ...
+Removing python3-serial (3.4-2) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['bash', '-ec', '[ ! -e /run/autopkgtest_no_reboot.stamp ] || exit 0;for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do s=/tmp/autopkgtest.dn9EKj/${d//\\//_}.stamp;  [ ! -d $d ] || [ `stat -c %Y $d` = `stat -c %Y $s` ]; done'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest [19:32:52]: rebooting testbed after setup commands that affected boot
+autopkgtest: DBG: sending command to testbed: reboot
+autopkgtest-virt-qemu: DBG: executing reboot
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec for d in /var/cache /home; do if [ -w $d ]; then   tar --warning=none --create --absolute-names     -f $d/autopkgtest-tmpdir.tar '/tmp/autopkgtest.dn9EKj';   rm -f /run/autopkgtest-reboot-prepare-mark;   exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: saved current downtmp, rebooting
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd test -d /run/systemd/system
+autopkgtest-virt-qemu: DBG: rebooting with command: ['systemd-run', '--no-block', '--quiet', 'sh', '-c', 'sleep 3; reboot']
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd systemd-run --no-block --quiet sh -c sleep 3; reboot
+autopkgtest-virt-qemu: DBG: expect: b' login: '
+[[0;32m  OK  [0m] Closed Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Stopped target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Stopped target Graphical Interface.
+[[0;32m  OK  [0m] Stopped target Multi-User System.
+         Stopping OpenBSD Secure Shell server...
+         Stopping autopkgtest root shell on ttyS1...
+         Stopping System Logging Service...
+         Stopping autopkgtest root shell on hvc1...
+         Stopping D-         Stopping LSB: Record successful boot for GRUB...
+         Stopping rng-tools.service...
+         Stopping Login Service...
+         Stopping Dispatcher daemon for systemd-networkd...
+         Stopping Regular background program processing daemon...
+[[0;32m  OK  [0m] Stopped target Timers.
+[[0;32m  OK  [0m] Stopped Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Stopped Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Stopped Message of the Day.
+[[0;32m  OK  [0m] Stopped Daily apt download activities.
+[[0;32m  OK  [0m] Stopped Discard unused blocks once a week.
+[[0;32m  OK  [0m] Stopped Ubuntu Advantage update messaging.
+[[0;32m  OK  [0m] Stopped target System Time Synchronized.
+         Stopping Getty on tty1...
+         Stopping irqbalance daemon...
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on hvc1.
+[[0;32m  OK  [0m] Stopped irqbalance daemon.
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Stopped Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Stopped Deferred execution scheduler.
+[[0;32m  OK  [0m] Stopped Regular background program processing daemon.
+[[0;32m  OK  [0m] Stopped System Logging Service.
+[[0;32m  OK  [0m] Stopped Serial Getty on hvc0.
+[[0;32m  OK  [0m] Stopped Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Stopped Getty on tty1.
+[[0;32m  OK  [0m] Stopped OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Stopped /bin/sh -c sleep 3; reboot.
+[[0;32m  OK  [0m] Stopped D-Bus System Message Bus.
+[[0;32m  OK  [0m] Removed slice system-getty.slice.
+[[0;32m  OK  [0m] Removed slice system-serial\x2dgetty.slice.
+         Stopping Permit User Sessions...
+[[0;32m  OK  [0m] Removed slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Stopped LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Stopped Permit User Sessions.
+[[0;32m  OK  [0m] Stopped LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Stopped target Network.
+         Stopping Network Name Resolution...
+[[0;32m  OK  [0m] Stopped Network Name Resolution.
+[[0;32m  OK  [0m] Stopped Login Service.
+         Stopping Network Service...
+[[0;32m  OK  [0m] Stopped Network Service.
+[[0m[0;31m*     [0m] A stop job is running for rng-tools.service (5s / 5min)[K[[0;1;31m*[0m[0;31m*    [0m] A stop job is running for rng-tools.service (5s / 5min)[K[[0;31m*[0;1;31m*[0m[0;31m*   [0m] A stop job is running for rng-tools.service (6s / 5min)[K[ [0;31m*[0;1;31m*[0m[0;31m*  [0m] A stop job is running for rng-tools.service (6s / 5min)[K[  [0;31m*[0;1;31m*[0m[0;31m* [0m] A stop job is running for rng-tools.service (7s / 5min)[K[   [0;31m*[0;1;31m*[0m[0;31m*[0m] A stop job is running for rng-tools.service (7s / 5min)[K[    [0;31m*[0;1;31m*[0m] A stop job is running for rng-tools.service (8s / 5min)[K[     [0;31m*[0m] A stop job is running for rng-tools.service (8s / 5min)[K[    [0;31m*[0;1;31m*[0m] A stop job is running for rng-tools.service (9s / 5min)[K[   [0;31m*[0;1;31m*[0m[0;31m*[0m] A stop job is running for rng-tools.service (9s / 5min)[K[[0;32m  OK  [0m] Stopped rng-tools.service.
+[[0;32m  OK  [0m] Stopped target Basic System.
+[[0;32m  OK  [0m] Stopped target Slices.
+[[0;32m  OK  [0m] Removed slice User and Session Slice.
+[[0;32m  OK  [0m] Stopped target Sockets.
+[[0;32m  OK  [0m] Closed Syslog Socket.
+[[0;32m  OK  [0m] Closed UUID daemon activation socket.
+[[0;32m  OK  [0m] Closed D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Closed ACPID Listen Socket.
+[[0;32m  OK  [0m] Stopped target Paths.
+[[0;32m  OK  [0m] Stopped ACPI Events Check.
+[[0;32m  OK  [0m] Stopped target System Initialization.
+         Stopping Network Time Synchronization...
+[[0;32m  OK  [0m] Stopped target Swap.
+[[0;32m  OK  [0m] Stopped target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Stopped Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Stopped Forward Password Requests to Wall Directory Watch.
+         Stopping Load/Save Random Seed...
+[[0;32m  OK  [0m] Stopped Apply Kernel Variables.
+         Stopping Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Stopped Load Kernel Modules.
+[[0;32m  OK  [0m] Stopped target Remote File Systems.
+[[0;32m  OK  [0m] Stopped Load/Save Random Seed.
+[[0;32m  OK  [0m] Stopped Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Stopped Network Time Synchronization.
+[[0;32m  OK  [0m] Stopped Create Volatile Files and Directories.
+[[0;32m  OK  [0m] Stopped target Local File Systems.
+         Unmounting /run/autopkgtest/shared...
+         Unmounting /boot/efi...
+[[0;32m  OK  [0m] Unmounted /run/autopkgtest/shared.
+[[0;32m  OK  [0m] Unmounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Unmount All Filesystems.
+[[0;32m  OK  [0m] Stopped File System Check on /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Removed slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Stopped target Local File Systems (Pre).
+[[0;32m  OK  [0m] Stopped Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Stopped Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Reached target Shutdown.
+[[0;32m  OK  [0m] Reached target Final Step.
+         Starting Reboot...
+[  128.401758] reboot: Restarting system
+c[?7l[2J[0mSeaBIOS (version 1.13.0-1ubuntu1.1)
+
+
+iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+BFF8C740+BFECC740 CA00
+Press Ctrl-B to configure iPXE (PCI 00:03.0)...                                                                               
+
+
+
+
+iPXE (http://ipxe.org) 00:08.0 CB00 PCI2.10 PnP PMM BFF8C740 BFECC740 CB00
+Press Ctrl-B to configure iPXE (PCI 00:08.0)...                                                                               
+
+
+Booting from Hard Disk...
+[    0.000000] Linux version 4.15.0-154-generic (buildd@lcy01-amd64-011) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #161-Ubuntu SMP Fri Jul 30 13:04:17 UTC 2021 (Ubuntu 4.15.0-154.161-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-154-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffdcfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffdd000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000023fffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.13.0-1ubuntu1.1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0x240000 max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] e820: last_pfn = 0xbffdd max_arch_pfn = 0x400000000
+[    0.000000] found SMP MP-table at [mem 0x000f5c70-0x000f5c7f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x32e6d000-0x3572dfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F5A80 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE17FE 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE16A2 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001662 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE1716 0000B0 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE17C6 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] ACPI: Reserving FACP table memory at [mem 0xbffe16a2-0xbffe1715]
+[    0.000000] ACPI: Reserving DSDT table memory at [mem 0xbffe0040-0xbffe16a1]
+[    0.000000] ACPI: Reserving FACS table memory at [mem 0xbffe0000-0xbffe003f]
+[    0.000000] ACPI: Reserving APIC table memory at [mem 0xbffe1716-0xbffe17c5]
+[    0.000000] ACPI: Reserving HPET table memory at [mem 0xbffe17c6-0xbffe17fd]
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x000000023fffffff]
+[    0.000000] NODE_DATA(0) allocated [mem 0x23ffd2000-0x23fffcfff]
+[    0.000000] kvm-clock: cpu 0, msr 2:3ff51001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 136796286206 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffdcfff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Reserved but unavailable: 100 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x000000023fffffff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xbffdd000-0xbfffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xc0000000-0xfeffbfff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfeffc000-0xfeffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xff000000-0xfffbffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfffc0000-0xffffffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x500 with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:8 nr_cpu_ids:8 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u262144
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr 23fc23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2064230
+[    0.000000] Policy zone: Normal
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-154-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 8118732K/8388076K available (12300K kernel code, 2483K rwdata, 4320K rodata, 2448K init, 2724K bss, 269344K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39461 entries in 155 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=8.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+[    0.004000] NR_IRQS: 524544, nr_irqs: 488, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [tty0] enabled
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004010] APIC: Switch to symmetric I/O mode setup
+[    0.005468] x2apic enabled
+[    0.006503] Switched APIC routing to physical x2apic.
+[    0.008000] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.202 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.40 BogoMIPS (lpj=9588808)
+[    0.008003] pid_max: default: 32768 minimum: 301
+[    0.009145] Security Framework initialized
+[    0.010140] Yama: becoming mindful.
+[    0.012029] AppArmor: AppArmor initialized
+[    0.014452] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.016698] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.018341] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.020027] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.022100] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.024004] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.025403] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.027395] Spectre V2 : Mitigation: Full generic retpoline
+[    0.028002] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.029923] Speculative Store Bypass: Vulnerable
+[    0.032046] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.033732] Freeing SMP alternatives memory: 36K
+[    0.145155] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.147113] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.148044] Hierarchical SRCU implementation.
+[    0.149769] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.151137] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.152099] smp: Bringing up secondary CPUs ...
+[    0.153264] x86: Booting SMP configuration:
+[    0.154272] .... node  #0, CPUs:      #1
+[    0.004000] kvm-clock: cpu 1, msr 2:3ff51041, secondary cpu clock
+[    0.171236] KVM setup async PF for cpu 1
+[    0.171236] kvm-stealtime: cpu 1, msr 23fc63040
+[    0.172107]  #2
+[    0.004000] kvm-clock: cpu 2, msr 2:3ff51081, secondary cpu clock
+[    0.191479] KVM setup async PF for cpu 2
+[    0.191479] kvm-stealtime: cpu 2, msr 23fca3040
+[    0.192125]  #3
+[    0.004000] kvm-clock: cpu 3, msr 2:3ff510c1, secondary cpu clock
+[    0.211508] KVM setup async PF for cpu 3
+[    0.211508] kvm-stealtime: cpu 3, msr 23fce3040
+[    0.216096]  #4
+[    0.004000] kvm-clock: cpu 4, msr 2:3ff51101, secondary cpu clock
+[    0.231709] KVM setup async PF for cpu 4
+[    0.231709] kvm-stealtime: cpu 4, msr 23fd23040
+[    0.236077]  #5
+[    0.004000] kvm-clock: cpu 5, msr 2:3ff51141, secondary cpu clock
+[    0.251910] KVM setup async PF for cpu 5
+[    0.251910] kvm-stealtime: cpu 5, msr 23fd63040
+[    0.252120]  #6
+[    0.004000] kvm-clock: cpu 6, msr 2:3ff51181, secondary cpu clock
+[    0.270352] KVM setup async PF for cpu 6
+[    0.270352] kvm-stealtime: cpu 6, msr 23fda3040
+[    0.272119]  #7
+[    0.004000] kvm-clock: cpu 7, msr 2:3ff511c1, secondary cpu clock
+[    0.290321] KVM setup async PF for cpu 7
+[    0.290321] kvm-stealtime: cpu 7, msr 23fde3040
+[    0.292006] smp: Brought up 1 node, 8 CPUs
+[    0.292980] smpboot: Max logical packages: 1
+[    0.293958] smpboot: Total of 8 processors activated (38355.23 BogoMIPS)
+[    0.296963] devtmpfs: initialized
+[    0.296963] x86/mm: Memory block size: 128MB
+[    0.300399] evm: security.selinux
+[    0.301266] evm: security.SMACK64
+[    0.302100] evm: security.SMACK64EXEC
+[    0.303006] evm: security.SMACK64TRANSMUTE
+[    0.304004] evm: security.SMACK64MMAP
+[    0.304951] evm: security.apparmor
+[    0.305809] evm: security.ima
+[    0.306576] evm: security.capability
+[    0.307476] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.308019] futex hash table entries: 2048 (order: 5, 131072 bytes)
+[    0.312060] pinctrl core: initialized pinctrl subsystem
+[    0.313374] RTC time: 19:33:10, date: 08/25/21
+[    0.314662] NET: Registered protocol family 16
+[    0.315791] audit: initializing netlink subsys (disabled)
+[    0.316055] audit: type=2000 audit(1629919988.986:1): state=initialized audit_enabled=0 res=1
+[    0.317940] cpuidle: using governor ladder
+[    0.320088] cpuidle: using governor menu
+[    0.320433] ACPI: bus type PCI registered
+[    0.322388] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.328243] PCI: Using configuration type 1 for base access
+[    0.333532] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.336184] ACPI: Added _OSI(Module Device)
+[    0.340009] ACPI: Added _OSI(Processor Device)
+[    0.342145] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.344003] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.345293] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.346355] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.348003] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.350253] ACPI: Interpreter enabled
+[    0.351191] ACPI: (supports S0 S3 S4 S5)
+[    0.352004] ACPI: Using IOAPIC for interrupt routing
+[    0.353240] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.353240] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.356844] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.358248] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.359823] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.364015] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.364268] acpiphp: Slot [3] registered
+[    0.365276] acpiphp: Slot [4] registered
+[    0.366252] acpiphp: Slot [5] registered
+[    0.367252] acpiphp: Slot [6] registered
+[    0.372044] acpiphp: Slot [7] registered
+[    0.373032] acpiphp: Slot [8] registered
+[    0.374036] acpiphp: Slot [9] registered
+[    0.375010] acpiphp: Slot [10] registered
+[    0.376046] acpiphp: Slot [11] registered
+[    0.377040] acpiphp: Slot [12] registered
+[    0.378045] acpiphp: Slot [13] registered
+[    0.379062] acpiphp: Slot [14] registered
+[    0.380044] acpiphp: Slot [15] registered
+[    0.381095] acpiphp: Slot [16] registered
+[    0.382118] acpiphp: Slot [17] registered
+[    0.383138] acpiphp: Slot [18] registered
+[    0.384043] acpiphp: Slot [19] registered
+[    0.385063] acpiphp: Slot [20] registered
+[    0.386085] acpiphp: Slot [21] registered
+[    0.387098] acpiphp: Slot [22] registered
+[    0.388044] acpiphp: Slot [23] registered
+[    0.389056] acpiphp: Slot [24] registered
+[    0.390070] acpiphp: Slot [25] registered
+[    0.391078] acpiphp: Slot [26] registered
+[    0.392044] acpiphp: Slot [27] registered
+[    0.393067] acpiphp: Slot [28] registered
+[    0.394083] acpiphp: Slot [29] registered
+[    0.395095] acpiphp: Slot [30] registered
+[    0.396042] acpiphp: Slot [31] registered
+[    0.397033] PCI host bridge to bus 0000:00
+[    0.398025] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.398025] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.398025] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.399280] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.404003] pci_bus 0000:00: root bus resource [mem 0x240000000-0x2bfffffff window]
+[    0.405810] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.410489] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.416004] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.417434] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.418935] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.420747] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.422396] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.498976] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.504145] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.505498] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.506838] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.508093] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.510117] SCSI subsystem initialized
+[    0.512181] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.513313] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.515153] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.516004] vgaarb: loaded
+[    0.516716] ACPI: bus type USB registered
+[    0.517666] usbcore: registered new interface driver usbfs
+[    0.517666] usbcore: registered new interface driver hub
+[    0.517666] usbcore: registered new device driver usb
+[    0.520035] EDAC MC: Ver: 3.0.0
+[    0.521066] PCI: Using ACPI for IRQ routing
+[    0.524348] NetLabel: Initializing
+[    0.526089] NetLabel:  domain hash size = 128
+[    0.527516] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.528027] NetLabel:  unlabeled traffic allowed by default
+[    0.532534] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.534677] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.536004] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.544130] clocksource: Switched to clocksource kvm-clock
+[    0.556034] VFS: Disk quotas dquot_6.6.0
+[    0.556994] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.558566] AppArmor: AppArmor Filesystem Enabled
+[    0.560028] pnp: PnP ACPI init
+[    0.561331] pnp: PnP ACPI: found 7 devices
+[    0.569329] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.571765] NET: Registered protocol family 2
+[    0.573135] TCP established hash table entries: 65536 (order: 7, 524288 bytes)
+[    0.574992] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
+[    0.576562] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.577994] UDP hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.579324] UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.580793] NET: Registered protocol family 1
+[    0.581805] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.584060] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.586635] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.589484] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.593512] Unpacking initramfs...
+[    1.231180] Freeing initrd memory: 41732K
+[    1.232196] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.233562] software IO TLB: mapped [mem 0xbbfdd000-0xbffdd000] (64MB)
+[    1.234996] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228de43df3e, max_idle_ns: 440795235278 ns
+[    1.237162] Scanning for low memory corruption every 60 seconds
+[    1.239157] Initialise system trusted keyrings
+[    1.240203] Key type blacklist registered
+[    1.241374] workingset: timestamp_bits=36 max_order=21 bucket_order=0
+[    1.243757] zbud: loaded
+[    1.245147] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.246867] fuse init (API version 7.26)
+[    1.250899] Key type asymmetric registered
+[    1.251898] Asymmetric key parser 'x509' registered
+[    1.253062] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    1.254852] io scheduler noop registered
+[    1.255779] io scheduler deadline registered
+[    1.256810] io scheduler cfq registered (default)
+[    1.258500] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    1.260222] ACPI: Power Button [PWRF]
+[    1.284236] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    1.306866] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    1.328757] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    1.351631] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    1.417368] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.443691] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.470403] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.482008] console [hvc0] enabled
+[    1.489229] Linux agpgart interface v0.103
+[    1.493131] loop: module loaded
+[    1.495192] scsi host0: ata_piix
+[    1.496345] scsi host1: ata_piix
+[    1.497250] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc1a0 irq 14
+[    1.498819] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc1a8 irq 15
+[    1.500580] libphy: Fixed MDIO Bus: probed
+[    1.501737] tun: Universal TUN/TAP device driver, 1.6
+[    1.503103] PPP generic driver version 2.4.2
+[    1.504242] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.505738] ehci-pci: EHCI PCI platform driver
+[    1.506887] ehci-platform: EHCI generic platform driver
+[    1.508102] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.509557] ohci-pci: OHCI PCI platform driver
+[    1.510636] ohci-platform: OHCI generic platform driver
+[    1.511963] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.513470] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.515967] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.517216] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.518680] mousedev: PS/2 mouse device common for all mice
+[    1.520284] rtc_cmos 00:00: RTC can wake from S4
+[    1.521933] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    1.521946] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    1.525377] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    1.534973] i2c /dev entries driver
+[    1.536518] device-mapper: uevent: version 1.0.3
+[    1.537958] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    1.540744] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.543612] NET: Registered protocol family 10
+[    1.554671] Segment Routing with IPv6
+[    1.555856] NET: Registered protocol family 17
+[    1.557249] Key type dns_resolver registered
+[    1.559581] mce: Using 10 MCE banks
+[    1.560756] RAS: Correctable Errors collector initialized.
+[    1.562283] sched_clock: Marking stable (1560724240, 0)->(1917574177, -356849937)
+[    1.564833] registered taskstats version 1
+[    1.566019] Loading compiled-in X.509 certificates
+[    1.572210] Loaded X.509 cert 'Build time autogenerated kernel key: 369b16149153afe509b010c5493c788cd1d7da9f'
+[    1.575526] Loaded X.509 cert 'Canonical Ltd. Live Patch Signing: 14df34d1a87cf37625abec039ef2bf521249b969'
+[    1.578708] Loaded X.509 cert 'Canonical Ltd. Kernel Module Signing: 88f752e560a1e0737e31163a466ad7b70a850c19'
+[    1.581280] zswap: loaded using pool lzo/zbud
+[    1.591885] Key type big_key registered
+[    1.593969] Key type trusted registered
+[    1.597865] Key type encrypted registered
+[    1.599849] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.601621] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    1.603575] ima: Allocated hash algorithm: sha1
+[    1.605130] evm: HMAC attrs: 0x1
+[    1.607178]   Magic number: 1:936:597
+[    1.608773] rtc_cmos 00:00: setting system clock to 2021-08-25 19:33:11 UTC (1629919991)
+[    1.611552] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    1.613197] EDD information not available.
+[    1.661591] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.665197] ata2.00: configured for MWDMA2
+[    1.668642] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.701388] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.706140] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.710895] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.718852] Freeing unused kernel image memory: 2448K
+[    1.728087] Write protecting the kernel read-only data: 20480k
+[    1.731652] Freeing unused kernel image memory: 2008K
+[    1.733681] Freeing unused kernel image memory: 1824K
+[    1.743424] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.745293] x86/mm: Checking user space page tables
+[    1.753964] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.861661] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.861861] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.869729] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.873919]  vda: vda1 vda14 vda15
+[    1.878172] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.883445] virtio_net virtio0 ens3: renamed from eth0
+[    1.886370] FDC 0 is a S82078B
+[    1.900446] virtio_net virtio5 ens8: renamed from eth1
+[    1.960153] print_req_error: I/O error, dev fd0, sector 0
+[    1.962809] floppy: error 10 while reading block 0
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    2.084048] raid6: sse2x1   gen()  7849 MB/s
+[    2.132088] raid6: sse2x1   xor()  2806 MB/s
+[    2.180076] raid6: sse2x2   gen()  4853 MB/s
+[    2.228071] raid6: sse2x2   xor()  4417 MB/s
+[    2.276056] raid6: sse2x4   gen() 11503 MB/s
+[    2.324073] raid6: sse2x4   xor()  7249 MB/s
+[    2.325354] raid6: using algorithm sse2x4 gen() 11503 MB/s
+[    2.326836] raid6: .... xor() 7249 MB/s, rmw enabled
+[    2.328232] raid6: using intx1 recovery algorithm
+[    2.333216] xor: measuring software checksum speed
+[    2.372076]    prefetch64-sse: 12102.000 MB/sec
+[    2.412072]    generic_sse:  9339.000 MB/sec
+[    2.413332] xor: using function: prefetch64-sse (12102.000 MB/sec)
+[    2.432368] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    2.576140] print_req_error: I/O error, dev fd0, sector 0
+[    2.578783] floppy: error 10 while reading block 0
+done.
+Begin: Will now check root file system ... fsck from util-linux 2.31.1
+[/sbin/fsck.ext4 (1) -- /dev/vda1] fsck.ext4 -a -C0 /dev/vda1 
+cloudimg-rootfs: clean, 102612/8015616 files, 1535220/16276731 blocks
+done.
+[    2.625086] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... [    2.641196] random: fast init done
+done.
+[    2.828114] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.833894] random: crng init done
+[    2.843794] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.851352] systemd[1]: Detected virtualization kvm.
+[    2.852944] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.5 LTS[0m!
+
+[    2.862328] systemd[1]: Set hostname to <autopkgtest>.
+[    2.966345] systemd[1]: Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[    2.970236] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executab…rmats File System Automount Point.
+[    2.977884] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    2.982451] systemd[1]: Created slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Created slice system-systemd\x2dfsck.slice.
+[    2.985940] systemd[1]: Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[    2.988645] systemd[1]: Listening on fsck to fsckd communication Socket.
+[[0;32m  OK  [0m] Listening on fsck to fsckd communication Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Mounting POSIX Message Queue File System...
+         Mounting Huge Pages File System...
+         Mounting Kernel Debug File System...
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Created slice system-autopkgtest.slice.
+         Starting udev Coldplug all Devices...
+         Starting Set the console keyboard layout...
+[[0;32m  OK  [0m] Reached target Swap.
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+         Starting Journal Service...
+         Starting Uncomplicated firewall...
+         Starting Remount Root and Kernel File Systems...
+         Starting Create list of required st…ce nodes for the current kernel...
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[    3.034910] EXT4-fs (vda1): re-mounted. Opts: (null)
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Started Create list of required sta…vice nodes for the current kernel.
+         Starting Create Static Device Nodes in /dev...
+         Starting Load/Save Random Seed...
+         Starting Apply Kernel Variables...
+         Mounting Kernel Configuration File System...
+         Mounting FUSE Control File System...
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+[    3.188055] print_req_error: I/O error, dev fd0, sector 0
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+         Starting File System Check on /dev/disk/by-label/UEFI...
+[[0;32m  OK  [0m] Found device /dev/hvc0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started File System Check Daemon to report status.
+[[0;32m  OK  [0m] Started File System Check on /dev/disk/by-label/UEFI.
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting AppArmor initialization...
+         Starting Set console font and keymap...
+         Starting Create Volatile Files and Directories...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+         Starting Network Name Resolution...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Reached target Basic System.
+         Starting LSB: automatic crash report generation...
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+[[0;32m  OK  [0m] Started autopkgtest root shell on hvc1.
+         Starting Login Service...
+         Starting Thermal Daemon Service...
+[[0;32m  OK  [0m] Started irqbalance daemon.
+         Starting LSB: Record successful boot for GRUB...
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting rng-tools.service...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started Ubuntu Advantage update messaging.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started rng-tools.service.
+[[0;32m  OK  [0m] Started Login Service.
+[[0;32m  OK  [0m] Reached target Network.
+         Starting OpenBSD Secure Shell server...
+         Starting Permit User Sessions...
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+         Starting Terminate Plymouth Boot Screen...
+         Starting Hold until boot process finishes up...
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on hvc0.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+
+Ubuntu 18.04.5 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found "'login prompt on serial console'"
+autopkgtest-virt-qemu: DBG: expect: b'ok'
+autopkgtest-virt-qemu: DBG: expect: found "b'ok'"
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on hvc1
+autopkgtest-virt-qemu: DBG: expect: b'f05eb629-b26b-421e-bd16-3405a667458f[1]'
+autopkgtest-virt-qemu: DBG: expect: found "b'f05eb629-b26b-421e-bd16-3405a667458f[1]'"
+autopkgtest-virt-qemu: DBG: expect: b'f05eb629-b26b-421e-bd16-3405a667458f[2]'
+autopkgtest-virt-qemu: DBG: expect: found "b'f05eb629-b26b-421e-bd16-3405a667458f[2]'"
+autopkgtest-virt-qemu: DBG: expect: b'f05eb629-b26b-421e-bd16-3405a667458f[3]'
+autopkgtest-virt-qemu: DBG: expect: found "b'f05eb629-b26b-421e-bd16-3405a667458f[3]'"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec for d in /var/cache /home; do if [ -e $d/autopkgtest-tmpdir.tar ]; then  tar --warning=none --extract --absolute-names      -f $d/autopkgtest-tmpdir.tar; rm $d/autopkgtest-tmpdir.tar; exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: restored downtmp after reboot
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [19:33:18]: testbed running kernel: Linux 4.15.0-154-generic #161-Ubuntu SMP Fri Jul 30 13:04:17 UTC 2021
+autopkgtest: DBG: testbed command ['sh', '-c', 'nproc; cat /proc/cpuinfo 2>/dev/null || true'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--print-architecture'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [19:33:18]: testbed dpkg architecture: amd64
+autopkgtest: DBG: testbed command ['which', 'eatmydata'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed has eatmydata
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.dn9EKj/testbed-packages"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.18dmni1z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/testbed-packages'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/testbed-packages
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Binaries: initialising
+autopkgtest [19:33:20]: @@@@@@@@@@@@@@@@@@@@ unbuilt-tree /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
+autopkgtest: DBG: blame += /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
+autopkgtest: DBG: testbed reset: modified=False, deps_installed=[](r: False), deps_new=[](r: False)
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.dn9EKj'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ /tmp/autopkgtest.dn9EKj/ubtree-maas/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ /tmp/autopkgtest.dn9EKj/ubtree-maas/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-qemu.18dmni1z/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.dn9EKj/ubtree-maas/; then mkdir -- /tmp/autopkgtest.dn9EKj/ubtree-maas/; fi; cd /tmp/autopkgtest.dn9EKj/ubtree-maas/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec if ! test -d /tmp/autopkgtest.dn9EKj/ubtree-maas/; then mkdir -- /tmp/autopkgtest.dn9EKj/ubtree-maas/; fi; cd /tmp/autopkgtest.dn9EKj/ubtree-maas/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.dn9EKj/ubtree-maas'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: install_deps: deps_new=[], recommends=False
+autopkgtest: DBG: testbed command ['which', 'dpkg-source'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'su --shell=/bin/sh ubuntu -c \'set -e; exec 3>&1 >&2; set -x; cd /; builddir=$(mktemp -d /tmp/autopkgtest.dn9EKj/build.XXX); cd $builddir; cp -rd --preserve=timestamps -- "/tmp/autopkgtest.dn9EKj/ubtree-maas" real-tree; [ -x real-tree/debian/rules ] && dpkg-source --before-build real-tree; chmod -R a+rX .; cd [a-z0-9]*/.; pwd >&3; sed -n "1 {s/).*//; s/ (/\\n/; p}" debian/changelog >&3; set +e; grep -q "^Restrictions:.*\\bbuild-needed\\b" debian/tests/control 2>/dev/null; echo $? >&3\''], kind build, sout pipe, serr raw, env ['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9']
++ cd /
++ mktemp -d /tmp/autopkgtest.dn9EKj/build.XXX
++ builddir=/tmp/autopkgtest.dn9EKj/build.Bke
++ cd /tmp/autopkgtest.dn9EKj/build.Bke
++ cp -rd --preserve=timestamps -- /tmp/autopkgtest.dn9EKj/ubtree-maas real-tree
++ [ -x real-tree/debian/rules ]
++ dpkg-source --before-build real-tree
++ chmod -R a+rX .
++ cd real-tree/.
++ pwd
++ sed -n 1 {s/).*//; s/ (/\n/; p} debian/changelog
++ set +e
++ grep -q ^Restrictions:.*\bbuild-needed\b debian/tests/control
++ echo 1
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [19:33:23]: testing package dummy version 0.1+-g+ci-1build1
+autopkgtest [19:33:23]: build needed for binaries
+autopkgtest: DBG: needs_reset, previously=False, requested by build_source() line 581
+autopkgtest: DBG: install_deps: deps_new=[], recommends=False
+autopkgtest: DBG: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas: satisfying debhelper (>= 9.20120311), , , build-essential, fakeroot
+autopkgtest: DBG: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas: architecture resolved: debhelper (>= 9.20120311), build-essential, fakeroot
+autopkgtest: DBG: testbed command ['test', '-w', '/var/lib/dpkg/status'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: can use apt-get on testbed: True
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.dn9EKj'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/1-autopkgtest-satdep.deb /tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/1-autopkgtest-satdep.deb /tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['cat'], ['/tmp/autopkgtest-qemu.18dmni1z/runcmd', 'sh', '-ec', 'cat >/tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/1-autopkgtest-satdep.deb'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< cat
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec cat >/tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--unpack', '/tmp/autopkgtest.dn9EKj/1-autopkgtest-satdep.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['/bin/sh', '-ec', '/usr/bin/eatmydata apt-get install --assume-yes --fix-broken -o APT::Status-Fd=3 -o APT::Install-Recommends=False -o Dpkg::Options::=--force-confnew -o Debug::pkgProblemResolver=true 3>&2 2>&1'], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Correcting dependencies...Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+ Done
+Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+The following additional packages will be installed:
+  autoconf automake autopoint autotools-dev build-essential cpp cpp-7
+  debhelper dh-autoreconf dh-strip-nondeterminism fakeroot g++ g++-7 gcc gcc-7
+  gcc-7-base gettext intltool-debian libarchive-zip-perl libasan4 libatomic1
+  libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcroco3 libfakeroot
+  libfile-stripnondeterminism-perl libgcc-7-dev libgomp1 libisl19 libitm1
+  liblsan0 libmpc3 libmpx2 libquadmath0 libstdc++-7-dev libtimedate-perl
+  libtool libtsan0 libubsan0 linux-libc-dev m4 po-debconf
+Suggested packages:
+  autoconf-archive gnu-standards autoconf-doc cpp-doc gcc-7-locales dh-make
+  dwz g++-multilib g++-7-multilib gcc-7-doc libstdc++6-7-dbg gcc-multilib
+  manpages-dev flex bison gdb gcc-doc gcc-7-multilib libgcc1-dbg libgomp1-dbg
+  libitm1-dbg libatomic1-dbg libasan4-dbg liblsan0-dbg libtsan0-dbg
+  libubsan0-dbg libcilkrts5-dbg libmpx2-dbg libquadmath0-dbg gettext-doc
+  libasprintf-dev libgettextpo-dev glibc-doc libstdc++-7-doc libtool-doc
+  gfortran | fortran95-compiler gcj-jdk m4-doc libmail-box-perl
+Recommended packages:
+  manpages manpages-dev libarchive-cpio-perl libltdl-dev libmail-sendmail-perl
+The following NEW packages will be installed:
+  autoconf automake autopoint autotools-dev build-essential cpp cpp-7
+  debhelper dh-autoreconf dh-strip-nondeterminism fakeroot g++ g++-7 gcc gcc-7
+  gcc-7-base gettext intltool-debian libarchive-zip-perl libasan4 libatomic1
+  libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcroco3 libfakeroot
+  libfile-stripnondeterminism-perl libgcc-7-dev libgomp1 libisl19 libitm1
+  liblsan0 libmpc3 libmpx2 libquadmath0 libstdc++-7-dev libtimedate-perl
+  libtool libtsan0 libubsan0 linux-libc-dev m4 po-debconf
+0 upgraded, 44 newly installed, 0 to remove and 0 not upgraded.
+1 not fully installed or removed.
+Need to get 41.5 MB of archives.
+After this operation, 156 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 autotools-dev all 20180224.1 [39.6 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 m4 amd64 1.4.18-1 [197 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic/main amd64 autoconf all 2.69-11 [322 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 automake all 1:1.15.1-3ubuntu2 [509 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 autopoint all 0.19.8.1-6ubuntu0.3 [426 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7-base amd64 7.5.0-3ubuntu1~18.04 [18.3 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libisl19 amd64 0.19-1 [551 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp-7 amd64 7.5.0-3ubuntu1~18.04 [8,591 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp amd64 4:7.4.0-1ubuntu2.3 [27.7 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcc1-0 amd64 8.4.0-1ubuntu1~18.04 [39.4 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgomp1 amd64 8.4.0-1ubuntu1~18.04 [76.5 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libitm1 amd64 8.4.0-1ubuntu1~18.04 [27.9 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libatomic1 amd64 8.4.0-1ubuntu1~18.04 [9,192 B]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libasan4 amd64 7.5.0-3ubuntu1~18.04 [358 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblsan0 amd64 8.4.0-1ubuntu1~18.04 [133 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libtsan0 amd64 8.4.0-1ubuntu1~18.04 [288 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libubsan0 amd64 7.5.0-3ubuntu1~18.04 [126 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcilkrts5 amd64 7.5.0-3ubuntu1~18.04 [42.5 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmpx2 amd64 8.4.0-1ubuntu1~18.04 [11.6 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libquadmath0 amd64 8.4.0-1ubuntu1~18.04 [134 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc-7-dev amd64 7.5.0-3ubuntu1~18.04 [2,378 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7 amd64 7.5.0-3ubuntu1~18.04 [9,381 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc amd64 4:7.4.0-1ubuntu2.3 [5,184 B]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libc-dev-bin amd64 2.27-3ubuntu1.4 [71.8 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-libc-dev amd64 4.15.0-154.161 [988 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libc6-dev amd64 2.27-3ubuntu1.4 [2,585 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtool all 2.4.6-2 [194 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-autoreconf all 17 [15.8 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libarchive-zip-perl all 1.60-1ubuntu0.1 [84.6 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-stripnondeterminism-perl all 0.040-1.1~build1 [13.8 kB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtimedate-perl all 2.3000-2 [37.5 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-strip-nondeterminism all 0.040-1.1~build1 [5,208 B]
+Get:34 http://archive.ubuntu.com/ubuntu bionic/main amd64 libcroco3 amd64 0.6.12-2 [81.3 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gettext amd64 0.19.8.1-6ubuntu0.3 [1,293 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic/main amd64 intltool-debian all 0.35.0+20060710.4 [24.9 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic/main amd64 po-debconf all 1.0.20 [232 kB]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 debhelper all 11.1.6ubuntu2 [902 kB]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++-7-dev amd64 7.5.0-3ubuntu1~18.04 [1,471 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++-7 amd64 7.5.0-3ubuntu1~18.04 [9,697 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++ amd64 4:7.4.0-1ubuntu2.3 [1,568 B]
+Get:42 http://archive.ubuntu.com/ubuntu bionic/main amd64 build-essential amd64 12.4ubuntu1 [4,758 B]
+Get:43 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfakeroot amd64 1.22-2ubuntu1 [25.9 kB]
+Get:44 http://archive.ubuntu.com/ubuntu bionic/main amd64 fakeroot amd64 1.22-2ubuntu1 [62.3 kB]
+Fetched 41.5 MB in 2s (16.8 MB/s)
+Selecting previously unselected package autotools-dev.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 96850 files and directories currently installed.)
+Preparing to unpack .../00-autotools-dev_20180224.1_all.deb ...
+Unpacking autotools-dev (20180224.1) ...
+Selecting previously unselected package m4.
+Preparing to unpack .../01-m4_1.4.18-1_amd64.deb ...
+Unpacking m4 (1.4.18-1) ...
+Selecting previously unselected package autoconf.
+Preparing to unpack .../02-autoconf_2.69-11_all.deb ...
+Unpacking autoconf (2.69-11) ...
+Selecting previously unselected package automake.
+Preparing to unpack .../03-automake_1%3a1.15.1-3ubuntu2_all.deb ...
+Unpacking automake (1:1.15.1-3ubuntu2) ...
+Selecting previously unselected package autopoint.
+Preparing to unpack .../04-autopoint_0.19.8.1-6ubuntu0.3_all.deb ...
+Unpacking autopoint (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package gcc-7-base:amd64.
+Preparing to unpack .../05-gcc-7-base_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libisl19:amd64.
+Preparing to unpack .../06-libisl19_0.19-1_amd64.deb ...
+Unpacking libisl19:amd64 (0.19-1) ...
+Selecting previously unselected package libmpc3:amd64.
+Preparing to unpack .../07-libmpc3_1.1.0-1_amd64.deb ...
+Unpacking libmpc3:amd64 (1.1.0-1) ...
+Selecting previously unselected package cpp-7.
+Preparing to unpack .../08-cpp-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package cpp.
+Preparing to unpack .../09-cpp_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking cpp (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libcc1-0:amd64.
+Preparing to unpack .../10-libcc1-0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgomp1:amd64.
+Preparing to unpack .../11-libgomp1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libitm1:amd64.
+Preparing to unpack .../12-libitm1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libatomic1:amd64.
+Preparing to unpack .../13-libatomic1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libasan4:amd64.
+Preparing to unpack .../14-libasan4_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package liblsan0:amd64.
+Preparing to unpack .../15-liblsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libtsan0:amd64.
+Preparing to unpack .../16-libtsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libubsan0:amd64.
+Preparing to unpack .../17-libubsan0_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libcilkrts5:amd64.
+Preparing to unpack .../18-libcilkrts5_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libmpx2:amd64.
+Preparing to unpack .../19-libmpx2_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libquadmath0:amd64.
+Preparing to unpack .../20-libquadmath0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgcc-7-dev:amd64.
+Preparing to unpack .../21-libgcc-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc-7.
+Preparing to unpack .../22-gcc-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc.
+Preparing to unpack .../23-gcc_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking gcc (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libc-dev-bin.
+Preparing to unpack .../24-libc-dev-bin_2.27-3ubuntu1.4_amd64.deb ...
+Unpacking libc-dev-bin (2.27-3ubuntu1.4) ...
+Selecting previously unselected package linux-libc-dev:amd64.
+Preparing to unpack .../25-linux-libc-dev_4.15.0-154.161_amd64.deb ...
+Unpacking linux-libc-dev:amd64 (4.15.0-154.161) ...
+Selecting previously unselected package libc6-dev:amd64.
+Preparing to unpack .../26-libc6-dev_2.27-3ubuntu1.4_amd64.deb ...
+Unpacking libc6-dev:amd64 (2.27-3ubuntu1.4) ...
+Selecting previously unselected package libtool.
+Preparing to unpack .../27-libtool_2.4.6-2_all.deb ...
+Unpacking libtool (2.4.6-2) ...
+Selecting previously unselected package dh-autoreconf.
+Preparing to unpack .../28-dh-autoreconf_17_all.deb ...
+Unpacking dh-autoreconf (17) ...
+Selecting previously unselected package libarchive-zip-perl.
+Preparing to unpack .../29-libarchive-zip-perl_1.60-1ubuntu0.1_all.deb ...
+Unpacking libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Selecting previously unselected package libfile-stripnondeterminism-perl.
+Preparing to unpack .../30-libfile-stripnondeterminism-perl_0.040-1.1~build1_all.deb ...
+Unpacking libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Selecting previously unselected package libtimedate-perl.
+Preparing to unpack .../31-libtimedate-perl_2.3000-2_all.deb ...
+Unpacking libtimedate-perl (2.3000-2) ...
+Selecting previously unselected package dh-strip-nondeterminism.
+Preparing to unpack .../32-dh-strip-nondeterminism_0.040-1.1~build1_all.deb ...
+Unpacking dh-strip-nondeterminism (0.040-1.1~build1) ...
+Selecting previously unselected package libcroco3:amd64.
+Preparing to unpack .../33-libcroco3_0.6.12-2_amd64.deb ...
+Unpacking libcroco3:amd64 (0.6.12-2) ...
+Selecting previously unselected package gettext.
+Preparing to unpack .../34-gettext_0.19.8.1-6ubuntu0.3_amd64.deb ...
+Unpacking gettext (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package intltool-debian.
+Preparing to unpack .../35-intltool-debian_0.35.0+20060710.4_all.deb ...
+Unpacking intltool-debian (0.35.0+20060710.4) ...
+Selecting previously unselected package po-debconf.
+Preparing to unpack .../36-po-debconf_1.0.20_all.deb ...
+Unpacking po-debconf (1.0.20) ...
+Selecting previously unselected package debhelper.
+Preparing to unpack .../37-debhelper_11.1.6ubuntu2_all.deb ...
+Unpacking debhelper (11.1.6ubuntu2) ...
+Selecting previously unselected package libstdc++-7-dev:amd64.
+Preparing to unpack .../38-libstdc++-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++-7.
+Preparing to unpack .../39-g++-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking g++-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++.
+Preparing to unpack .../40-g++_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking g++ (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package build-essential.
+Preparing to unpack .../41-build-essential_12.4ubuntu1_amd64.deb ...
+Unpacking build-essential (12.4ubuntu1) ...
+Selecting previously unselected package libfakeroot:amd64.
+Preparing to unpack .../42-libfakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking libfakeroot:amd64 (1.22-2ubuntu1) ...
+Selecting previously unselected package fakeroot.
+Preparing to unpack .../43-fakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking fakeroot (1.22-2ubuntu1) ...
+Setting up libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Setting up libtimedate-perl (2.3000-2) ...
+Setting up libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up linux-libc-dev:amd64 (4.15.0-154.161) ...
+Setting up m4 (1.4.18-1) ...
+Setting up liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcroco3:amd64 (0.6.12-2) ...
+Setting up gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up autotools-dev (20180224.1) ...
+Setting up libfakeroot:amd64 (1.22-2ubuntu1) ...
+Setting up libmpc3:amd64 (1.1.0-1) ...
+Setting up libc-dev-bin (2.27-3ubuntu1.4) ...
+Setting up libc6-dev:amd64 (2.27-3ubuntu1.4) ...
+Setting up libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up autopoint (0.19.8.1-6ubuntu0.3) ...
+Setting up libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Setting up libisl19:amd64 (0.19-1) ...
+Setting up libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up gettext (0.19.8.1-6ubuntu0.3) ...
+Setting up libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up autoconf (2.69-11) ...
+Setting up fakeroot (1.22-2ubuntu1) ...
+update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
+Setting up libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up intltool-debian (0.35.0+20060710.4) ...
+Setting up automake (1:1.15.1-3ubuntu2) ...
+update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
+Setting up cpp (4:7.4.0-1ubuntu2.3) ...
+Setting up po-debconf (1.0.20) ...
+Setting up gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up g++-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up gcc (4:7.4.0-1ubuntu2.3) ...
+Setting up g++ (4:7.4.0-1ubuntu2.3) ...
+update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
+Setting up libtool (2.4.6-2) ...
+Setting up build-essential (12.4ubuntu1) ...
+Setting up dh-autoreconf (17) ...
+Setting up dh-strip-nondeterminism (0.040-1.1~build1) ...
+Setting up debhelper (11.1.6ubuntu2) ...
+Setting up autopkgtest-satdep (0) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--status', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-get', '--simulate', '--quiet', '-o', 'APT::Get::Show-User-Simulation-Note=False', '--auto-remove', 'purge', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Marking test dependencies as manually installed: dh-strip-nondeterminism debhelper dh-autoreconf libfile-stripnondeterminism-perl libarchive-zip-perl libtimedate-perl
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'dh-strip-nondeterminism', 'debhelper', 'dh-autoreconf', 'libfile-stripnondeterminism-perl', 'libarchive-zip-perl', 'libtimedate-perl'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--purge', 'autopkgtest-satdep'], kind short, sout raw, serr raw, env []
+(Reading database ... 100775 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'su --shell=/bin/sh ubuntu -c \'set -e; exec 3>&1 >&2; set -x; cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree; DEB_BUILD_OPTIONS="parallel=8 $DEB_BUILD_OPTIONS" dpkg-buildpackage -us -uc -b; dpkg-source --before-build .\''], kind build, sout pipe, serr raw, env ['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9']
++ cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree
++ DEB_BUILD_OPTIONS=parallel=8  dpkg-buildpackage -us -uc -b
+dpkg-buildpackage: info: source package dummy
+dpkg-buildpackage: info: source version 0.1+-g+ci-1build1
+dpkg-buildpackage: info: source distribution bionic
+dpkg-buildpackage: info: source changed by Andres Rodriguez <andreserl@ubuntu.com>
+ dpkg-source --before-build real-tree
+dpkg-buildpackage: info: host architecture amd64
+ fakeroot debian/rules clean
+dh clean
+   dh_clean
+ debian/rules build
+dh build
+   dh_update_autotools_config
+ fakeroot debian/rules binary
+dh binary
+   dh_testroot
+   dh_prep
+   dh_installdocs
+   dh_installchangelogs
+   dh_perl
+   dh_link
+   dh_strip_nondeterminism
+   dh_compress
+   dh_fixperms
+   dh_missing
+   dh_strip
+   dh_makeshlibs
+   dh_shlibdeps
+   dh_installdeb
+   dh_gencontrol
+dpkg-gencontrol: warning: Depends field of package dummy: unknown substitution variable ${shlibs:Depends}
+   dh_md5sums
+   dh_builddeb
+dpkg-deb: building package 'dummy' in '../dummy_0.1+-g+ci-1build1_amd64.deb'.
+ dpkg-genbuildinfo --build=binary
+ dpkg-genchanges --build=binary >../dummy_0.1+-g+ci-1build1_amd64.changes
+dpkg-genchanges: info: binary-only upload (no source code included)
+ dpkg-source --after-build real-tree
+dpkg-buildpackage: info: binary-only upload (no source included)
++ dpkg-source --before-build .
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.18dmni1z/runcmd', 'sh', '-ec', 'cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; tar --warning=none -c . -f -'], ['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/', '--warning=none', '--preserve-permissions', '--extract', '--no-same-owner', '-f', '-'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; tar --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> want built binaries, getting and registering built debs
+autopkgtest: DBG: testbed command ['sh', '-ec', 'cd "/tmp/autopkgtest.dn9EKj/build.Bke"; echo *.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> debs=['dummy_0.1+-g+ci-1build1_amd64.deb']
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas>  deb=dummy_0.1+-g+ci-1build1_amd64.deb, pkgname=dummy
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/../dummy_0.1%2B-g%2Bci-1build1_amd64.deb /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1%2B-g%2Bci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/../dummy_0.1%2B-g%2Bci-1build1_amd64.deb /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1%2B-g%2Bci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.18dmni1z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/build.Bke/real-tree/../dummy_0.1+-g+ci-1build1_amd64.deb'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1+-g+ci-1build1_amd64.deb'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.18dmni1z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/build.Bke/real-tree/../dummy_0.1+-g+ci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: Binaries: register deb=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1+-g+ci-1build1_amd64.deb pkgname=dummy 
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> got all built binaries
+autopkgtest: DBG: processing dependency maas
+autopkgtest: DBG: processing dependency maas-dhcp
+autopkgtest: DBG: processing dependency maas-dns
+autopkgtest: DBG: processing dependency maas-cli
+autopkgtest: DBG: processing dependency python3-mock
+autopkgtest: DBG: processing dependency python3-nose
+autopkgtest: DBG: processing dependency python3-setuptools
+autopkgtest: DBG: processing dependency python3-yaml
+autopkgtest: DBG: processing dependency devscripts
+autopkgtest: DBG: processing dependency build-essential
+autopkgtest: DBG: processing dependency pep8
+autopkgtest: DBG: processing dependency pyflakes
+autopkgtest: DBG: processing dependency fakeroot
+autopkgtest: DBG: processing dependency debhelper
+autopkgtest: DBG: processing dependency python3-oauthlib
+autopkgtest: DBG: processing dependency python3-testtools
+autopkgtest: DBG: Test defined: name maas-package-test path debian/tests/maas-package-test command "None" restrictions ['needs-root'] features [] depends ['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'] clicks [] installed clicks []
+autopkgtest [19:33:49]: test maas-package-test: preparing testbed
+autopkgtest: DBG: testbed reset: modified=True, deps_installed=[](r: False), deps_new=['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'](r: False)
+autopkgtest: DBG: testbed reset
+autopkgtest: DBG: sending command to testbed: revert
+autopkgtest-virt-qemu: DBG: executing revert
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.18dmni1z/runcmd rm -rf -- /tmp/autopkgtest.dn9EKj
+qemu-system-x86_64: terminating on signal 15 from pid 4007712 (/usr/bin/python3)
+autopkgtest-virt-qemu: DBG: find_free_port: trying 10022
+autopkgtest-virt-qemu: DBG: find_free_port: 10022 is free
+autopkgtest-virt-qemu: DBG: qemu architecture: x86_64
+autopkgtest-virt-qemu: DBG: qemu command: qemu-system-x86_64
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img info --output=json /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest-virt-qemu: DBG: Creating temporary overlay image in /tmp/autopkgtest-qemu.rtstl4_z/overlay.img
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img create -f qcow2 -F qcow2 -b /home/ubuntu/images/autopkgtest-bionic-amd64.img /tmp/autopkgtest-qemu.rtstl4_z/overlay.img
+autopkgtest-virt-qemu: DBG: Forwarding local port 10022 to VM ssh port 22
+autopkgtest-virt-qemu: DBG: Assuming nothing special needs to be done to set up firmware to boot this machine (boot method: bios)
+autopkgtest-virt-qemu: DBG: Detected KVM capable Intel host CPU, enabling nested KVM
+autopkgtest-virt-qemu: DBG: full qemu command-line: ['qemu-system-x86_64', '-m', '8192', '-smp', '1', '-nographic', '-net', 'nic,model=virtio', '-net', 'user,hostfwd=tcp:127.0.0.1:10022-:22', '-object', 'rng-random,filename=/dev/urandom,id=rng0', '-device', 'virtio-rng-pci,rng=rng0,id=rng-device0', '-monitor', 'unix:/tmp/autopkgtest-qemu.rtstl4_z/monitor,server,nowait', '-virtfs', 'local,id=autopkgtest,path=/tmp/autopkgtest-qemu.rtstl4_z/shared,security_model=none,mount_tag=autopkgtest', '-chardev', 'socket,path=/tmp/autopkgtest-qemu.rtstl4_z/hvc0,server,nowait,id=hvc0', '-device', 'virtio-serial', '-device', 'virtconsole,chardev=hvc0', '-chardev', 'socket,path=/tmp/autopkgtest-qemu.rtstl4_z/hvc1,server,nowait,id=hvc1', '-device', 'virtio-serial', '-device', 'virtconsole,chardev=hvc1', '-serial', 'unix:/tmp/autopkgtest-qemu.rtstl4_z/ttyS0,server,nowait', '-serial', 'unix:/tmp/autopkgtest-qemu.rtstl4_z/ttyS1,server,nowait', '-drive', 'index=0,file=/tmp/autopkgtest-qemu.rtstl4_z/overlay.img,cache=unsafe,if=virtio,discard=unmap,format=qcow2', '-enable-kvm', '-cpu', 'kvm64,+vmx,+lahf_lm', '-readconfig', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg']
+autopkgtest-virt-qemu: DBG: expect: b' login: '
+c[?7l[2J[0mSeaBIOS (version 1.13.0-1ubuntu1.1)
+
+
+iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+BFF8C740+BFECC740 CA00
+Press Ctrl-B to configure iPXE (PCI 00:03.0)...                                                                               
+
+
+
+
+iPXE (http://ipxe.org) 00:08.0 CB00 PCI2.10 PnP PMM BFF8C740 BFECC740 CB00
+Press Ctrl-B to configure iPXE (PCI 00:08.0)...                                                                               
+
+
+Booting from Hard Disk...
+[    0.000000] Linux version 4.15.0-144-generic (buildd@lgw01-amd64-031) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #148-Ubuntu SMP Sat May 8 02:33:43 UTC 2021 (Ubuntu 4.15.0-144.148-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-144-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffdcfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffdd000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000023fffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.13.0-1ubuntu1.1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0x240000 max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] e820: last_pfn = 0xbffdd max_arch_pfn = 0x400000000
+[    0.000000] found SMP MP-table at [mem 0x000f5c70-0x000f5c7f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x32e6d000-0x3572dfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F5A80 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE17FE 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE16A2 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001662 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE1716 0000B0 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE17C6 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x000000023fffffff]
+[    0.000000] NODE_DATA(0) allocated [mem 0x23ffd2000-0x23fffcfff]
+[    0.000000] kvm-clock: cpu 0, msr 2:3ff51001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 2120284134 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffdcfff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x000000023fffffff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xbffdd000-0xbfffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xc0000000-0xfeffbfff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfeffc000-0xfeffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xff000000-0xfffbffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfffc0000-0xffffffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x500 with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:8 nr_cpu_ids:8 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u262144
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr 23fc23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2064230
+[    0.000000] Policy zone: Normal
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-144-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 8118732K/8388076K available (12300K kernel code, 2483K rwdata, 4316K rodata, 2448K init, 2724K bss, 269344K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39453 entries in 155 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=8.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+[    0.004000] NR_IRQS: 524544, nr_irqs: 488, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [tty0] enabled
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004007] APIC: Switch to symmetric I/O mode setup
+[    0.005288] x2apic enabled
+[    0.006174] Switched APIC routing to physical x2apic.
+[    0.008000] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.202 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.40 BogoMIPS (lpj=9588808)
+[    0.008000] pid_max: default: 32768 minimum: 301
+[    0.008027] Security Framework initialized
+[    0.008820] Yama: becoming mindful.
+[    0.009672] AppArmor: AppArmor initialized
+[    0.012979] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.015390] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.016018] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.017313] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.018974] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.020002] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.021186] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.022705] Spectre V2 : Mitigation: Full generic retpoline
+[    0.024001] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.025698] Speculative Store Bypass: Vulnerable
+[    0.026547] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.028162] Freeing SMP alternatives memory: 36K
+[    0.139561] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.140000] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.140000] Hierarchical SRCU implementation.
+[    0.140520] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.141568] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.142756] smp: Bringing up secondary CPUs ...
+[    0.144075] x86: Booting SMP configuration:
+[    0.144815] .... node  #0, CPUs:      #1
+[    0.004000] kvm-clock: cpu 1, msr 2:3ff51041, secondary cpu clock
+[    0.160029] KVM setup async PF for cpu 1
+[    0.162053] kvm-stealtime: cpu 1, msr 23fc63040
+[    0.164072]  #2
+[    0.004000] kvm-clock: cpu 2, msr 2:3ff51081, secondary cpu clock
+[    0.180031] KVM setup async PF for cpu 2
+[    0.181946] kvm-stealtime: cpu 2, msr 23fca3040
+[    0.184096]  #3
+[    0.004000] kvm-clock: cpu 3, msr 2:3ff510c1, secondary cpu clock
+[    0.200033] KVM setup async PF for cpu 3
+[    0.201945] kvm-stealtime: cpu 3, msr 23fce3040
+[    0.204090]  #4
+[    0.004000] kvm-clock: cpu 4, msr 2:3ff51101, secondary cpu clock
+[    0.220030] KVM setup async PF for cpu 4
+[    0.221585] kvm-stealtime: cpu 4, msr 23fd23040
+[    0.224086]  #5
+[    0.004000] kvm-clock: cpu 5, msr 2:3ff51141, secondary cpu clock
+[    0.240031] KVM setup async PF for cpu 5
+[    0.241976] kvm-stealtime: cpu 5, msr 23fd63040
+[    0.244098]  #6
+[    0.004000] kvm-clock: cpu 6, msr 2:3ff51181, secondary cpu clock
+[    0.260031] KVM setup async PF for cpu 6
+[    0.261934] kvm-stealtime: cpu 6, msr 23fda3040
+[    0.264093]  #7
+[    0.004000] kvm-clock: cpu 7, msr 2:3ff511c1, secondary cpu clock
+[    0.280039] KVM setup async PF for cpu 7
+[    0.281845] kvm-stealtime: cpu 7, msr 23fde3040
+[    0.282925] smp: Brought up 1 node, 8 CPUs
+[    0.284018] smpboot: Max logical packages: 1
+[    0.284932] smpboot: Total of 8 processors activated (38355.23 BogoMIPS)
+[    0.288119] devtmpfs: initialized
+[    0.288812] x86/mm: Memory block size: 128MB
+[    0.290233] evm: security.selinux
+[    0.290895] evm: security.SMACK64
+[    0.292003] evm: security.SMACK64EXEC
+[    0.292722] evm: security.SMACK64TRANSMUTE
+[    0.293655] evm: security.SMACK64MMAP
+[    0.294481] evm: security.apparmor
+[    0.295243] evm: security.ima
+[    0.296003] evm: security.capability
+[    0.296818] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.300028] futex hash table entries: 2048 (order: 5, 131072 bytes)
+[    0.302199] pinctrl core: initialized pinctrl subsystem
+[    0.303795] RTC time: 19:33:53, date: 08/25/21
+[    0.304280] NET: Registered protocol family 16
+[    0.305646] audit: initializing netlink subsys (disabled)
+[    0.312090] audit: type=2000 audit(1629920033.590:1): state=initialized audit_enabled=0 res=1
+[    0.316023] cpuidle: using governor ladder
+[    0.320049] cpuidle: using governor menu
+[    0.320399] ACPI: bus type PCI registered
+[    0.324007] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.327137] PCI: Using configuration type 1 for base access
+[    0.332087] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.336185] ACPI: Added _OSI(Module Device)
+[    0.338221] ACPI: Added _OSI(Processor Device)
+[    0.340019] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.342088] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.344006] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.345067] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.348002] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.351004] ACPI: Interpreter enabled
+[    0.352020] ACPI: (supports S0 S3 S4 S5)
+[    0.353000] ACPI: Using IOAPIC for interrupt routing
+[    0.354257] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.356165] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.361798] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.363430] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.364009] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.365554] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.368684] acpiphp: Slot [3] registered
+[    0.372084] acpiphp: Slot [4] registered
+[    0.374092] acpiphp: Slot [5] registered
+[    0.376081] acpiphp: Slot [6] registered
+[    0.378088] acpiphp: Slot [7] registered
+[    0.380081] acpiphp: Slot [8] registered
+[    0.382068] acpiphp: Slot [9] registered
+[    0.384099] acpiphp: Slot [10] registered
+[    0.386236] acpiphp: Slot [11] registered
+[    0.388086] acpiphp: Slot [12] registered
+[    0.390114] acpiphp: Slot [13] registered
+[    0.392080] acpiphp: Slot [14] registered
+[    0.394131] acpiphp: Slot [15] registered
+[    0.396080] acpiphp: Slot [16] registered
+[    0.398097] acpiphp: Slot [17] registered
+[    0.400080] acpiphp: Slot [18] registered
+[    0.402229] acpiphp: Slot [19] registered
+[    0.404080] acpiphp: Slot [20] registered
+[    0.406106] acpiphp: Slot [21] registered
+[    0.408080] acpiphp: Slot [22] registered
+[    0.410118] acpiphp: Slot [23] registered
+[    0.412080] acpiphp: Slot [24] registered
+[    0.414129] acpiphp: Slot [25] registered
+[    0.416080] acpiphp: Slot [26] registered
+[    0.418132] acpiphp: Slot [27] registered
+[    0.420080] acpiphp: Slot [28] registered
+[    0.422123] acpiphp: Slot [29] registered
+[    0.424081] acpiphp: Slot [30] registered
+[    0.426126] acpiphp: Slot [31] registered
+[    0.428035] PCI host bridge to bus 0000:00
+[    0.430028] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.432005] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.436005] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.440005] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.444005] pci_bus 0000:00: root bus resource [mem 0x240000000-0x2bfffffff window]
+[    0.447605] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.463127] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.464008] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.468006] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.472004] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.477452] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.480027] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.573401] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.574863] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.576139] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.577554] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.578879] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.580970] SCSI subsystem initialized
+[    0.581943] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.581943] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.584006] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.585506] vgaarb: loaded
+[    0.588039] ACPI: bus type USB registered
+[    0.589112] usbcore: registered new interface driver usbfs
+[    0.590473] usbcore: registered new interface driver hub
+[    0.591779] usbcore: registered new device driver usb
+[    0.592057] EDAC MC: Ver: 3.0.0
+[    0.593131] PCI: Using ACPI for IRQ routing
+[    0.596420] NetLabel: Initializing
+[    0.597319] NetLabel:  domain hash size = 128
+[    0.598417] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.599828] NetLabel:  unlabeled traffic allowed by default
+[    0.600938] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.604029] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.605247] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.609075] clocksource: Switched to clocksource kvm-clock
+[    0.628710] VFS: Disk quotas dquot_6.6.0
+[    0.629524] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.630917] AppArmor: AppArmor Filesystem Enabled
+[    0.631885] pnp: PnP ACPI init
+[    0.632951] pnp: PnP ACPI: found 7 devices
+[    0.641130] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.642841] NET: Registered protocol family 2
+[    0.643811] TCP established hash table entries: 65536 (order: 7, 524288 bytes)
+[    0.645262] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
+[    0.646607] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.647846] UDP hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.648884] UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.650508] NET: Registered protocol family 1
+[    0.651375] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.652534] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.653562] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.654737] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.656386] Unpacking initramfs...
+[    1.086533] Freeing initrd memory: 41732K
+[    1.087494] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.088545] software IO TLB: mapped [mem 0xbbfdd000-0xbffdd000] (64MB)
+[    1.089611] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228de43df3e, max_idle_ns: 440795235278 ns
+[    1.091375] Scanning for low memory corruption every 60 seconds
+[    1.093032] Initialise system trusted keyrings
+[    1.093878] Key type blacklist registered
+[    1.094769] workingset: timestamp_bits=36 max_order=21 bucket_order=0
+[    1.096650] zbud: loaded
+[    1.097958] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.099355] fuse init (API version 7.26)
+[    1.103766] Key type asymmetric registered
+[    1.104646] Asymmetric key parser 'x509' registered
+[    1.105646] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    1.107363] io scheduler noop registered
+[    1.108222] io scheduler deadline registered
+[    1.109032] io scheduler cfq registered (default)
+[    1.110566] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    1.112083] ACPI: Power Button [PWRF]
+[    1.133230] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    1.154989] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    1.176483] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    1.198089] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    1.261159] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.287431] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.313958] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.342655] console [hvc0] enabled
+[    1.378363] Linux agpgart interface v0.103
+[    1.384272] loop: module loaded
+[    1.386534] scsi host0: ata_piix
+[    1.387741] scsi host1: ata_piix
+[    1.388682] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc1a0 irq 14
+[    1.390326] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc1a8 irq 15
+[    1.392040] libphy: Fixed MDIO Bus: probed
+[    1.393211] tun: Universal TUN/TAP device driver, 1.6
+[    1.394532] PPP generic driver version 2.4.2
+[    1.395802] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.397427] ehci-pci: EHCI PCI platform driver
+[    1.398564] ehci-platform: EHCI generic platform driver
+[    1.399841] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.401391] ohci-pci: OHCI PCI platform driver
+[    1.402562] ohci-platform: OHCI generic platform driver
+[    1.403841] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.405321] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.407871] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.409137] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.410569] mousedev: PS/2 mouse device common for all mice
+[    1.412269] rtc_cmos 00:00: RTC can wake from S4
+[    1.413907] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    1.413910] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    1.417549] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    1.423149] i2c /dev entries driver
+[    1.424352] device-mapper: uevent: version 1.0.3
+[    1.425827] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    1.433467] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.435741] NET: Registered protocol family 10
+[    1.446641] Segment Routing with IPv6
+[    1.447965] NET: Registered protocol family 17
+[    1.449718] Key type dns_resolver registered
+[    1.452674] mce: Using 10 MCE banks
+[    1.453918] RAS: Correctable Errors collector initialized.
+[    1.455597] sched_clock: Marking stable (1452638506, 0)->(1817227924, -364589418)
+[    1.458231] registered taskstats version 1
+[    1.459389] Loading compiled-in X.509 certificates
+[    1.465373] Loaded X.509 cert 'Build time autogenerated kernel key: 1e5516648b223d94d04ce7d99e6048c9b3ebcb77'
+[    1.469056] Loaded X.509 cert 'Canonical Ltd. Live Patch Signing: 14df34d1a87cf37625abec039ef2bf521249b969'
+[    1.475697] Loaded X.509 cert 'Canonical Ltd. Kernel Module Signing: 88f752e560a1e0737e31163a466ad7b70a850c19'
+[    1.479315] zswap: loaded using pool lzo/zbud
+[    1.485701] Key type big_key registered
+[    1.486990] Key type trusted registered
+[    1.491022] Key type encrypted registered
+[    1.493974] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.496226] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    1.498327] ima: Allocated hash algorithm: sha1
+[    1.500060] evm: HMAC attrs: 0x1
+[    1.502240]   Magic number: 1:936:597
+[    1.503955] rtc_cmos 00:00: setting system clock to 2021-08-25 19:33:54 UTC (1629920034)
+[    1.506824] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    1.508469] EDD information not available.
+[    1.553859] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.557748] ata2.00: configured for MWDMA2
+[    1.561473] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.593293] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.596824] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.600199] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.609280] Freeing unused kernel image memory: 2448K
+[    1.628110] Write protecting the kernel read-only data: 20480k
+[    1.632207] Freeing unused kernel image memory: 2008K
+[    1.635017] Freeing unused kernel image memory: 1828K
+[    1.646990] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.648865] x86/mm: Checking user space page tables
+[    1.657583] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.769553] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.773431] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.781718] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.782737]  vda: vda1 vda14 vda15
+[    1.785883] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.793055] FDC 0 is a S82078B
+[    1.802679] virtio_net virtio0 ens3: renamed from eth0
+[    1.820334] virtio_net virtio5 ens8: renamed from eth1
+[    1.872151] print_req_error: I/O error, dev fd0, sector 0
+[    1.874982] floppy: error 10 while reading block 0
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    2.004043] raid6: sse2x1   gen()  6392 MB/s
+[    2.052015] raid6: sse2x1   xor()  2877 MB/s
+[    2.100031] raid6: sse2x2   gen()  5026 MB/s
+[    2.148011] raid6: sse2x2   xor()  5241 MB/s
+[    2.196009] raid6: sse2x4   gen() 11639 MB/s
+[    2.244013] raid6: sse2x4   xor()  7225 MB/s
+[    2.245282] raid6: using algorithm sse2x4 gen() 11639 MB/s
+[    2.246752] raid6: .... xor() 7225 MB/s, rmw enabled
+[    2.248104] raid6: using intx1 recovery algorithm
+[    2.252828] xor: measuring software checksum speed
+[    2.292008]    prefetch64-sse: 14685.000 MB/sec
+[    2.332007]    generic_sse: 13359.000 MB/sec
+[    2.333253] xor: using function: prefetch64-sse (14685.000 MB/sec)
+[    2.352290] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    2.504089] print_req_error: I/O error, dev fd0, sector 0
+[    2.506027] floppy: error 10 while reading block 0
+done.
+Begin: Will now check root file system ... fsck from util-linux 2.31.1
+[/sbin/fsck.ext4 (1) -- /dev/vda1] fsck.ext4 -a -C0 /dev/vda1 
+cloudimg-rootfs: clean, 67053/8015616 files, 1399457/16276731 blocks
+done.
+[    2.549602] random: fast init done
+[    2.551482] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+[    2.553040] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+[    2.553797] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+done.
+Begin: Running /[    2.559018] random: systemd-udevd: uninitialized urandom read (16 bytes read)
+scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+[    2.778767] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.786015] random: crng init done
+[    2.794428] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.799989] systemd[1]: Detected virtualization kvm.
+[    2.801526] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.5 LTS[0m!
+
+[    2.812039] systemd[1]: Set hostname to <autopkgtest>.
+[    3.005432] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[    3.010200] systemd[1]: Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[    3.015489] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    3.020566] systemd[1]: Reached target Swap.
+[[0;32m  OK  [0m] Reached target Swap.
+[    3.023949] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    3.026527] systemd[1]: Created slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Created slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Created slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executab…rmats File System Automount Point.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Starting Set the console keyboard layout...
+         Starting Uncomplicated firewall...
+         Mounting Huge Pages File System...
+         Mounting POSIX Message Queue File System...
+         Starting Create list of required st…ce nodes for the current kernel...
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+         Starting Journal Service...
+         Starting udev Coldplug all Devices...
+[[0;32m  OK  [0m] Listening on fsck to fsckd communication Socket.
+         Starting Remount Root and Kernel File Systems...
+         Mounting Kernel Debug File System...
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Mounted Huge Pag[    3.073974] EXT4-fs (vda1): re-mounted. Opts: (null)
+es File System.
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Create list of required sta…vice nodes for the current kernel.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+         Starting Load/Save Random Seed...
+         Starting Apply Kernel Variables...
+         Mounting FUSE Control File System...
+         Mounting Kernel Configuration File System...
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Started Network Service.
+[    3.268049] print_req_error: I/O error, dev fd0, sector 0
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Found device /dev/hvc0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+         Starting File System Check on /dev/disk/by-label/UEFI...
+[[0;32m  OK  [0m] Started File System Check Daemon to report status.
+[[0;32m  OK  [0m] Started File System Check on /dev/disk/by-label/UEFI.
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Create Volatile Files and Directories...
+         Starting AppArmor initialization...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting Set console font and keymap...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Network Name Resolution...
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Started Ubuntu Advantage update messaging.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+         Starting rng-tools.service...
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started irqbalance daemon.
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+[[0;32m  OK  [0m] Started autopkgtest root shell on hvc1.
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+         Starting Thermal Daemon Service...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+         Starting LSB: Record successful boot for GRUB...
+         Starting Login Service...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting LSB: automatic crash report generation...
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started rng-tools.service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started Login Service.
+         Starting Discard unused blocks...
+         Starting Message of the Day...
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Reached target Network.
+         Starting Daily apt download activities...
+         Starting OpenBSD Secure Shell server...
+         Starting Permit User Sessions...
+         Starting Ubuntu Advantage APT and MOTD Messages...
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started Discard unused blocks.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+         Starting Terminate Plymouth Boot Screen...
+         Starting Hold until boot process finishes up...
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on hvc0.
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+[[0;32m  OK  [0m] Started Ubuntu Advantage APT and MOTD Messages.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+         Starting Daily apt upgrade and clean activities...
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+
+Ubuntu 18.04.5 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found "'login prompt on serial console'"
+autopkgtest-virt-qemu: DBG: expect: b'ok'
+autopkgtest-virt-qemu: DBG: expect: found "b'ok'"
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on hvc1
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[1]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[1]'"
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[2]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[2]'"
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[3]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[3]'"
+autopkgtest-virt-qemu: DBG: Copying host timezone Etc/UTC to VM
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[4]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[4]'"
+autopkgtest-virt-qemu: DBG: expect: b'/python'
+autopkgtest-virt-qemu: DBG: expect: found "b'/python'"
+autopkgtest-virt-qemu: DBG: expect: b'# '
+autopkgtest-virt-qemu: DBG: expect: found "b'# '"
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[5]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[5]'"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd true
+autopkgtest-virt-qemu: DBG: can connect to autopkgtest sh in VM
+autopkgtest-virt-qemu: DBG: expect: b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[6]'
+autopkgtest-virt-qemu: DBG: expect: found "b'144d5d65-00d3-4a0e-b6a2-7b766c79e218[6]'"
+autopkgtest-virt-qemu: DBG: determine_normal_user: got user "ubuntu"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd mkdir --mode=1777 --parents /tmp/autopkgtest.dn9EKj
+autopkgtest-virt-qemu: DBG: auxverb = ['/tmp/autopkgtest-qemu.rtstl4_z/runcmd'], downtmp = /tmp/autopkgtest.dn9EKj
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest.dn9EKj
+autopkgtest: DBG: sending command to testbed: print-execute-command
+autopkgtest-virt-qemu: DBG: executing print-execute-command
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest-qemu.rtstl4_z/runcmd
+autopkgtest: DBG: sending command to testbed: capabilities
+autopkgtest-virt-qemu: DBG: executing capabilities
+autopkgtest: DBG: got reply from testbed: ok revert revert-full-system root-on-testbed isolation-machine reboot suggested-normal-user=ubuntu
+autopkgtest: DBG: testbed capabilities: ['revert', 'revert-full-system', 'root-on-testbed', 'isolation-machine', 'reboot', 'suggested-normal-user=ubuntu', 'has_internet']
+autopkgtest [19:34:07]: @@@@@@@@@@@@@@@@@@@@ test bed setup
+autopkgtest: DBG: testbed command ['bash', '-ec', 'for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do [ ! -d $d ] || touch -r $d /tmp/autopkgtest.dn9EKj/${d//\\//_}.stamp; done'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew" && $(which eatmydata || true) apt-get --purge autoremove -y'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,747 kB]
+Get:6 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [419 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [443 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [27.3 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2,191 kB]
+Get:10 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [20.9 kB]
+Get:11 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1,136 kB]
+Get:12 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [1,845 kB]
+Fetched 8,081 kB in 2s (3,239 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following packages were automatically installed and are no longer required:
+  python3-configobj python3-serial
+Use 'apt autoremove' to remove them.
+The following NEW packages will be installed:
+  linux-headers-4.15.0-154 linux-headers-4.15.0-154-generic
+  linux-image-4.15.0-154-generic linux-modules-4.15.0-154-generic
+  linux-modules-extra-4.15.0-154-generic
+The following packages will be upgraded:
+  apt apt-utils curl distro-info-data grub-efi-amd64-bin grub-efi-amd64-signed
+  gzip initramfs-tools initramfs-tools-bin initramfs-tools-core libapt-inst2.0
+  libapt-pkg5.0 libcurl4 libhogweed4 libnettle6 libnss-systemd libpam-systemd
+  libssl1.1 libsystemd0 libudev1 libxml2 linux-base linux-generic
+  linux-headers-generic linux-headers-virtual linux-image-generic
+  linux-image-virtual linux-virtual openssh-client openssh-server
+  openssh-sftp-server openssl systemd systemd-sysv ubuntu-advantage-tools udev
+  wireless-regdb
+37 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
+Need to get 80.5 MB of archives.
+After this operation, 351 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gzip amd64 1.6-5ubuntu1.1 [89.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss-systemd amd64 237-3ubuntu10.51 [105 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsystemd0 amd64 237-3ubuntu10.51 [207 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpam-systemd amd64 237-3ubuntu10.51 [107 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd amd64 237-3ubuntu10.51 [2,913 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 udev amd64 237-3ubuntu10.51 [1,102 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libudev1 amd64 237-3ubuntu10.51 [56.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools all 0.130ubuntu3.13 [9,608 B]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-core all 0.130ubuntu3.13 [49.0 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-bin amd64 0.130ubuntu3.13 [10.9 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-base all 4.5ubuntu1.6 [17.9 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd-sysv amd64 237-3ubuntu10.51 [13.9 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-pkg5.0 amd64 1.6.14 [809 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-inst2.0 amd64 1.6.14 [57.3 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt amd64 1.6.14 [1,207 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt-utils amd64 1.6.14 [209 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnettle6 amd64 3.4.1-0ubuntu0.18.04.1 [111 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libhogweed4 amd64 3.4.1-0ubuntu0.18.04.1 [140 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.11 [4,652 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.13 [1,302 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxml2 amd64 2.9.4+dfsg1-6.1ubuntu1.4 [664 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssl amd64 1.1.1-1ubuntu2.1~18.04.13 [614 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ubuntu-advantage-tools amd64 27.2.2~18.04.1 [686 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-sftp-server amd64 1:7.6p1-4ubuntu0.5 [45.5 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-server amd64 1:7.6p1-4ubuntu0.5 [332 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssh-client amd64 1:7.6p1-4ubuntu0.5 [612 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 curl amd64 7.58.0-2ubuntu3.14 [159 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4 amd64 7.58.0-2ubuntu3.14 [219 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-signed amd64 1.167~18.04.5+2.04-1ubuntu44.1.2 [481 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-bin amd64 2.04-1ubuntu44.1.2 [726 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-4.15.0-154-generic amd64 4.15.0-154.161 [13.4 MB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-4.15.0-154-generic amd64 4.15.0-154.161 [8,092 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-4.15.0-154-generic amd64 4.15.0-154.161 [33.7 MB]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic amd64 4.15.0.154.143 [1,864 B]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic amd64 4.15.0.154.143 [2,536 B]
+Get:36 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-virtual amd64 4.15.0.154.143 [1,860 B]
+Get:37 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-virtual amd64 4.15.0.154.143 [2,512 B]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-virtual amd64 4.15.0.154.143 [1,840 B]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-154 all 4.15.0-154.161 [10.9 MB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-154-generic amd64 4.15.0-154.161 [1,256 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic amd64 4.15.0.154.143 [2,440 B]
+Get:42 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2021.07.14-0ubuntu1~18.04.1 [10.1 kB]
+Preconfiguring packages ...
+Fetched 80.5 MB in 19s (4,321 kB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../gzip_1.6-5ubuntu1.1_amd64.deb ...
+Unpacking gzip (1.6-5ubuntu1.1) over (1.6-5ubuntu1) ...
+Setting up gzip (1.6-5ubuntu1.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../libnss-systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking libnss-systemd:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libsystemd0_237-3ubuntu10.51_amd64.deb ...
+Unpacking libsystemd0:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Setting up libsystemd0:amd64 (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../libpam-systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking libpam-systemd:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../systemd_237-3ubuntu10.51_amd64.deb ...
+Unpacking systemd (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../udev_237-3ubuntu10.51_amd64.deb ...
+Unpacking udev (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libudev1_237-3ubuntu10.51_amd64.deb ...
+Unpacking libudev1:amd64 (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Setting up libudev1:amd64 (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61340 files and directories currently installed.)
+Preparing to unpack .../initramfs-tools_0.130ubuntu3.13_all.deb ...
+Unpacking initramfs-tools (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../initramfs-tools-core_0.130ubuntu3.13_all.deb ...
+Unpacking initramfs-tools-core (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../initramfs-tools-bin_0.130ubuntu3.13_amd64.deb ...
+Unpacking initramfs-tools-bin (0.130ubuntu3.13) over (0.130ubuntu3.12) ...
+Preparing to unpack .../linux-base_4.5ubuntu1.6_all.deb ...
+Unpacking linux-base (4.5ubuntu1.6) over (4.5ubuntu1.2) ...
+Setting up systemd (237-3ubuntu10.51) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../systemd-sysv_237-3ubuntu10.51_amd64.deb ...
+Unpacking systemd-sysv (237-3ubuntu10.51) over (237-3ubuntu10.47) ...
+Preparing to unpack .../libapt-pkg5.0_1.6.14_amd64.deb ...
+Unpacking libapt-pkg5.0:amd64 (1.6.14) over (1.6.13) ...
+Setting up libapt-pkg5.0:amd64 (1.6.14) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../libapt-inst2.0_1.6.14_amd64.deb ...
+Unpacking libapt-inst2.0:amd64 (1.6.14) over (1.6.13) ...
+Preparing to unpack .../archives/apt_1.6.14_amd64.deb ...
+Unpacking apt (1.6.14) over (1.6.13) ...
+Setting up apt (1.6.14) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../apt-utils_1.6.14_amd64.deb ...
+Unpacking apt-utils (1.6.14) over (1.6.13) ...
+Preparing to unpack .../libnettle6_3.4.1-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libnettle6:amd64 (3.4.1-0ubuntu0.18.04.1) over (3.4-1ubuntu0.1) ...
+Setting up libnettle6:amd64 (3.4.1-0ubuntu0.18.04.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../libhogweed4_3.4.1-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libhogweed4:amd64 (3.4.1-0ubuntu0.18.04.1) over (3.4-1ubuntu0.1) ...
+Setting up libhogweed4:amd64 (3.4.1-0ubuntu0.18.04.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 61341 files and directories currently installed.)
+Preparing to unpack .../00-distro-info-data_0.37ubuntu0.11_all.deb ...
+Unpacking distro-info-data (0.37ubuntu0.11) over (0.37ubuntu0.10) ...
+Preparing to unpack .../01-libssl1.1_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.9) ...
+Preparing to unpack .../02-libxml2_2.9.4+dfsg1-6.1ubuntu1.4_amd64.deb ...
+Unpacking libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.4) over (2.9.4+dfsg1-6.1ubuntu1.3) ...
+Preparing to unpack .../03-openssl_1.1.1-1ubuntu2.1~18.04.13_amd64.deb ...
+Unpacking openssl (1.1.1-1ubuntu2.1~18.04.13) over (1.1.1-1ubuntu2.1~18.04.9) ...
+Preparing to unpack .../04-ubuntu-advantage-tools_27.2.2~18.04.1_amd64.deb ...
+Unpacking ubuntu-advantage-tools (27.2.2~18.04.1) over (27.0.2~18.04.1) ...
+Preparing to unpack .../05-openssh-sftp-server_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-sftp-server (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../06-openssh-server_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-server (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../07-openssh-client_1%3a7.6p1-4ubuntu0.5_amd64.deb ...
+Unpacking openssh-client (1:7.6p1-4ubuntu0.5) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../08-curl_7.58.0-2ubuntu3.14_amd64.deb ...
+Unpacking curl (7.58.0-2ubuntu3.14) over (7.58.0-2ubuntu3.13) ...
+Preparing to unpack .../09-libcurl4_7.58.0-2ubuntu3.14_amd64.deb ...
+Unpacking libcurl4:amd64 (7.58.0-2ubuntu3.14) over (7.58.0-2ubuntu3.13) ...
+Preparing to unpack .../10-grub-efi-amd64-signed_1.167~18.04.5+2.04-1ubuntu44.1.2_amd64.deb ...
+Unpacking grub-efi-amd64-signed (1.167~18.04.5+2.04-1ubuntu44.1.2) over (1.167~18.04.3+2.04-1ubuntu44.1) ...
+Preparing to unpack .../11-grub-efi-amd64-bin_2.04-1ubuntu44.1.2_amd64.deb ...
+Unpacking grub-efi-amd64-bin (2.04-1ubuntu44.1.2) over (2.04-1ubuntu44.1) ...
+Selecting previously unselected package linux-modules-4.15.0-154-generic.
+Preparing to unpack .../12-linux-modules-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-modules-4.15.0-154-generic (4.15.0-154.161) ...
+Selecting previously unselected package linux-image-4.15.0-154-generic.
+Preparing to unpack .../13-linux-image-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-154-generic.
+Preparing to unpack .../14-linux-modules-extra-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-154-generic (4.15.0-154.161) ...
+Preparing to unpack .../15-linux-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../16-linux-image-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../17-linux-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../18-linux-image-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-image-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../19-linux-headers-virtual_4.15.0.154.143_amd64.deb ...
+Unpacking linux-headers-virtual (4.15.0.154.143) over (4.15.0.144.131) ...
+Selecting previously unselected package linux-headers-4.15.0-154.
+Preparing to unpack .../20-linux-headers-4.15.0-154_4.15.0-154.161_all.deb ...
+Unpacking linux-headers-4.15.0-154 (4.15.0-154.161) ...
+Selecting previously unselected package linux-headers-4.15.0-154-generic.
+Preparing to unpack .../21-linux-headers-4.15.0-154-generic_4.15.0-154.161_amd64.deb ...
+Unpacking linux-headers-4.15.0-154-generic (4.15.0-154.161) ...
+Preparing to unpack .../22-linux-headers-generic_4.15.0.154.143_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.154.143) over (4.15.0.144.131) ...
+Preparing to unpack .../23-wireless-regdb_2021.07.14-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2021.07.14-0ubuntu1~18.04.1) over (2020.11.20-0ubuntu1~18.04.1) ...
+Setting up linux-modules-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up libapt-inst2.0:amd64 (1.6.14) ...
+Setting up libnss-systemd:amd64 (237-3ubuntu10.51) ...
+Setting up grub-efi-amd64-bin (2.04-1ubuntu44.1.2) ...
+Setting up apt-utils (1.6.14) ...
+Setting up systemd-sysv (237-3ubuntu10.51) ...
+Setting up linux-base (4.5ubuntu1.6) ...
+Setting up linux-headers-4.15.0-154 (4.15.0-154.161) ...
+Setting up distro-info-data (0.37ubuntu0.11) ...
+Setting up wireless-regdb (2021.07.14-0ubuntu1~18.04.1) ...
+Setting up libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.4) ...
+Setting up grub-efi-amd64-signed (1.167~18.04.5+2.04-1ubuntu44.1.2) ...
+Installing for x86_64-efi platform.
+EFI variables are not supported on this system.
+Installation finished. No error reported.
+Setting up udev (237-3ubuntu10.51) ...
+update-initramfs: deferring update (trigger activated)
+Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up linux-headers-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up openssl (1.1.1-1ubuntu2.1~18.04.13) ...
+Setting up initramfs-tools-bin (0.130ubuntu3.13) ...
+Setting up openssh-client (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-154-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-154-generic
+Setting up linux-headers-generic (4.15.0.154.143) ...
+Setting up ubuntu-advantage-tools (27.2.2~18.04.1) ...
+Installing new version of config file /etc/apt/apt.conf.d/20apt-esm-hook.conf ...
+Installing new version of config file /etc/ubuntu-advantage/uaclient.conf ...
+Setting up libpam-systemd:amd64 (237-3ubuntu10.51) ...
+Setting up initramfs-tools-core (0.130ubuntu3.13) ...
+Setting up libcurl4:amd64 (7.58.0-2ubuntu3.14) ...
+Setting up initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: deferring update (trigger activated)
+Setting up linux-image-virtual (4.15.0.154.143) ...
+Setting up linux-modules-extra-4.15.0-154-generic (4.15.0-154.161) ...
+Setting up openssh-sftp-server (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-headers-virtual (4.15.0.154.143) ...
+Setting up linux-virtual (4.15.0.154.143) ...
+Setting up linux-image-generic (4.15.0.154.143) ...
+Setting up curl (7.58.0-2ubuntu3.14) ...
+Setting up openssh-server (1:7.6p1-4ubuntu0.5) ...
+Setting up linux-generic (4.15.0.154.143) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for linux-image-4.15.0-154-generic (4.15.0-154.161) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-154-generic
+/etc/kernel/postinst.d/x-grub-legacy-ec2:
+Searching for GRUB installation directory ... found: /boot/grub
+Searching for default file ... found: /boot/grub/default
+Testing for an existing GRUB menu.lst file ... found: /boot/grub/menu.lst
+Searching for splash image ... none found, skipping ...
+Found kernel: /boot/vmlinuz-4.15.0-144-generic
+Found kernel: /boot/vmlinuz-4.15.0-154-generic
+Found kernel: /boot/vmlinuz-4.15.0-144-generic
+Replacing config file /run/grub/menu.lst with new version
+Updating /boot/grub/menu.lst ... done
+
+/etc/kernel/postinst.d/zz-update-grub:
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-154-generic
+Found initrd image: /boot/initrd.img-4.15.0-154-generic
+Found linux image: /boot/vmlinuz-4.15.0-144-generic
+Found initrd image: /boot/initrd.img-4.15.0-144-generic
+done
+Processing triggers for initramfs-tools (0.130ubuntu3.13) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-154-generic
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following packages will be REMOVED:
+  python3-configobj* python3-serial*
+0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
+After this operation, 563 kB disk space will be freed.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 96897 files and directories currently installed.)
+Removing python3-configobj (5.0.6-2) ...
+Removing python3-serial (3.4-2) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['bash', '-ec', '[ ! -e /run/autopkgtest_no_reboot.stamp ] || exit 0;for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do s=/tmp/autopkgtest.dn9EKj/${d//\\//_}.stamp;  [ ! -d $d ] || [ `stat -c %Y $d` = `stat -c %Y $s` ]; done'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest [19:35:44]: rebooting testbed after setup commands that affected boot
+autopkgtest: DBG: sending command to testbed: reboot
+autopkgtest-virt-qemu: DBG: executing reboot
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec for d in /var/cache /home; do if [ -w $d ]; then   tar --warning=none --create --absolute-names     -f $d/autopkgtest-tmpdir.tar '/tmp/autopkgtest.dn9EKj';   rm -f /run/autopkgtest-reboot-prepare-mark;   exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: saved current downtmp, rebooting
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd test -d /run/systemd/system
+autopkgtest-virt-qemu: DBG: rebooting with command: ['systemd-run', '--no-block', '--quiet', 'sh', '-c', 'sleep 3; reboot']
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd systemd-run --no-block --quiet sh -c sleep 3; reboot
+autopkgtest-virt-qemu: DBG: expect: b' login: '
+[[0;32m  OK  [0m] Stopped target Graphical Interface.
+[[0;32m  OK  [0m] Stopped target Timers.
+[[0;32m  OK  [0m] Stopped Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Stopped Discard unused blocks once a week.
+[[0;32m  OK  [0m] Stopped target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Stopped Daily apt upgrade and clean activities.
+         Stopping /bin/sh -c sleep 3; reboot...
+[[0;32m  OK  [0m] Stopped target Multi-User System.
+         Stopping D-Bus System Message Bus...
+         Stopping irqbalance daemon...
+         Stopping Dispatcher daemon for systemd-networkd...
+         Stopping Login Service...
+         Stopping LSB: automatic crash report generation...
+         Stopping OpenBSD Secure Shell server...
+         Stopping autopkgtest root shell on ttyS1...
+         Stopping Deferred execution scheduler...
+         Stopping LSB: Record successful boot for GRUB...
+         Stopping rng-tools.service...
+[[0;32m  OK  [0m] Stopped Ubuntu Advantage updateStopping Serial Getty on ttyS0...
+         Stopping Getty on tty1...
+[[0;32m  OK  [0m] Stopped Message of the Day.
+[[0;32m  OK  [0m] Stopped target System Time Synchronized.
+[[0;32m  OK  [0m] Closed Load/Save RF Kill Switch Status /dev/rfkill Watch.
+         Stopping System Logging Service...
+         Stopping Serial Getty on hvc0...
+         Stopping Regular background program processing daemon...
+[[0;32m  OK  [0m] Stopped Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Stopped System Logging Service.
+[[0;32m  OK  [0m] Stopped irqbalance daemon.
+[[0;32m  OK  [0m] Stopped Regular background program processing daemon.
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on hvc1.
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Stopped Deferred execution scheduler.
+[[0;32m  OK  [0m] Stopped Serial Getty on hvc0.
+[[0;32m  OK  [0m] Stopped Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Stopped Getty on tty1.
+[[0;32m  OK  [0m] Stopped OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Stopped /bin/sh -c sleep 3; reboot.
+[[0;32m  OK  [0m] Stopped D-Bus System Message Bus.
+[[0;32m  OK  [0m] Removed slice system-getty.slice.
+         Stopping Permit User Sessions...
+[[0;32m  OK  [0m] Removed slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Removed slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Stopped Permit User Sessions.
+[[0;32m  OK  [0m] Stopped Login Service.
+[[0;32m  OK  [0m] Stopped target Network.
+         Stopping Network Name Resolution...
+[[0;32m  OK  [0m] Stopped LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Stopped LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Stopped Network Name Resolution.
+         Stopping Network Service...
+[[0;32m  OK  [0m] Stopped Network Service.
+[[0m[0;31m*     [0m] A stop job is running for rng-tools.service (5s / 5min)[K[[0;1;31m*[0m[0;31m*    [0m] A stop job is running for rng-tools.service (5s / 5min)[K[[0;31m*[0;1;31m*[0m[0;31m*   [0m] A stop job is running for rng-tools.service (6s / 5min)[K[ [0;31m*[0;1;31m*[0m[0;31m*  [0m] A stop job is running for rng-tools.service (6s / 5min)[K[  [0;31m*[0;1;31m*[0m[0;31m* [0m] A stop job is running for rng-tools.service (7s / 5min)[K[   [0;31m*[0;1;31m*[0m[0;31m*[0m] A stop job is running for rng-tools.service (7s / 5min)[K[    [0;31m*[0;1;31m*[0m] A stop job is running for rng-tools.service (8s / 5min)[K[     [0;31m*[0m] A stop job is running for rng-tools.service (8s / 5min)[K[    [0;31m*[0;1;31m*[0m] A stop job is running for rng-tools.service (9s / 5min)[K[   [0;31m*[0;1;31m*[0m[0;31m*[0m] A stop job is running for rng-tools.service (9s / 5min)[K[[0;32m  OK  [0m] Stopped rng-tools.service.
+[[0;32m  OK  [0m] Stopped target Basic System.
+[[0;32m  OK  [0m] Stopped target Slices.
+[[0;32m  OK  [0m] Removed slice User and Session Slice.
+[[0;32m  OK  [0m] Stopped target Paths.
+[[0;32m  OK  [0m] Stopped ACPI Events Check.
+[[0;32m  OK  [0m] Stopped target Sockets.
+[[0;32m  OK  [0m] Closed UUID daemon activation socket.
+[[0;32m  OK  [0m] Closed Syslog Socket.
+[[0;32m  OK  [0m] Closed ACPID Listen Socket.
+[[0;32m  OK  [0m] Closed D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Stopped target System Initialization.
+         Stopping Network Time Synchronization...
+         Stopping Load/Save Random Seed...
+[[0;32m  OK  [0m] Stopped target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Stopped Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Stopped Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Stopped target Swap.
+[[0;32m  OK  [0m] Stopped Apply Kernel Variables.
+[[0;32m  OK  [0m] Stopped Load Kernel Modules.
+         Stopping Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Stopped target Remote File Systems.
+[[0;32m  OK  [0m] Stopped Load/Save Random Seed.
+[[0;32m  OK  [0m] Stopped Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Stopped Network Time Synchronization.
+[[0;32m  OK  [0m] Stopped Create Volatile Files and Directories.
+[[0;32m  OK  [0m] Stopped target Local File Systems.
+         Unmounting /boot/efi...
+         Unmounting /run/autopkgtest/shared...
+[[0;32m  OK  [0m] Unmounted /boot/efi.
+[[0;32m  OK  [0m] Unmounted /run/autopkgtest/shared.
+[[0;32m  OK  [0m] Reached target Unmount All Filesystems.
+[[0;32m  OK  [0m] Stopped File System Check on /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Removed slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Stopped target Local File Systems (Pre).
+[[0;32m  OK  [0m] Stopped Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Stopped Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Reached target Shutdown.
+[[0;32m  OK  [0m] Reached target Final Step.
+         Starting Reboot...
+[  125.559388] reboot: Restarting system
+c[?7l[2J[0mSeaBIOS (version 1.13.0-1ubuntu1.1)
+
+
+iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+BFF8C740+BFECC740 CA00
+Press Ctrl-B to configure iPXE (PCI 00:03.0)...                                                                               
+
+
+
+
+iPXE (http://ipxe.org) 00:08.0 CB00 PCI2.10 PnP PMM BFF8C740 BFECC740 CB00
+Press Ctrl-B to configure iPXE (PCI 00:08.0)...                                                                               
+
+
+Booting from Hard Disk...
+[    0.000000] Linux version 4.15.0-154-generic (buildd@lcy01-amd64-011) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #161-Ubuntu SMP Fri Jul 30 13:04:17 UTC 2021 (Ubuntu 4.15.0-154.161-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-154-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffdcfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffdd000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000023fffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.13.0-1ubuntu1.1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0x240000 max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] e820: last_pfn = 0xbffdd max_arch_pfn = 0x400000000
+[    0.000000] found SMP MP-table at [mem 0x000f5c70-0x000f5c7f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x32e6d000-0x3572dfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F5A80 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE17FE 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE16A2 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001662 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE1716 0000B0 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE17C6 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] ACPI: Reserving FACP table memory at [mem 0xbffe16a2-0xbffe1715]
+[    0.000000] ACPI: Reserving DSDT table memory at [mem 0xbffe0040-0xbffe16a1]
+[    0.000000] ACPI: Reserving FACS table memory at [mem 0xbffe0000-0xbffe003f]
+[    0.000000] ACPI: Reserving APIC table memory at [mem 0xbffe1716-0xbffe17c5]
+[    0.000000] ACPI: Reserving HPET table memory at [mem 0xbffe17c6-0xbffe17fd]
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x000000023fffffff]
+[    0.000000] NODE_DATA(0) allocated [mem 0x23ffd5000-0x23fffffff]
+[    0.000000] kvm-clock: cpu 0, msr 2:3ff54001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 129386565857 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffdcfff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Reserved but unavailable: 100 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x000000023fffffff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xbffdd000-0xbfffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xc0000000-0xfeffbfff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfeffc000-0xfeffffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xff000000-0xfffbffff]
+[    0.000000] PM: Registered nosave memory: [mem 0xfffc0000-0xffffffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x500 with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:8 nr_cpu_ids:8 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u262144
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr 23fc23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2064230
+[    0.000000] Policy zone: Normal
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-154-generic root=UUID=e831388f-065e-40f6-8e64-4ed8cff75d1a ro console=tty0 console=hvc0 console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 8118744K/8388076K available (12300K kernel code, 2483K rwdata, 4320K rodata, 2448K init, 2724K bss, 269332K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39461 entries in 155 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=8.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+[    0.004000] NR_IRQS: 524544, nr_irqs: 488, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [tty0] enabled
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004010] APIC: Switch to symmetric I/O mode setup
+[    0.005553] x2apic enabled
+[    0.006612] Switched APIC routing to physical x2apic.
+[    0.008000] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.202 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.40 BogoMIPS (lpj=9588808)
+[    0.008003] pid_max: default: 32768 minimum: 301
+[    0.009152] Security Framework initialized
+[    0.010145] Yama: becoming mindful.
+[    0.012027] AppArmor: AppArmor initialized
+[    0.014382] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.016668] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.018313] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.020026] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.022138] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.024003] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.025279] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.027102] Spectre V2 : Mitigation: Full generic retpoline
+[    0.028002] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.029796] Speculative Store Bypass: Vulnerable
+[    0.030864] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.032178] Freeing SMP alternatives memory: 36K
+[    0.144286] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.146249] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.148028] Hierarchical SRCU implementation.
+[    0.149733] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.151075] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.152098] smp: Bringing up secondary CPUs ...
+[    0.153252] x86: Booting SMP configuration:
+[    0.154254] .... node  #0, CPUs:      #1
+[    0.004000] kvm-clock: cpu 1, msr 2:3ff54041, secondary cpu clock
+[    0.171036] KVM setup async PF for cpu 1
+[    0.171036] kvm-stealtime: cpu 1, msr 23fc63040
+[    0.172110]  #2
+[    0.004000] kvm-clock: cpu 2, msr 2:3ff54081, secondary cpu clock
+[    0.188029] KVM setup async PF for cpu 2
+[    0.189664] kvm-stealtime: cpu 2, msr 23fca3040
+[    0.192124]  #3
+[    0.004000] kvm-clock: cpu 3, msr 2:3ff540c1, secondary cpu clock
+[    0.208031] KVM setup async PF for cpu 3
+[    0.209931] kvm-stealtime: cpu 3, msr 23fce3040
+[    0.212120]  #4
+[    0.004000] kvm-clock: cpu 4, msr 2:3ff54101, secondary cpu clock
+[    0.228023] KVM setup async PF for cpu 4
+[    0.229231] kvm-stealtime: cpu 4, msr 23fd23040
+[    0.230612]  #5
+[    0.004000] kvm-clock: cpu 5, msr 2:3ff54141, secondary cpu clock
+[    0.247693] KVM setup async PF for cpu 5
+[    0.247693] kvm-stealtime: cpu 5, msr 23fd63040
+[    0.248122]  #6
+[    0.004000] kvm-clock: cpu 6, msr 2:3ff54181, secondary cpu clock
+[    0.266349] KVM setup async PF for cpu 6
+[    0.266349] kvm-stealtime: cpu 6, msr 23fda3040
+[    0.268119]  #7
+[    0.004000] kvm-clock: cpu 7, msr 2:3ff541c1, secondary cpu clock
+[    0.284031] KVM setup async PF for cpu 7
+[    0.285982] kvm-stealtime: cpu 7, msr 23fde3040
+[    0.288014] smp: Brought up 1 node, 8 CPUs
+[    0.288974] smpboot: Max logical packages: 1
+[    0.292007] smpboot: Total of 8 processors activated (38355.23 BogoMIPS)
+[    0.294157] devtmpfs: initialized
+[    0.294157] x86/mm: Memory block size: 128MB
+[    0.296635] evm: security.selinux
+[    0.297508] evm: security.SMACK64
+[    0.298363] evm: security.SMACK64EXEC
+[    0.300009] evm: security.SMACK64TRANSMUTE
+[    0.301049] evm: security.SMACK64MMAP
+[    0.301990] evm: security.apparmor
+[    0.302869] evm: security.ima
+[    0.303654] evm: security.capability
+[    0.304079] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.312018] futex hash table entries: 2048 (order: 5, 131072 bytes)
+[    0.313459] pinctrl core: initialized pinctrl subsystem
+[    0.314765] RTC time: 19:36:02, date: 08/25/21
+[    0.316334] NET: Registered protocol family 16
+[    0.317446] audit: initializing netlink subsys (disabled)
+[    0.320118] audit: type=2000 audit(1629920160.840:1): state=initialized audit_enabled=0 res=1
+[    0.324018] cpuidle: using governor ladder
+[    0.328026] cpuidle: using governor menu
+[    0.328478] ACPI: bus type PCI registered
+[    0.330427] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.332242] PCI: Using configuration type 1 for base access
+[    0.340079] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.340229] ACPI: Added _OSI(Module Device)
+[    0.342311] ACPI: Added _OSI(Processor Device)
+[    0.348020] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.350255] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.352007] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.353854] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.356005] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.358266] ACPI: Interpreter enabled
+[    0.360019] ACPI: (supports S0 S3 S4 S5)
+[    0.360958] ACPI: Using IOAPIC for interrupt routing
+[    0.362092] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.364248] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.368272] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.370242] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.376013] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.378355] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.380558] acpiphp: Slot [3] registered
+[    0.384087] acpiphp: Slot [4] registered
+[    0.385801] acpiphp: Slot [5] registered
+[    0.388079] acpiphp: Slot [6] registered
+[    0.389962] acpiphp: Slot [7] registered
+[    0.392075] acpiphp: Slot [8] registered
+[    0.393936] acpiphp: Slot [9] registered
+[    0.393936] acpiphp: Slot [10] registered
+[    0.393988] acpiphp: Slot [11] registered
+[    0.396088] acpiphp: Slot [12] registered
+[    0.398117] acpiphp: Slot [13] registered
+[    0.400080] acpiphp: Slot [14] registered
+[    0.402122] acpiphp: Slot [15] registered
+[    0.404086] acpiphp: Slot [16] registered
+[    0.406149] acpiphp: Slot [17] registered
+[    0.408080] acpiphp: Slot [18] registered
+[    0.410170] acpiphp: Slot [19] registered
+[    0.416082] acpiphp: Slot [20] registered
+[    0.418178] acpiphp: Slot [21] registered
+[    0.420082] acpiphp: Slot [22] registered
+[    0.422111] acpiphp: Slot [23] registered
+[    0.424084] acpiphp: Slot [24] registered
+[    0.426126] acpiphp: Slot [25] registered
+[    0.428083] acpiphp: Slot [26] registered
+[    0.430120] acpiphp: Slot [27] registered
+[    0.432081] acpiphp: Slot [28] registered
+[    0.434116] acpiphp: Slot [29] registered
+[    0.436080] acpiphp: Slot [30] registered
+[    0.438128] acpiphp: Slot [31] registered
+[    0.440032] PCI host bridge to bus 0000:00
+[    0.442033] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.444006] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.448006] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.452005] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.455530] pci_bus 0000:00: root bus resource [mem 0x240000000-0x2bfffffff window]
+[    0.456009] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.473420] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.476007] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.476007] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.479194] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.485437] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.488015] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.563449] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.568153] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.569523] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.572156] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.573451] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.573451] SCSI subsystem initialized
+[    0.576201] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.577313] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.580007] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.581317] vgaarb: loaded
+[    0.582209] ACPI: bus type USB registered
+[    0.584039] usbcore: registered new interface driver usbfs
+[    0.585476] usbcore: registered new interface driver hub
+[    0.586652] usbcore: registered new device driver usb
+[    0.588050] EDAC MC: Ver: 3.0.0
+[    0.589060] PCI: Using ACPI for IRQ routing
+[    0.589413] NetLabel: Initializing
+[    0.589413] NetLabel:  domain hash size = 128
+[    0.589413] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.590394] NetLabel:  unlabeled traffic allowed by default
+[    0.592912] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.594529] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.595666] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.608173] clocksource: Switched to clocksource kvm-clock
+[    0.627595] VFS: Disk quotas dquot_6.6.0
+[    0.628561] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.630142] AppArmor: AppArmor Filesystem Enabled
+[    0.631244] pnp: PnP ACPI init
+[    0.632574] pnp: PnP ACPI: found 7 devices
+[    0.640547] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.642535] NET: Registered protocol family 2
+[    0.643714] TCP established hash table entries: 65536 (order: 7, 524288 bytes)
+[    0.645440] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
+[    0.646980] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.648418] UDP hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.649741] UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes)
+[    0.651182] NET: Registered protocol family 1
+[    0.652190] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.653528] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.654950] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.656403] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.658436] Unpacking initramfs...
+[    1.163855] Freeing initrd memory: 41732K
+[    1.164804] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.166009] software IO TLB: mapped [mem 0xbbfdd000-0xbffdd000] (64MB)
+[    1.167201] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228de43df3e, max_idle_ns: 440795235278 ns
+[    1.168913] Scanning for low memory corruption every 60 seconds
+[    1.170475] Initialise system trusted keyrings
+[    1.171229] Key type blacklist registered
+[    1.172146] workingset: timestamp_bits=36 max_order=21 bucket_order=0
+[    1.174064] zbud: loaded
+[    1.175119] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.176553] fuse init (API version 7.26)
+[    1.181017] Key type asymmetric registered
+[    1.181763] Asymmetric key parser 'x509' registered
+[    1.182729] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    1.184157] io scheduler noop registered
+[    1.184935] io scheduler deadline registered
+[    1.185758] io scheduler cfq registered (default)
+[    1.187425] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    1.188929] ACPI: Power Button [PWRF]
+[    1.209059] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    1.230477] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    1.253302] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    1.275103] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    1.341899] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.368262] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.394558] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.405725] console [hvc0] enabled
+[    1.412539] Linux agpgart interface v0.103
+[    1.416700] loop: module loaded
+[    1.418793] scsi host0: ata_piix
+[    1.420051] scsi host1: ata_piix
+[    1.420953] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc1a0 irq 14
+[    1.422526] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc1a8 irq 15
+[    1.424261] libphy: Fixed MDIO Bus: probed
+[    1.425395] tun: Universal TUN/TAP device driver, 1.6
+[    1.426682] PPP generic driver version 2.4.2
+[    1.427900] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.429388] ehci-pci: EHCI PCI platform driver
+[    1.430426] ehci-platform: EHCI generic platform driver
+[    1.431518] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.432951] ohci-pci: OHCI PCI platform driver
+[    1.434084] ohci-platform: OHCI generic platform driver
+[    1.435225] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.436603] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.439141] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.440402] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.441748] mousedev: PS/2 mouse device common for all mice
+[    1.443507] rtc_cmos 00:00: RTC can wake from S4
+[    1.443734] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    1.446611] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    1.458701] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    1.460744] i2c /dev entries driver
+[    1.461842] device-mapper: uevent: version 1.0.3
+[    1.463288] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    1.465995] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.468104] NET: Registered protocol family 10
+[    1.479087] Segment Routing with IPv6
+[    1.480214] NET: Registered protocol family 17
+[    1.482052] Key type dns_resolver registered
+[    1.484744] mce: Using 10 MCE banks
+[    1.486216] RAS: Correctable Errors collector initialized.
+[    1.488121] sched_clock: Marking stable (1488087790, 0)->(1840655128, -352567338)
+[    1.491916] registered taskstats version 1
+[    1.493063] Loading compiled-in X.509 certificates
+[    1.499179] Loaded X.509 cert 'Build time autogenerated kernel key: 369b16149153afe509b010c5493c788cd1d7da9f'
+[    1.502438] Loaded X.509 cert 'Canonical Ltd. Live Patch Signing: 14df34d1a87cf37625abec039ef2bf521249b969'
+[    1.505593] Loaded X.509 cert 'Canonical Ltd. Kernel Module Signing: 88f752e560a1e0737e31163a466ad7b70a850c19'
+[    1.508184] zswap: loaded using pool lzo/zbud
+[    1.517288] Key type big_key registered
+[    1.518434] Key type trusted registered
+[    1.523251] Key type encrypted registered
+[    1.524455] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.526321] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    1.528531] ima: Allocated hash algorithm: sha1
+[    1.530263] evm: HMAC attrs: 0x1
+[    1.532517]   Magic number: 1:489:648
+[    1.533996] acpi LNXCPU:01: hash matches
+[    1.535618] rtc_cmos 00:00: setting system clock to 2021-08-25 19:36:03 UTC (1629920163)
+[    1.538095] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    1.539682] EDD information not available.
+[    1.585825] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.589521] ata2.00: configured for MWDMA2
+[    1.592861] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.625318] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.628580] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.631619] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.639126] Freeing unused kernel image memory: 2448K
+[    1.648118] Write protecting the kernel read-only data: 20480k
+[    1.651303] Freeing unused kernel image memory: 2008K
+[    1.653329] Freeing unused kernel image memory: 1824K
+[    1.664614] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.666475] x86/mm: Checking user space page tables
+[    1.675147] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.786757] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.790753] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.798573] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.800280]  vda: vda1 vda14 vda15
+[    1.802106] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.808505] FDC 0 is a S82078B
+[    1.812737] virtio_net virtio0 ens3: renamed from eth0
+[    1.840375] virtio_net virtio5 ens8: renamed from eth1
+[    1.888103] print_req_error: I/O error, dev fd0, sector 0
+[    1.890645] floppy: error 10 while reading block 0
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    2.016079] raid6: sse2x1   gen()  5462 MB/s
+[    2.064041] raid6: sse2x1   xor()  3250 MB/s
+[    2.112085] raid6: sse2x2   gen()  5550 MB/s
+[    2.160071] raid6: sse2x2   xor()  6121 MB/s
+[    2.208080] raid6: sse2x4   gen() 11489 MB/s
+[    2.256072] raid6: sse2x4   xor()  7215 MB/s
+[    2.257353] raid6: using algorithm sse2x4 gen() 11489 MB/s
+[    2.258763] raid6: .... xor() 7215 MB/s, rmw enabled
+[    2.260148] raid6: using intx1 recovery algorithm
+[    2.265258] xor: measuring software checksum speed
+[    2.304071]    prefetch64-sse: 14719.000 MB/sec
+[    2.344071]    generic_sse: 13368.000 MB/sec
+[    2.345335] xor: using function: prefetch64-sse (14719.000 MB/sec)
+[    2.364701] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    2.516162] print_req_error: I/O error, dev fd0, sector 0
+[    2.518886] floppy: error 10 while reading block 0
+done.
+Begin: Will now check root file system ... fsck from util-linux 2.31.1
+[/sbin/fsck.ext4 (1) -- /dev/vda1] fsck.ext4 -a -C0 /dev/vda1 
+cloudimg-rootfs: clean, 102612/8015616 files, 1535220/16276731 blocks
+done.
+[    2.568525] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... [    2.586487] random: fast init done
+done.
+[    2.771345] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.776608] random: crng init done
+[    2.783592] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.788179] systemd[1]: Detected virtualization kvm.
+[    2.789631] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.5 LTS[0m!
+
+[    2.798341] systemd[1]: Set hostname to <autopkgtest>.
+[    2.901833] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    2.904227] systemd[1]: Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[    2.906984] systemd[1]: Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[    2.910133] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executab…rmats File System Automount Point.
+[    2.914185] systemd[1]: Created slice system-systemd\x2dfsck.slice.
+[[0;32m  OK  [0m] Created slice system-systemd\x2dfsck.slice.
+[    2.917360] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Created slice system-autopkgtest.slice.
+[[0;32m  OK  [0m] Reached target Swap.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Mounting POSIX Message Queue File System...
+         Starting Set the console keyboard layout...
+         Starting Create list of required st…ce nodes for the current kernel...
+         Mounting Kernel Debug File System...
+         Starting Uncomplicated firewall...
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[[0;32m  OK  [0m] Listening on fsck to fsckd communication Socket.
+         Starting Remount Root and Kernel File Systems...
+         Mounting Huge Pages File System...
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[    2.950995] EXT4-fs (vda1): re-mounted. Opts: (null)
+         Starting Journal Service...
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+         Starting udev Coldplug all Devices...
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Create list of required sta…vice nodes for the current kernel.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+         Starting Load/Save Random Seed...
+         Mounting Kernel Configuration File System...
+         Mounting FUSE Control File System...
+         Starting Apply Kernel Variables...
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Started Network Service.
+[    3.125608] print_req_error: I/O error, dev fd0, sector 0
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Found device /dev/hvc0.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+         Starting File System Check on /dev/disk/by-label/UEFI...
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started File System Check Daemon to report status.
+[[0;32m  OK  [0m] Started File System Check on /dev/disk/by-label/UEFI.
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Create Volatile Files and Directories...
+         Starting Set console font and keymap...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting AppArmor initialization...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Network Name Resolution...
+         Starting Update UTMP about System Boot/Shutdown...
+         Starting Network Time Synchronization...
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Started Ubuntu Advantage update messaging.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+         Starting Login Service...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+         Starting LSB: automatic crash report generation...
+         Starting Dispatcher daemon for systemd-networkd...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+[[0;32m  OK  [0m] Started Login Service.
+         Starting rng-tools.service...
+         Starting Permit User Sessions...
+         Starting LSB: Record successful boot for GRUB...
+         Starting Thermal Daemon Service...
+         Starting OpenBSD Secure Shell server...
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started autopkgtest root shell on hvc1.
+[[0;32m  OK  [0m] Started irqbalance daemon.
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Started rng-tools.service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+         Starting Hold until boot process finishes up...
+         Starting Terminate Plymouth Boot Screen...
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Serial Getty on hvc0.
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+
+Ubuntu 18.04.5 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found "'login prompt on serial console'"
+autopkgtest-virt-qemu: DBG: expect: b'ok'
+autopkgtest-virt-qemu: DBG: expect: found "b'ok'"
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on hvc1
+autopkgtest-virt-qemu: DBG: expect: b'84484269-35c2-4fe1-a80f-c4b4647c5926[1]'
+autopkgtest-virt-qemu: DBG: expect: found "b'84484269-35c2-4fe1-a80f-c4b4647c5926[1]'"
+autopkgtest-virt-qemu: DBG: expect: b'84484269-35c2-4fe1-a80f-c4b4647c5926[2]'
+autopkgtest-virt-qemu: DBG: expect: found "b'84484269-35c2-4fe1-a80f-c4b4647c5926[2]'"
+autopkgtest-virt-qemu: DBG: expect: b'84484269-35c2-4fe1-a80f-c4b4647c5926[3]'
+autopkgtest-virt-qemu: DBG: expect: found "b'84484269-35c2-4fe1-a80f-c4b4647c5926[3]'"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec for d in /var/cache /home; do if [ -e $d/autopkgtest-tmpdir.tar ]; then  tar --warning=none --extract --absolute-names      -f $d/autopkgtest-tmpdir.tar; rm $d/autopkgtest-tmpdir.tar; exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: restored downtmp after reboot
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--print-architecture'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [19:36:10]: testbed dpkg architecture: amd64
+autopkgtest: DBG: testbed command ['which', 'eatmydata'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed has eatmydata
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.dn9EKj/testbed-packages"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/testbed-packages'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/testbed-packages
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Binaries: publish
+autopkgtest: DBG: testbed command ['rm', '-rf', '/tmp/autopkgtest.dn9EKj/binaries'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.dn9EKj'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ /tmp/autopkgtest.dn9EKj/binaries/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ /tmp/autopkgtest.dn9EKj/binaries/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.dn9EKj/binaries/; then mkdir -- /tmp/autopkgtest.dn9EKj/binaries/; fi; cd /tmp/autopkgtest.dn9EKj/binaries/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec if ! test -d /tmp/autopkgtest.dn9EKj/binaries/; then mkdir -- /tmp/autopkgtest.dn9EKj/binaries/; fi; cd /tmp/autopkgtest.dn9EKj/binaries/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.dn9EKj/binaries'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '\n  type apt-ftparchive >/dev/null 2>&1 || DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils 2>&1\n  (cd /tmp/autopkgtest.dn9EKj/binaries; apt-ftparchive packages . > Packages; apt-ftparchive release . > Release)\n  printf \'Package: *\\nPin: origin ""\\nPin-Priority: 1002\\n\' > /etc/apt/preferences.d/90autopkgtest\n  echo "deb [ trusted=yes ] file:///tmp/autopkgtest.dn9EKj/binaries /" >/etc/apt/sources.list.d/autopkgtest.list\n  if [ "x`ls /var/lib/dpkg/updates`" != x ]; then\n    echo >&2 "/var/lib/dpkg/updates contains some files, aargh"; exit 1\n  fi\n  apt-get --quiet --no-list-cleanup -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/autopkgtest.list -o Dir::Etc::sourceparts=/dev/null update 2>&1\n  cp /var/lib/dpkg/status /tmp/autopkgtest.dn9EKj/2-apt-update.out\n  '], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Get:1 file:/tmp/autopkgtest.dn9EKj/binaries  InRelease
+Ign:1 file:/tmp/autopkgtest.dn9EKj/binaries  InRelease
+Get:2 file:/tmp/autopkgtest.dn9EKj/binaries  Release [816 B]
+Get:2 file:/tmp/autopkgtest.dn9EKj/binaries  Release [816 B]
+Get:3 file:/tmp/autopkgtest.dn9EKj/binaries  Release.gpg
+Ign:3 file:/tmp/autopkgtest.dn9EKj/binaries  Release.gpg
+Get:4 file:/tmp/autopkgtest.dn9EKj/binaries  Packages [583 B]
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/2-apt-update.out /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/2-apt-update.out
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/2-apt-update.out /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/2-apt-update.out
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/2-apt-update.out'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/2-apt-update.out'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/2-apt-update.out
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: Binaries: publish reinstall checking...
+autopkgtest: DBG: Binaries: publish done
+autopkgtest: DBG: install_deps: deps_new=['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'], recommends=False
+autopkgtest: DBG: install-deps: satisfying maas, maas-dhcp, maas-dns, maas-cli, python3-mock, python3-nose, python3-setuptools, python3-yaml, devscripts, build-essential, pep8, pyflakes, fakeroot, debhelper, python3-oauthlib, python3-testtools
+autopkgtest: DBG: install-deps: architecture resolved: maas, maas-dhcp, maas-dns, maas-cli, python3-mock, python3-nose, python3-setuptools, python3-yaml, devscripts, build-essential, pep8, pyflakes, fakeroot, debhelper, python3-oauthlib, python3-testtools
+autopkgtest: DBG: testbed command ['test', '-w', '/var/lib/dpkg/status'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: can use apt-get on testbed: True
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.dn9EKj'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/3-autopkgtest-satdep.deb /tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/3-autopkgtest-satdep.deb /tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['cat'], ['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat >/tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/3-autopkgtest-satdep.deb'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< cat
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat >/tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--unpack', '/tmp/autopkgtest.dn9EKj/3-autopkgtest-satdep.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['/bin/sh', '-ec', '/usr/bin/eatmydata apt-get install --assume-yes --fix-broken -o APT::Status-Fd=3 -o APT::Install-Recommends=False -o Dpkg::Options::=--force-confnew -o Debug::pkgProblemResolver=true 3>&2 2>&1'], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Correcting dependencies...Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+ Done
+Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+The following additional packages will be installed:
+  archdetect-deb authbind autoconf automake autopoint autotools-dev
+  avahi-daemon avahi-utils bind9 bind9utils build-essential chrony cpp cpp-7
+  curtin-common dbconfig-common dbconfig-pgsql debhelper devscripts
+  dh-autoreconf dh-strip-nondeterminism docutils-common fakeroot
+  formencode-i18n freeipmi-common freeipmi-tools g++ g++-7 gcc gcc-7
+  gcc-7-base gettext ieee-data intltool-debian isc-dhcp-server
+  libarchive-zip-perl libasan4 libatomic1 libavahi-client3
+  libavahi-common-data libavahi-common3 libavahi-core7 libc-dev-bin libc6-dev
+  libcc1-0 libcilkrts5 libcroco3 libcurl3-gnutls libdaemon0 libdbi-perl
+  libdebian-installer4 libecap3 libfakeroot libfile-homedir-perl
+  libfile-stripnondeterminism-perl libfile-which-perl libfreeipmi16
+  libgcc-7-dev libgomp1 libipmiconsole2 libipmidetect0 libirs-export160
+  libisccfg-export160 libisl19 libitm1 libjs-angularjs libjs-jquery
+  libjs-sphinxdoc libjs-underscore liblsan0 libltdl7 libmpc3 libmpx2 libnspr4
+  libnss3 libpq5 libprotobuf10 libpython-stdlib libpython2.7-minimal
+  libpython2.7-stdlib libquadmath0 libsodium23 libstdc++-7-dev
+  libtimedate-perl libtool libtsan0 libubsan0 libuv1 libvirt-clients libvirt0
+  libxslt1.1 libyajl2 linux-libc-dev m4 maas maas-cli maas-common maas-dhcp
+  maas-dns maas-proxy maas-rack-controller maas-region-api
+  maas-region-controller pep8 po-debconf postgresql postgresql-10
+  postgresql-client postgresql-client-10 postgresql-client-common
+  postgresql-common pxelinux pycodestyle pyflakes python
+  python-babel-localedata python-django-common python-minimal
+  python-pkg-resources python-pyflakes python2.7 python2.7-minimal
+  python3-alabaster python3-attr python3-automat python3-babel python3-bson
+  python3-constantly python3-convoy python3-crochet python3-curtin
+  python3-distro-info python3-distutils python3-django python3-django-maas
+  python3-django-piston3 python3-djorm-ext-pgarray python3-dnspython
+  python3-docutils python3-extras python3-fixtures python3-formencode
+  python3-hyperlink python3-imagesize python3-incremental python3-iso8601
+  python3-lib2to3 python3-linecache2 python3-lxml python3-maas-client
+  python3-maas-provisioningserver python3-macaroonbakery python3-mimeparse
+  python3-mock python3-nacl python3-netaddr python3-nose python3-oauth
+  python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply
+  python3-prettytable python3-protobuf python3-psycopg2 python3-ptyprocess
+  python3-pyasn1 python3-pyasn1-modules python3-pycodestyle python3-pygments
+  python3-pymacaroons python3-pyparsing python3-pyvmomi python3-rfc3339
+  python3-roman python3-seamicroclient python3-service-identity
+  python3-setuptools python3-simplejson python3-simplestreams python3-sphinx
+  python3-tempita python3-testtools python3-traceback2 python3-twisted
+  python3-twisted-bin python3-txtftp python3-tz python3-unittest2
+  python3-uvloop python3-zope.interface sgml-base sphinx-common squid
+  squid-common squid-langpack ssl-cert syslinux-common xml-core
+Suggested packages:
+  autoconf-archive gnu-standards autoconf-doc avahi-autoipd bind9-doc
+  resolvconf cpp-doc gcc-7-locales dh-make dwz adequate autopkgtest
+  bls-standalone bsd-mailx | mailx check-all-the-things cvs-buildpackage
+  devscripts-el diffoscope disorderfs dose-extra duck faketime gnuplot
+  how-can-i-help libauthen-sasl-perl libfile-desktopentry-perl
+  libnet-smtps-perl libterm-size-perl libyaml-syck-perl mozilla-devscripts
+  mutt piuparts quilt ratt reprotest svn-buildpackage w3m debian-keyring
+  equivs liblwp-protocol-https-perl libsoap-lite-perl freeipmi-ipmidetect
+  freeipmi-bmc-watchdog g++-multilib g++-7-multilib gcc-7-doc libstdc++6-7-dbg
+  gcc-multilib manpages-dev flex bison gdb gcc-doc gcc-7-multilib libgcc1-dbg
+  libgomp1-dbg libitm1-dbg libatomic1-dbg libasan4-dbg liblsan0-dbg
+  libtsan0-dbg libubsan0-dbg libcilkrts5-dbg libmpx2-dbg libquadmath0-dbg
+  gettext-doc libasprintf-dev libgettextpo-dev isc-dhcp-server-ldap
+  policycoreutils glibc-doc libclone-perl libmldbm-perl libnet-daemon-perl
+  libsql-statement-perl libstdc++-7-doc libtool-doc gfortran
+  | fortran95-compiler gcj-jdk libvirt-daemon m4-doc amtterm ipmitool nmap
+  wsmancli libmail-box-perl postgresql-doc locales-all postgresql-doc-10
+  libjson-perl tftpd-hpa python-doc python-tk python-setuptools python2.7-doc
+  binfmt-support python-attr-doc bpython3 geoip-database-contrib ipython3
+  libgdal1 python-django-doc python3-bcrypt python3-flup python3-memcache
+  python3-pil python3-pymysql python3-sqlite docutils-doc fonts-linuxlibertine
+  | ttf-linux-libertine texlive-lang-french texlive-latex-base
+  texlive-latex-recommended python3-egenix-mxdatetime python3-lxml-dbg
+  python-lxml-doc python-mock-doc python-nacl-doc python-netaddr-docs
+  python-nose-doc python3-gssapi python-pexpect-doc python-ply-doc
+  python-psycopg2-doc ttf-bitstream-vera python-pyparsing-doc
+  python-pyvmomi-doc python-setuptools-doc python3-sphinx-rtd-theme
+  libjs-mathjax dvipng texlive-latex-extra texlive-fonts-recommended
+  texlive-generic-extra latexmk imagemagick-6.q16 sphinx-doc
+  python-testtools-doc python3-tk python3-gtk2 python3-glade2 python3-qt4
+  python3-wxgtk2.8 python3-twisted-bin-dbg sgml-base-doc squidclient squid-cgi
+  squid-purge smbclient winbindd openssl-blacklist
+Recommended packages:
+  libnss-mdns dctrl-tools dput | dupload libdistro-info-perl
+  libencode-locale-perl libgit-wrapper-perl liblist-compare-perl liburi-perl
+  libwww-perl licensecheck lintian patchutils python3-debian python3-magic
+  python3-unidiff python3-xdg unzip wdiff manpages manpages-dev
+  libarchive-cpio-perl javascript-common libltdl-dev lvm2
+  libmail-sendmail-perl sysstat pyflakes3 python3-bson-ext python3-sqlparse
+  libpaper-utils python3-pil python3-click python3-bs4 python3-html5lib
+  python3-pam python3-serial
+The following NEW packages will be installed:
+  archdetect-deb authbind autoconf automake autopoint autotools-dev
+  avahi-daemon avahi-utils bind9 bind9utils build-essential chrony cpp cpp-7
+  curtin-common dbconfig-common dbconfig-pgsql debhelper devscripts
+  dh-autoreconf dh-strip-nondeterminism docutils-common fakeroot
+  formencode-i18n freeipmi-common freeipmi-tools g++ g++-7 gcc gcc-7
+  gcc-7-base gettext ieee-data intltool-debian isc-dhcp-server
+  libarchive-zip-perl libasan4 libatomic1 libavahi-client3
+  libavahi-common-data libavahi-common3 libavahi-core7 libc-dev-bin libc6-dev
+  libcc1-0 libcilkrts5 libcroco3 libcurl3-gnutls libdaemon0 libdbi-perl
+  libdebian-installer4 libecap3 libfakeroot libfile-homedir-perl
+  libfile-stripnondeterminism-perl libfile-which-perl libfreeipmi16
+  libgcc-7-dev libgomp1 libipmiconsole2 libipmidetect0 libirs-export160
+  libisccfg-export160 libisl19 libitm1 libjs-angularjs libjs-jquery
+  libjs-sphinxdoc libjs-underscore liblsan0 libltdl7 libmpc3 libmpx2 libnspr4
+  libnss3 libpq5 libprotobuf10 libpython-stdlib libpython2.7-minimal
+  libpython2.7-stdlib libquadmath0 libsodium23 libstdc++-7-dev
+  libtimedate-perl libtool libtsan0 libubsan0 libuv1 libvirt-clients libvirt0
+  libxslt1.1 libyajl2 linux-libc-dev m4 maas maas-cli maas-common maas-dhcp
+  maas-dns maas-proxy maas-rack-controller maas-region-api
+  maas-region-controller pep8 po-debconf postgresql postgresql-10
+  postgresql-client postgresql-client-10 postgresql-client-common
+  postgresql-common pxelinux pycodestyle pyflakes python
+  python-babel-localedata python-django-common python-minimal
+  python-pkg-resources python-pyflakes python2.7 python2.7-minimal
+  python3-alabaster python3-attr python3-automat python3-babel python3-bson
+  python3-constantly python3-convoy python3-crochet python3-curtin
+  python3-distro-info python3-distutils python3-django python3-django-maas
+  python3-django-piston3 python3-djorm-ext-pgarray python3-dnspython
+  python3-docutils python3-extras python3-fixtures python3-formencode
+  python3-hyperlink python3-imagesize python3-incremental python3-iso8601
+  python3-lib2to3 python3-linecache2 python3-lxml python3-maas-client
+  python3-maas-provisioningserver python3-macaroonbakery python3-mimeparse
+  python3-mock python3-nacl python3-netaddr python3-nose python3-oauth
+  python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply
+  python3-prettytable python3-protobuf python3-psycopg2 python3-ptyprocess
+  python3-pyasn1 python3-pyasn1-modules python3-pycodestyle python3-pygments
+  python3-pymacaroons python3-pyparsing python3-pyvmomi python3-rfc3339
+  python3-roman python3-seamicroclient python3-service-identity
+  python3-setuptools python3-simplejson python3-simplestreams python3-sphinx
+  python3-tempita python3-testtools python3-traceback2 python3-twisted
+  python3-twisted-bin python3-txtftp python3-tz python3-unittest2
+  python3-uvloop python3-zope.interface sgml-base sphinx-common squid
+  squid-common squid-langpack ssl-cert syslinux-common xml-core
+0 upgraded, 200 newly installed, 0 to remove and 0 not upgraded.
+1 not fully installed or removed.
+Need to get 88.7 MB of archives.
+After this operation, 380 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 authbind amd64 2.1.2 [17.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-common-data amd64 0.7-3.1ubuntu1.3 [22.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-common3 amd64 0.7-3.1ubuntu1.3 [21.6 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-client3 amd64 0.7-3.1ubuntu1.3 [25.2 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-core7 amd64 0.7-3.1ubuntu1.3 [81.3 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdaemon0 amd64 0.14-6 [16.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 avahi-daemon amd64 0.7-3.1ubuntu1.3 [62.4 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 avahi-utils amd64 0.7-3.1ubuntu1.3 [24.7 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-ply all 3.11-1 [46.6 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9utils amd64 1:9.11.3+dfsg-1ubuntu1.15 [216 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 freeipmi-common amd64 1.4.11-1.1ubuntu4.1 [174 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libfreeipmi16 amd64 1.4.11-1.1ubuntu4.1 [826 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libipmiconsole2 amd64 1.4.11-1.1ubuntu4.1 [83.9 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libipmidetect0 amd64 1.4.11-1.1ubuntu4.1 [25.6 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 freeipmi-tools amd64 1.4.11-1.1ubuntu4.1 [622 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl3-gnutls amd64 7.58.0-2ubuntu3.14 [218 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic/main amd64 libyajl2 amd64 2.1.0-2build1 [20.0 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libvirt0 amd64 4.0.0-1ubuntu8.19 [1,249 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libvirt-clients amd64 4.0.0-1ubuntu8.19 [595 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic/main amd64 libsodium23 amd64 1.0.16-2 [143 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-nacl amd64 1.1.2-1build1 [27.9 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic/main amd64 libprotobuf10 amd64 3.0.0-9.1ubuntu1 [651 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-protobuf amd64 3.0.0-9.1ubuntu1 [262 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pymacaroons all 0.13.0-1 [13.1 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-tz all 2018.3-2 [25.1 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-rfc3339 all 1.0-4 [6,356 B]
+Get:27 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-macaroonbakery all 1.1.3-1 [62.3 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-oauth all 1.0.1-5 [8,238 B]
+Get:29 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-tempita all 0.5.2-2 [13.9 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-maas-client all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [32.6 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-cli all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [2,636 B]
+Get:32 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdebian-installer4 amd64 0.110ubuntu2 [21.6 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 archdetect-deb amd64 1.117ubuntu6.18.04.1 [6,192 B]
+Get:34 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-attr all 17.4.0-2 [23.8 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-bson amd64 3.6.1+dfsg1-1 [31.8 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-automat all 0.6.0-1 [25.2 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-constantly all 15.1.0-1 [8,030 B]
+Get:38 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-hyperlink all 17.3.1-2 [27.6 kB]
+Get:39 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-incremental all 16.10.1-3 [14.5 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-zope.interface amd64 4.3.2-1build2 [82.4 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-twisted-bin amd64 17.9.0-2ubuntu0.1 [11.4 kB]
+Get:42 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyasn1 all 0.4.2-3 [46.8 kB]
+Get:43 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyasn1-modules all 0.2.1-0.2 [32.9 kB]
+Get:44 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-service-identity all 16.0.0-2 [9,388 B]
+Get:45 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-twisted all 17.9.0-2ubuntu0.1 [1,919 kB]
+Get:46 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-crochet all 1.4.0-0ubuntu2 [20.9 kB]
+Get:47 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 curtin-common all 20.1-2-g42a9667f-0ubuntu1~18.04.1 [21.5 kB]
+Get:48 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-curtin all 20.1-2-g42a9667f-0ubuntu1~18.04.1 [154 kB]
+Get:49 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-distro-info all 0.18ubuntu0.18.04.1 [9,296 B]
+Get:50 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-dnspython all 1.15.0-1 [85.0 kB]
+Get:51 http://archive.ubuntu.com/ubuntu bionic/main amd64 formencode-i18n all 1.3.0-0ubuntu5 [3,382 B]
+Get:52 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-formencode all 1.3.0-0ubuntu5 [69.2 kB]
+Get:53 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxslt1.1 amd64 1.1.29-5ubuntu0.2 [150 kB]
+Get:54 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-lxml amd64 4.2.1-1ubuntu0.4 [1,097 kB]
+Get:55 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-paramiko all 2.0.0-1ubuntu1.2 [110 kB]
+Get:56 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-ptyprocess all 0.5.2-1 [12.7 kB]
+Get:57 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pexpect all 4.2.1-1 [42.4 kB]
+Get:58 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyparsing all 2.2.0+dfsg1-2 [52.2 kB]
+Get:59 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyvmomi all 6.5.0.2017.5-0ubuntu1 [169 kB]
+Get:60 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-babel-localedata all 2.4.0+dfsg.1-2ubuntu1.1 [3,410 kB]
+Get:61 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-babel all 2.4.0+dfsg.1-2ubuntu1.1 [79.9 kB]
+Get:62 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pbr all 3.1.1-3ubuntu3 [53.8 kB]
+Get:63 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-prettytable all 0.7.2-3 [19.7 kB]
+Get:64 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-simplejson amd64 3.13.2-1 [49.6 kB]
+Get:65 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-iso8601 all 0.1.11-1 [9,876 B]
+Get:66 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-seamicroclient all 0.4.0-1ubuntu1 [27.4 kB]
+Get:67 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-simplestreams all 0.1.0~bzr460-0ubuntu1.1 [22.3 kB]
+Get:68 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-txtftp all 0.1~bzr47-0ubuntu2 [17.6 kB]
+Get:69 http://archive.ubuntu.com/ubuntu bionic/main amd64 libuv1 amd64 1.18.0-3 [64.4 kB]
+Get:70 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-uvloop amd64 0.8.1+ds1-1ubuntu0.1 [420 kB]
+Get:71 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-maas-provisioningserver all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [274 kB]
+Get:72 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-common all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [6,988 B]
+Get:73 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccfg-export160 amd64 1:9.11.3+dfsg-1ubuntu1.15 [45.3 kB]
+Get:74 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libirs-export160 amd64 1:9.11.3+dfsg-1ubuntu1.15 [18.4 kB]
+Get:75 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 isc-dhcp-server amd64 4.3.5-3ubuntu7.3 [446 kB]
+Get:76 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-dhcp all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,912 B]
+Get:77 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnspr4 amd64 2:4.18-1ubuntu1 [112 kB]
+Get:78 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss3 amd64 2:3.35-2ubuntu2.12 [1,220 kB]
+Get:79 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 chrony amd64 3.2-4ubuntu4.5 [204 kB]
+Get:80 http://archive.ubuntu.com/ubuntu bionic/main amd64 pxelinux all 3:6.03+dfsg1-2 [187 kB]
+Get:81 http://archive.ubuntu.com/ubuntu bionic/main amd64 ieee-data all 20180204.1 [1,539 kB]
+Get:82 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-netaddr all 0.7.19-1 [213 kB]
+Get:83 http://archive.ubuntu.com/ubuntu bionic/main amd64 syslinux-common all 3:6.03+dfsg1-2 [1,171 kB]
+Get:84 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-rack-controller all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [10.6 kB]
+Get:85 http://archive.ubuntu.com/ubuntu bionic/main amd64 dbconfig-common all 2.0.9 [601 kB]
+Get:86 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpq5 amd64 10.18-0ubuntu0.18.04.1 [108 kB]
+Get:87 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client-common all 190ubuntu0.1 [29.6 kB]
+Get:88 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client-10 amd64 10.18-0ubuntu0.18.04.1 [942 kB]
+Get:89 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client all 10+190ubuntu0.1 [5,896 B]
+Get:90 http://archive.ubuntu.com/ubuntu bionic/main amd64 dbconfig-pgsql all 2.0.9 [1,010 B]
+Get:91 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9 amd64 1:9.11.3+dfsg-1ubuntu1.15 [398 kB]
+Get:92 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-angularjs all 1.5.10-1 [506 kB]
+Get:93 http://archive.ubuntu.com/ubuntu bionic/main amd64 libecap3 amd64 1.0.1-3.2 [16.6 kB]
+Get:94 http://archive.ubuntu.com/ubuntu bionic/main amd64 libltdl7 amd64 2.4.6-2 [38.8 kB]
+Get:95 http://archive.ubuntu.com/ubuntu bionic/main amd64 squid-langpack all 20170901-1 [137 kB]
+Get:96 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 squid-common all 3.5.27-1ubuntu1.11 [176 kB]
+Get:97 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdbi-perl amd64 1.640-1ubuntu0.3 [724 kB]
+Get:98 http://archive.ubuntu.com/ubuntu bionic/main amd64 ssl-cert all 1.0.39 [17.0 kB]
+Get:99 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 squid amd64 3.5.27-1ubuntu1.11 [2,224 kB]
+Get:100 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-proxy all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,668 B]
+Get:101 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-django-common all 1:1.11.11-1ubuntu1.14 [1,522 kB]
+Get:102 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-django all 1:1.11.11-1ubuntu1.14 [900 kB]
+Get:103 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-convoy all 0.2.1+bzr39-1 [9,478 B]
+Get:104 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-psycopg2 amd64 2.7.4-1 [152 kB]
+Get:105 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-lib2to3 all 3.6.9-1~18.04 [77.4 kB]
+Get:106 http://archive.ubuntu.com/ubuntu bionic/main amd64 sgml-base all 1.29 [12.3 kB]
+Get:107 http://archive.ubuntu.com/ubuntu bionic/main amd64 xml-core all 0.18 [21.3 kB]
+Get:108 http://archive.ubuntu.com/ubuntu bionic/main amd64 docutils-common all 0.14+dfsg-3 [156 kB]
+Get:109 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-roman all 2.0.0-3 [8,624 B]
+Get:110 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-docutils all 0.14+dfsg-3 [363 kB]
+Get:111 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-pygments all 2.2.0+dfsg-1ubuntu0.2 [574 kB]
+Get:112 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-alabaster all 0.7.8-1 [18.5 kB]
+Get:113 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-imagesize all 0.7.1-1 [3,926 B]
+Get:114 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-jquery all 3.2.1-1 [152 kB]
+Get:115 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libjs-underscore all 1.8.3~dfsg-1ubuntu0.1 [60.4 kB]
+Get:116 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-sphinxdoc all 1.6.7-1ubuntu1 [85.6 kB]
+Get:117 http://archive.ubuntu.com/ubuntu bionic/main amd64 sphinx-common all 1.6.7-1ubuntu1 [420 kB]
+Get:118 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-sphinx all 1.6.7-1ubuntu1 [459 kB]
+Get:119 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-django-maas all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,123 kB]
+Get:120 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-mimeparse all 0.1.4-3.1 [6,256 B]
+Get:121 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-django-piston3 amd64 0.3~rc2-3ubuntu5 [35.3 kB]
+Get:122 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-djorm-ext-pgarray all 1.2-0ubuntu2 [6,938 B]
+Get:123 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-petname all 2.2-0ubuntu1 [10.9 kB]
+Get:124 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-region-api all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [1,768 kB]
+Get:125 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-common all 190ubuntu0.1 [157 kB]
+Get:126 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-10 amd64 10.18-0ubuntu0.18.04.1 [3,772 kB]
+Get:127 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql all 10+190ubuntu0.1 [5,884 B]
+Get:128 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-region-controller all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,316 B]
+Get:129 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [3,112 B]
+Get:130 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 maas-dns all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [3,504 B]
+Get:131 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-mock all 2.0.0-3 [47.5 kB]
+Get:132 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-nose all 1.3.7-3 [115 kB]
+Get:133 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-distutils all 3.6.9-1~18.04 [144 kB]
+Get:134 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-setuptools all 39.0.1-2 [248 kB]
+Get:135 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-which-perl all 1.21-1 [11.8 kB]
+Get:136 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-homedir-perl all 1.002-1 [37.1 kB]
+Get:137 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 devscripts amd64 2.17.12ubuntu1.1 [870 kB]
+Get:138 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libc-dev-bin amd64 2.27-3ubuntu1.4 [71.8 kB]
+Get:139 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-libc-dev amd64 4.15.0-154.161 [988 kB]
+Get:140 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libc6-dev amd64 2.27-3ubuntu1.4 [2,585 kB]
+Get:141 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7-base amd64 7.5.0-3ubuntu1~18.04 [18.3 kB]
+Get:142 http://archive.ubuntu.com/ubuntu bionic/main amd64 libisl19 amd64 0.19-1 [551 kB]
+Get:143 http://archive.ubuntu.com/ubuntu bionic/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB]
+Get:144 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp-7 amd64 7.5.0-3ubuntu1~18.04 [8,591 kB]
+Get:145 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp amd64 4:7.4.0-1ubuntu2.3 [27.7 kB]
+Get:146 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcc1-0 amd64 8.4.0-1ubuntu1~18.04 [39.4 kB]
+Get:147 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgomp1 amd64 8.4.0-1ubuntu1~18.04 [76.5 kB]
+Get:148 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libitm1 amd64 8.4.0-1ubuntu1~18.04 [27.9 kB]
+Get:149 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libatomic1 amd64 8.4.0-1ubuntu1~18.04 [9,192 B]
+Get:150 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libasan4 amd64 7.5.0-3ubuntu1~18.04 [358 kB]
+Get:151 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblsan0 amd64 8.4.0-1ubuntu1~18.04 [133 kB]
+Get:152 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libtsan0 amd64 8.4.0-1ubuntu1~18.04 [288 kB]
+Get:153 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libubsan0 amd64 7.5.0-3ubuntu1~18.04 [126 kB]
+Get:154 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcilkrts5 amd64 7.5.0-3ubuntu1~18.04 [42.5 kB]
+Get:155 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmpx2 amd64 8.4.0-1ubuntu1~18.04 [11.6 kB]
+Get:156 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libquadmath0 amd64 8.4.0-1ubuntu1~18.04 [134 kB]
+Get:157 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc-7-dev amd64 7.5.0-3ubuntu1~18.04 [2,378 kB]
+Get:158 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7 amd64 7.5.0-3ubuntu1~18.04 [9,381 kB]
+Get:159 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc amd64 4:7.4.0-1ubuntu2.3 [5,184 B]
+Get:160 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++-7-dev amd64 7.5.0-3ubuntu1~18.04 [1,471 kB]
+Get:161 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++-7 amd64 7.5.0-3ubuntu1~18.04 [9,697 kB]
+Get:162 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++ amd64 4:7.4.0-1ubuntu2.3 [1,568 B]
+Get:163 http://archive.ubuntu.com/ubuntu bionic/main amd64 build-essential amd64 12.4ubuntu1 [4,758 B]
+Get:164 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-pycodestyle all 2.3.1-2 [32.9 kB]
+Get:165 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pycodestyle all 2.3.1-2 [4,978 B]
+Get:166 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pep8 all 1.7.1-1ubuntu1 [5,700 B]
+Get:167 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython2.7-minimal amd64 2.7.17-1~18.04ubuntu1.6 [335 kB]
+Get:168 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python2.7-minimal amd64 2.7.17-1~18.04ubuntu1.6 [1,291 kB]
+Get:169 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-minimal amd64 2.7.15~rc1-1 [28.1 kB]
+Get:170 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython2.7-stdlib amd64 2.7.17-1~18.04ubuntu1.6 [1,917 kB]
+Get:171 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python2.7 amd64 2.7.17-1~18.04ubuntu1.6 [248 kB]
+Get:172 http://archive.ubuntu.com/ubuntu bionic/main amd64 libpython-stdlib amd64 2.7.15~rc1-1 [7,620 B]
+Get:173 http://archive.ubuntu.com/ubuntu bionic/main amd64 python amd64 2.7.15~rc1-1 [140 kB]
+Get:174 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-pkg-resources all 39.0.1-2 [128 kB]
+Get:175 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-pyflakes all 1.6.0-1 [41.7 kB]
+Get:176 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pyflakes all 1.6.0-1 [3,296 B]
+Get:177 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfakeroot amd64 1.22-2ubuntu1 [25.9 kB]
+Get:178 http://archive.ubuntu.com/ubuntu bionic/main amd64 fakeroot amd64 1.22-2ubuntu1 [62.3 kB]
+Get:179 http://archive.ubuntu.com/ubuntu bionic/main amd64 autotools-dev all 20180224.1 [39.6 kB]
+Get:180 http://archive.ubuntu.com/ubuntu bionic/main amd64 m4 amd64 1.4.18-1 [197 kB]
+Get:181 http://archive.ubuntu.com/ubuntu bionic/main amd64 autoconf all 2.69-11 [322 kB]
+Get:182 http://archive.ubuntu.com/ubuntu bionic/main amd64 automake all 1:1.15.1-3ubuntu2 [509 kB]
+Get:183 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 autopoint all 0.19.8.1-6ubuntu0.3 [426 kB]
+Get:184 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtool all 2.4.6-2 [194 kB]
+Get:185 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-autoreconf all 17 [15.8 kB]
+Get:186 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libarchive-zip-perl all 1.60-1ubuntu0.1 [84.6 kB]
+Get:187 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-stripnondeterminism-perl all 0.040-1.1~build1 [13.8 kB]
+Get:188 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtimedate-perl all 2.3000-2 [37.5 kB]
+Get:189 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-strip-nondeterminism all 0.040-1.1~build1 [5,208 B]
+Get:190 http://archive.ubuntu.com/ubuntu bionic/main amd64 libcroco3 amd64 0.6.12-2 [81.3 kB]
+Get:191 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gettext amd64 0.19.8.1-6ubuntu0.3 [1,293 kB]
+Get:192 http://archive.ubuntu.com/ubuntu bionic/main amd64 intltool-debian all 0.35.0+20060710.4 [24.9 kB]
+Get:193 http://archive.ubuntu.com/ubuntu bionic/main amd64 po-debconf all 1.0.20 [232 kB]
+Get:194 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 debhelper all 11.1.6ubuntu2 [902 kB]
+Get:195 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-extras all 1.0.0-3 [7,480 B]
+Get:196 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-fixtures all 3.0.0-2 [32.4 kB]
+Get:197 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-linecache2 all 1.0.0-3 [12.5 kB]
+Get:198 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-traceback2 all 1.4.0-5 [16.4 kB]
+Get:199 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-unittest2 all 1.1.0-6.1 [69.2 kB]
+Get:200 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-testtools all 2.3.0-3ubuntu2 [124 kB]
+Preconfiguring packages ...
+Fetched 88.7 MB in 16s (5,648 kB/s)
+Selecting previously unselected package authbind.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 96850 files and directories currently installed.)
+Preparing to unpack .../000-authbind_2.1.2_amd64.deb ...
+Unpacking authbind (2.1.2) ...
+Selecting previously unselected package libavahi-common-data:amd64.
+Preparing to unpack .../001-libavahi-common-data_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking libavahi-common-data:amd64 (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package libavahi-common3:amd64.
+Preparing to unpack .../002-libavahi-common3_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking libavahi-common3:amd64 (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package libavahi-client3:amd64.
+Preparing to unpack .../003-libavahi-client3_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking libavahi-client3:amd64 (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package libavahi-core7:amd64.
+Preparing to unpack .../004-libavahi-core7_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking libavahi-core7:amd64 (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package libdaemon0:amd64.
+Preparing to unpack .../005-libdaemon0_0.14-6_amd64.deb ...
+Unpacking libdaemon0:amd64 (0.14-6) ...
+Selecting previously unselected package avahi-daemon.
+Preparing to unpack .../006-avahi-daemon_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking avahi-daemon (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package avahi-utils.
+Preparing to unpack .../007-avahi-utils_0.7-3.1ubuntu1.3_amd64.deb ...
+Unpacking avahi-utils (0.7-3.1ubuntu1.3) ...
+Selecting previously unselected package python3-ply.
+Preparing to unpack .../008-python3-ply_3.11-1_all.deb ...
+Unpacking python3-ply (3.11-1) ...
+Selecting previously unselected package bind9utils.
+Preparing to unpack .../009-bind9utils_1%3a9.11.3+dfsg-1ubuntu1.15_amd64.deb ...
+Unpacking bind9utils (1:9.11.3+dfsg-1ubuntu1.15) ...
+Selecting previously unselected package freeipmi-common.
+Preparing to unpack .../010-freeipmi-common_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking freeipmi-common (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libfreeipmi16.
+Preparing to unpack .../011-libfreeipmi16_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libfreeipmi16 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libipmiconsole2.
+Preparing to unpack .../012-libipmiconsole2_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libipmiconsole2 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libipmidetect0.
+Preparing to unpack .../013-libipmidetect0_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libipmidetect0 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package freeipmi-tools.
+Preparing to unpack .../014-freeipmi-tools_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking freeipmi-tools (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libcurl3-gnutls:amd64.
+Preparing to unpack .../015-libcurl3-gnutls_7.58.0-2ubuntu3.14_amd64.deb ...
+Unpacking libcurl3-gnutls:amd64 (7.58.0-2ubuntu3.14) ...
+Selecting previously unselected package libyajl2:amd64.
+Preparing to unpack .../016-libyajl2_2.1.0-2build1_amd64.deb ...
+Unpacking libyajl2:amd64 (2.1.0-2build1) ...
+Selecting previously unselected package libvirt0:amd64.
+Preparing to unpack .../017-libvirt0_4.0.0-1ubuntu8.19_amd64.deb ...
+Unpacking libvirt0:amd64 (4.0.0-1ubuntu8.19) ...
+Selecting previously unselected package libvirt-clients.
+Preparing to unpack .../018-libvirt-clients_4.0.0-1ubuntu8.19_amd64.deb ...
+Unpacking libvirt-clients (4.0.0-1ubuntu8.19) ...
+Selecting previously unselected package libsodium23:amd64.
+Preparing to unpack .../019-libsodium23_1.0.16-2_amd64.deb ...
+Unpacking libsodium23:amd64 (1.0.16-2) ...
+Selecting previously unselected package python3-nacl.
+Preparing to unpack .../020-python3-nacl_1.1.2-1build1_amd64.deb ...
+Unpacking python3-nacl (1.1.2-1build1) ...
+Selecting previously unselected package libprotobuf10:amd64.
+Preparing to unpack .../021-libprotobuf10_3.0.0-9.1ubuntu1_amd64.deb ...
+Unpacking libprotobuf10:amd64 (3.0.0-9.1ubuntu1) ...
+Selecting previously unselected package python3-protobuf.
+Preparing to unpack .../022-python3-protobuf_3.0.0-9.1ubuntu1_amd64.deb ...
+Unpacking python3-protobuf (3.0.0-9.1ubuntu1) ...
+Selecting previously unselected package python3-pymacaroons.
+Preparing to unpack .../023-python3-pymacaroons_0.13.0-1_all.deb ...
+Unpacking python3-pymacaroons (0.13.0-1) ...
+Selecting previously unselected package python3-tz.
+Preparing to unpack .../024-python3-tz_2018.3-2_all.deb ...
+Unpacking python3-tz (2018.3-2) ...
+Selecting previously unselected package python3-rfc3339.
+Preparing to unpack .../025-python3-rfc3339_1.0-4_all.deb ...
+Unpacking python3-rfc3339 (1.0-4) ...
+Selecting previously unselected package python3-macaroonbakery.
+Preparing to unpack .../026-python3-macaroonbakery_1.1.3-1_all.deb ...
+Unpacking python3-macaroonbakery (1.1.3-1) ...
+Selecting previously unselected package python3-oauth.
+Preparing to unpack .../027-python3-oauth_1.0.1-5_all.deb ...
+Unpacking python3-oauth (1.0.1-5) ...
+Selecting previously unselected package python3-tempita.
+Preparing to unpack .../028-python3-tempita_0.5.2-2_all.deb ...
+Unpacking python3-tempita (0.5.2-2) ...
+Selecting previously unselected package python3-maas-client.
+Preparing to unpack .../029-python3-maas-client_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-maas-client (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-cli.
+Preparing to unpack .../030-maas-cli_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-cli (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libdebian-installer4:amd64.
+Preparing to unpack .../031-libdebian-installer4_0.110ubuntu2_amd64.deb ...
+Unpacking libdebian-installer4:amd64 (0.110ubuntu2) ...
+Selecting previously unselected package archdetect-deb.
+Preparing to unpack .../032-archdetect-deb_1.117ubuntu6.18.04.1_amd64.deb ...
+Unpacking archdetect-deb (1.117ubuntu6.18.04.1) ...
+Selecting previously unselected package python3-attr.
+Preparing to unpack .../033-python3-attr_17.4.0-2_all.deb ...
+Unpacking python3-attr (17.4.0-2) ...
+Selecting previously unselected package python3-bson.
+Preparing to unpack .../034-python3-bson_3.6.1+dfsg1-1_amd64.deb ...
+Unpacking python3-bson (3.6.1+dfsg1-1) ...
+Selecting previously unselected package python3-automat.
+Preparing to unpack .../035-python3-automat_0.6.0-1_all.deb ...
+Unpacking python3-automat (0.6.0-1) ...
+Selecting previously unselected package python3-constantly.
+Preparing to unpack .../036-python3-constantly_15.1.0-1_all.deb ...
+Unpacking python3-constantly (15.1.0-1) ...
+Selecting previously unselected package python3-hyperlink.
+Preparing to unpack .../037-python3-hyperlink_17.3.1-2_all.deb ...
+Unpacking python3-hyperlink (17.3.1-2) ...
+Selecting previously unselected package python3-incremental.
+Preparing to unpack .../038-python3-incremental_16.10.1-3_all.deb ...
+Unpacking python3-incremental (16.10.1-3) ...
+Selecting previously unselected package python3-zope.interface.
+Preparing to unpack .../039-python3-zope.interface_4.3.2-1build2_amd64.deb ...
+Unpacking python3-zope.interface (4.3.2-1build2) ...
+Selecting previously unselected package python3-twisted-bin:amd64.
+Preparing to unpack .../040-python3-twisted-bin_17.9.0-2ubuntu0.1_amd64.deb ...
+Unpacking python3-twisted-bin:amd64 (17.9.0-2ubuntu0.1) ...
+Selecting previously unselected package python3-pyasn1.
+Preparing to unpack .../041-python3-pyasn1_0.4.2-3_all.deb ...
+Unpacking python3-pyasn1 (0.4.2-3) ...
+Selecting previously unselected package python3-pyasn1-modules.
+Preparing to unpack .../042-python3-pyasn1-modules_0.2.1-0.2_all.deb ...
+Unpacking python3-pyasn1-modules (0.2.1-0.2) ...
+Selecting previously unselected package python3-service-identity.
+Preparing to unpack .../043-python3-service-identity_16.0.0-2_all.deb ...
+Unpacking python3-service-identity (16.0.0-2) ...
+Selecting previously unselected package python3-twisted.
+Preparing to unpack .../044-python3-twisted_17.9.0-2ubuntu0.1_all.deb ...
+Unpacking python3-twisted (17.9.0-2ubuntu0.1) ...
+Selecting previously unselected package python3-crochet.
+Preparing to unpack .../045-python3-crochet_1.4.0-0ubuntu2_all.deb ...
+Unpacking python3-crochet (1.4.0-0ubuntu2) ...
+Selecting previously unselected package curtin-common.
+Preparing to unpack .../046-curtin-common_20.1-2-g42a9667f-0ubuntu1~18.04.1_all.deb ...
+Unpacking curtin-common (20.1-2-g42a9667f-0ubuntu1~18.04.1) ...
+Selecting previously unselected package python3-curtin.
+Preparing to unpack .../047-python3-curtin_20.1-2-g42a9667f-0ubuntu1~18.04.1_all.deb ...
+Unpacking python3-curtin (20.1-2-g42a9667f-0ubuntu1~18.04.1) ...
+Selecting previously unselected package python3-distro-info.
+Preparing to unpack .../048-python3-distro-info_0.18ubuntu0.18.04.1_all.deb ...
+Unpacking python3-distro-info (0.18ubuntu0.18.04.1) ...
+Selecting previously unselected package python3-dnspython.
+Preparing to unpack .../049-python3-dnspython_1.15.0-1_all.deb ...
+Unpacking python3-dnspython (1.15.0-1) ...
+Selecting previously unselected package formencode-i18n.
+Preparing to unpack .../050-formencode-i18n_1.3.0-0ubuntu5_all.deb ...
+Unpacking formencode-i18n (1.3.0-0ubuntu5) ...
+Selecting previously unselected package python3-formencode.
+Preparing to unpack .../051-python3-formencode_1.3.0-0ubuntu5_all.deb ...
+Unpacking python3-formencode (1.3.0-0ubuntu5) ...
+Selecting previously unselected package libxslt1.1:amd64.
+Preparing to unpack .../052-libxslt1.1_1.1.29-5ubuntu0.2_amd64.deb ...
+Unpacking libxslt1.1:amd64 (1.1.29-5ubuntu0.2) ...
+Selecting previously unselected package python3-lxml:amd64.
+Preparing to unpack .../053-python3-lxml_4.2.1-1ubuntu0.4_amd64.deb ...
+Unpacking python3-lxml:amd64 (4.2.1-1ubuntu0.4) ...
+Selecting previously unselected package python3-paramiko.
+Preparing to unpack .../054-python3-paramiko_2.0.0-1ubuntu1.2_all.deb ...
+Unpacking python3-paramiko (2.0.0-1ubuntu1.2) ...
+Selecting previously unselected package python3-ptyprocess.
+Preparing to unpack .../055-python3-ptyprocess_0.5.2-1_all.deb ...
+Unpacking python3-ptyprocess (0.5.2-1) ...
+Selecting previously unselected package python3-pexpect.
+Preparing to unpack .../056-python3-pexpect_4.2.1-1_all.deb ...
+Unpacking python3-pexpect (4.2.1-1) ...
+Selecting previously unselected package python3-pyparsing.
+Preparing to unpack .../057-python3-pyparsing_2.2.0+dfsg1-2_all.deb ...
+Unpacking python3-pyparsing (2.2.0+dfsg1-2) ...
+Selecting previously unselected package python3-pyvmomi.
+Preparing to unpack .../058-python3-pyvmomi_6.5.0.2017.5-0ubuntu1_all.deb ...
+Unpacking python3-pyvmomi (6.5.0.2017.5-0ubuntu1) ...
+Selecting previously unselected package python-babel-localedata.
+Preparing to unpack .../059-python-babel-localedata_2.4.0+dfsg.1-2ubuntu1.1_all.deb ...
+Unpacking python-babel-localedata (2.4.0+dfsg.1-2ubuntu1.1) ...
+Selecting previously unselected package python3-babel.
+Preparing to unpack .../060-python3-babel_2.4.0+dfsg.1-2ubuntu1.1_all.deb ...
+Unpacking python3-babel (2.4.0+dfsg.1-2ubuntu1.1) ...
+Selecting previously unselected package python3-pbr.
+Preparing to unpack .../061-python3-pbr_3.1.1-3ubuntu3_all.deb ...
+Unpacking python3-pbr (3.1.1-3ubuntu3) ...
+Selecting previously unselected package python3-prettytable.
+Preparing to unpack .../062-python3-prettytable_0.7.2-3_all.deb ...
+Unpacking python3-prettytable (0.7.2-3) ...
+Selecting previously unselected package python3-simplejson.
+Preparing to unpack .../063-python3-simplejson_3.13.2-1_amd64.deb ...
+Unpacking python3-simplejson (3.13.2-1) ...
+Selecting previously unselected package python3-iso8601.
+Preparing to unpack .../064-python3-iso8601_0.1.11-1_all.deb ...
+Unpacking python3-iso8601 (0.1.11-1) ...
+Selecting previously unselected package python3-seamicroclient.
+Preparing to unpack .../065-python3-seamicroclient_0.4.0-1ubuntu1_all.deb ...
+Unpacking python3-seamicroclient (0.4.0-1ubuntu1) ...
+Selecting previously unselected package python3-simplestreams.
+Preparing to unpack .../066-python3-simplestreams_0.1.0~bzr460-0ubuntu1.1_all.deb ...
+Unpacking python3-simplestreams (0.1.0~bzr460-0ubuntu1.1) ...
+Selecting previously unselected package python3-txtftp.
+Preparing to unpack .../067-python3-txtftp_0.1~bzr47-0ubuntu2_all.deb ...
+Unpacking python3-txtftp (0.1~bzr47-0ubuntu2) ...
+Selecting previously unselected package libuv1:amd64.
+Preparing to unpack .../068-libuv1_1.18.0-3_amd64.deb ...
+Unpacking libuv1:amd64 (1.18.0-3) ...
+Selecting previously unselected package python3-uvloop.
+Preparing to unpack .../069-python3-uvloop_0.8.1+ds1-1ubuntu0.1_amd64.deb ...
+Unpacking python3-uvloop (0.8.1+ds1-1ubuntu0.1) ...
+Selecting previously unselected package python3-maas-provisioningserver.
+Preparing to unpack .../070-python3-maas-provisioningserver_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-maas-provisioningserver (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-common.
+Preparing to unpack .../071-maas-common_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-common (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libisccfg-export160.
+Preparing to unpack .../072-libisccfg-export160_1%3a9.11.3+dfsg-1ubuntu1.15_amd64.deb ...
+Unpacking libisccfg-export160 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Selecting previously unselected package libirs-export160.
+Preparing to unpack .../073-libirs-export160_1%3a9.11.3+dfsg-1ubuntu1.15_amd64.deb ...
+Unpacking libirs-export160 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Selecting previously unselected package isc-dhcp-server.
+Preparing to unpack .../074-isc-dhcp-server_4.3.5-3ubuntu7.3_amd64.deb ...
+Unpacking isc-dhcp-server (4.3.5-3ubuntu7.3) ...
+Selecting previously unselected package maas-dhcp.
+Preparing to unpack .../075-maas-dhcp_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-dhcp (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libnspr4:amd64.
+Preparing to unpack .../076-libnspr4_2%3a4.18-1ubuntu1_amd64.deb ...
+Unpacking libnspr4:amd64 (2:4.18-1ubuntu1) ...
+Selecting previously unselected package libnss3:amd64.
+Preparing to unpack .../077-libnss3_2%3a3.35-2ubuntu2.12_amd64.deb ...
+Unpacking libnss3:amd64 (2:3.35-2ubuntu2.12) ...
+Selecting previously unselected package chrony.
+Preparing to unpack .../078-chrony_3.2-4ubuntu4.5_amd64.deb ...
+Unpacking chrony (3.2-4ubuntu4.5) ...
+Selecting previously unselected package pxelinux.
+Preparing to unpack .../079-pxelinux_3%3a6.03+dfsg1-2_all.deb ...
+Unpacking pxelinux (3:6.03+dfsg1-2) ...
+Selecting previously unselected package ieee-data.
+Preparing to unpack .../080-ieee-data_20180204.1_all.deb ...
+Unpacking ieee-data (20180204.1) ...
+Selecting previously unselected package python3-netaddr.
+Preparing to unpack .../081-python3-netaddr_0.7.19-1_all.deb ...
+Unpacking python3-netaddr (0.7.19-1) ...
+Selecting previously unselected package syslinux-common.
+Preparing to unpack .../082-syslinux-common_3%3a6.03+dfsg1-2_all.deb ...
+Unpacking syslinux-common (3:6.03+dfsg1-2) ...
+Selecting previously unselected package maas-rack-controller.
+Preparing to unpack .../083-maas-rack-controller_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-rack-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package dbconfig-common.
+Preparing to unpack .../084-dbconfig-common_2.0.9_all.deb ...
+Unpacking dbconfig-common (2.0.9) ...
+Selecting previously unselected package libpq5:amd64.
+Preparing to unpack .../085-libpq5_10.18-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libpq5:amd64 (10.18-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql-client-common.
+Preparing to unpack .../086-postgresql-client-common_190ubuntu0.1_all.deb ...
+Unpacking postgresql-client-common (190ubuntu0.1) ...
+Selecting previously unselected package postgresql-client-10.
+Preparing to unpack .../087-postgresql-client-10_10.18-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking postgresql-client-10 (10.18-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql-client.
+Preparing to unpack .../088-postgresql-client_10+190ubuntu0.1_all.deb ...
+Unpacking postgresql-client (10+190ubuntu0.1) ...
+Selecting previously unselected package dbconfig-pgsql.
+Preparing to unpack .../089-dbconfig-pgsql_2.0.9_all.deb ...
+Unpacking dbconfig-pgsql (2.0.9) ...
+Selecting previously unselected package bind9.
+Preparing to unpack .../090-bind9_1%3a9.11.3+dfsg-1ubuntu1.15_amd64.deb ...
+Unpacking bind9 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Selecting previously unselected package libjs-angularjs.
+Preparing to unpack .../091-libjs-angularjs_1.5.10-1_all.deb ...
+Unpacking libjs-angularjs (1.5.10-1) ...
+Selecting previously unselected package libecap3:amd64.
+Preparing to unpack .../092-libecap3_1.0.1-3.2_amd64.deb ...
+Unpacking libecap3:amd64 (1.0.1-3.2) ...
+Selecting previously unselected package libltdl7:amd64.
+Preparing to unpack .../093-libltdl7_2.4.6-2_amd64.deb ...
+Unpacking libltdl7:amd64 (2.4.6-2) ...
+Selecting previously unselected package squid-langpack.
+Preparing to unpack .../094-squid-langpack_20170901-1_all.deb ...
+Unpacking squid-langpack (20170901-1) ...
+Selecting previously unselected package squid-common.
+Preparing to unpack .../095-squid-common_3.5.27-1ubuntu1.11_all.deb ...
+Unpacking squid-common (3.5.27-1ubuntu1.11) ...
+Selecting previously unselected package libdbi-perl.
+Preparing to unpack .../096-libdbi-perl_1.640-1ubuntu0.3_amd64.deb ...
+Unpacking libdbi-perl (1.640-1ubuntu0.3) ...
+Selecting previously unselected package ssl-cert.
+Preparing to unpack .../097-ssl-cert_1.0.39_all.deb ...
+Unpacking ssl-cert (1.0.39) ...
+Selecting previously unselected package squid.
+Preparing to unpack .../098-squid_3.5.27-1ubuntu1.11_amd64.deb ...
+Unpacking squid (3.5.27-1ubuntu1.11) ...
+Selecting previously unselected package maas-proxy.
+Preparing to unpack .../099-maas-proxy_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-proxy (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python-django-common.
+Preparing to unpack .../100-python-django-common_1%3a1.11.11-1ubuntu1.14_all.deb ...
+Unpacking python-django-common (1:1.11.11-1ubuntu1.14) ...
+Selecting previously unselected package python3-django.
+Preparing to unpack .../101-python3-django_1%3a1.11.11-1ubuntu1.14_all.deb ...
+Unpacking python3-django (1:1.11.11-1ubuntu1.14) ...
+Selecting previously unselected package python3-convoy.
+Preparing to unpack .../102-python3-convoy_0.2.1+bzr39-1_all.deb ...
+Unpacking python3-convoy (0.2.1+bzr39-1) ...
+Selecting previously unselected package python3-psycopg2.
+Preparing to unpack .../103-python3-psycopg2_2.7.4-1_amd64.deb ...
+Unpacking python3-psycopg2 (2.7.4-1) ...
+Selecting previously unselected package python3-lib2to3.
+Preparing to unpack .../104-python3-lib2to3_3.6.9-1~18.04_all.deb ...
+Unpacking python3-lib2to3 (3.6.9-1~18.04) ...
+Selecting previously unselected package sgml-base.
+Preparing to unpack .../105-sgml-base_1.29_all.deb ...
+Unpacking sgml-base (1.29) ...
+Selecting previously unselected package xml-core.
+Preparing to unpack .../106-xml-core_0.18_all.deb ...
+Unpacking xml-core (0.18) ...
+Selecting previously unselected package docutils-common.
+Preparing to unpack .../107-docutils-common_0.14+dfsg-3_all.deb ...
+Unpacking docutils-common (0.14+dfsg-3) ...
+Selecting previously unselected package python3-roman.
+Preparing to unpack .../108-python3-roman_2.0.0-3_all.deb ...
+Unpacking python3-roman (2.0.0-3) ...
+Selecting previously unselected package python3-docutils.
+Preparing to unpack .../109-python3-docutils_0.14+dfsg-3_all.deb ...
+Unpacking python3-docutils (0.14+dfsg-3) ...
+Selecting previously unselected package python3-pygments.
+Preparing to unpack .../110-python3-pygments_2.2.0+dfsg-1ubuntu0.2_all.deb ...
+Unpacking python3-pygments (2.2.0+dfsg-1ubuntu0.2) ...
+Selecting previously unselected package python3-alabaster.
+Preparing to unpack .../111-python3-alabaster_0.7.8-1_all.deb ...
+Unpacking python3-alabaster (0.7.8-1) ...
+Selecting previously unselected package python3-imagesize.
+Preparing to unpack .../112-python3-imagesize_0.7.1-1_all.deb ...
+Unpacking python3-imagesize (0.7.1-1) ...
+Selecting previously unselected package libjs-jquery.
+Preparing to unpack .../113-libjs-jquery_3.2.1-1_all.deb ...
+Unpacking libjs-jquery (3.2.1-1) ...
+Selecting previously unselected package libjs-underscore.
+Preparing to unpack .../114-libjs-underscore_1.8.3~dfsg-1ubuntu0.1_all.deb ...
+Unpacking libjs-underscore (1.8.3~dfsg-1ubuntu0.1) ...
+Selecting previously unselected package libjs-sphinxdoc.
+Preparing to unpack .../115-libjs-sphinxdoc_1.6.7-1ubuntu1_all.deb ...
+Unpacking libjs-sphinxdoc (1.6.7-1ubuntu1) ...
+Selecting previously unselected package sphinx-common.
+Preparing to unpack .../116-sphinx-common_1.6.7-1ubuntu1_all.deb ...
+Unpacking sphinx-common (1.6.7-1ubuntu1) ...
+Selecting previously unselected package python3-sphinx.
+Preparing to unpack .../117-python3-sphinx_1.6.7-1ubuntu1_all.deb ...
+Unpacking python3-sphinx (1.6.7-1ubuntu1) ...
+Selecting previously unselected package python3-django-maas.
+Preparing to unpack .../118-python3-django-maas_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-django-maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python3-mimeparse.
+Preparing to unpack .../119-python3-mimeparse_0.1.4-3.1_all.deb ...
+Unpacking python3-mimeparse (0.1.4-3.1) ...
+Selecting previously unselected package python3-django-piston3.
+Preparing to unpack .../120-python3-django-piston3_0.3~rc2-3ubuntu5_amd64.deb ...
+Unpacking python3-django-piston3 (0.3~rc2-3ubuntu5) ...
+Selecting previously unselected package python3-djorm-ext-pgarray.
+Preparing to unpack .../121-python3-djorm-ext-pgarray_1.2-0ubuntu2_all.deb ...
+Unpacking python3-djorm-ext-pgarray (1.2-0ubuntu2) ...
+Selecting previously unselected package python3-petname.
+Preparing to unpack .../122-python3-petname_2.2-0ubuntu1_all.deb ...
+Unpacking python3-petname (2.2-0ubuntu1) ...
+Selecting previously unselected package maas-region-api.
+Preparing to unpack .../123-maas-region-api_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-region-api (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package postgresql-common.
+Preparing to unpack .../124-postgresql-common_190ubuntu0.1_all.deb ...
+Adding 'diversion of /usr/bin/pg_config to /usr/bin/pg_config.libpq-dev by postgresql-common'
+Unpacking postgresql-common (190ubuntu0.1) ...
+Selecting previously unselected package postgresql-10.
+Preparing to unpack .../125-postgresql-10_10.18-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking postgresql-10 (10.18-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql.
+Preparing to unpack .../126-postgresql_10+190ubuntu0.1_all.deb ...
+Unpacking postgresql (10+190ubuntu0.1) ...
+Selecting previously unselected package maas-region-controller.
+Preparing to unpack .../127-maas-region-controller_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-region-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas.
+Preparing to unpack .../128-maas_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-dns.
+Preparing to unpack .../129-maas-dns_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-dns (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python3-mock.
+Preparing to unpack .../130-python3-mock_2.0.0-3_all.deb ...
+Unpacking python3-mock (2.0.0-3) ...
+Selecting previously unselected package python3-nose.
+Preparing to unpack .../131-python3-nose_1.3.7-3_all.deb ...
+Unpacking python3-nose (1.3.7-3) ...
+Selecting previously unselected package python3-distutils.
+Preparing to unpack .../132-python3-distutils_3.6.9-1~18.04_all.deb ...
+Unpacking python3-distutils (3.6.9-1~18.04) ...
+Selecting previously unselected package python3-setuptools.
+Preparing to unpack .../133-python3-setuptools_39.0.1-2_all.deb ...
+Unpacking python3-setuptools (39.0.1-2) ...
+Selecting previously unselected package libfile-which-perl.
+Preparing to unpack .../134-libfile-which-perl_1.21-1_all.deb ...
+Unpacking libfile-which-perl (1.21-1) ...
+Selecting previously unselected package libfile-homedir-perl.
+Preparing to unpack .../135-libfile-homedir-perl_1.002-1_all.deb ...
+Unpacking libfile-homedir-perl (1.002-1) ...
+Selecting previously unselected package devscripts.
+Preparing to unpack .../136-devscripts_2.17.12ubuntu1.1_amd64.deb ...
+Unpacking devscripts (2.17.12ubuntu1.1) ...
+Selecting previously unselected package libc-dev-bin.
+Preparing to unpack .../137-libc-dev-bin_2.27-3ubuntu1.4_amd64.deb ...
+Unpacking libc-dev-bin (2.27-3ubuntu1.4) ...
+Selecting previously unselected package linux-libc-dev:amd64.
+Preparing to unpack .../138-linux-libc-dev_4.15.0-154.161_amd64.deb ...
+Unpacking linux-libc-dev:amd64 (4.15.0-154.161) ...
+Selecting previously unselected package libc6-dev:amd64.
+Preparing to unpack .../139-libc6-dev_2.27-3ubuntu1.4_amd64.deb ...
+Unpacking libc6-dev:amd64 (2.27-3ubuntu1.4) ...
+Selecting previously unselected package gcc-7-base:amd64.
+Preparing to unpack .../140-gcc-7-base_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libisl19:amd64.
+Preparing to unpack .../141-libisl19_0.19-1_amd64.deb ...
+Unpacking libisl19:amd64 (0.19-1) ...
+Selecting previously unselected package libmpc3:amd64.
+Preparing to unpack .../142-libmpc3_1.1.0-1_amd64.deb ...
+Unpacking libmpc3:amd64 (1.1.0-1) ...
+Selecting previously unselected package cpp-7.
+Preparing to unpack .../143-cpp-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package cpp.
+Preparing to unpack .../144-cpp_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking cpp (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libcc1-0:amd64.
+Preparing to unpack .../145-libcc1-0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgomp1:amd64.
+Preparing to unpack .../146-libgomp1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libitm1:amd64.
+Preparing to unpack .../147-libitm1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libatomic1:amd64.
+Preparing to unpack .../148-libatomic1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libasan4:amd64.
+Preparing to unpack .../149-libasan4_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package liblsan0:amd64.
+Preparing to unpack .../150-liblsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libtsan0:amd64.
+Preparing to unpack .../151-libtsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libubsan0:amd64.
+Preparing to unpack .../152-libubsan0_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libcilkrts5:amd64.
+Preparing to unpack .../153-libcilkrts5_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libmpx2:amd64.
+Preparing to unpack .../154-libmpx2_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libquadmath0:amd64.
+Preparing to unpack .../155-libquadmath0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgcc-7-dev:amd64.
+Preparing to unpack .../156-libgcc-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc-7.
+Preparing to unpack .../157-gcc-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc.
+Preparing to unpack .../158-gcc_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking gcc (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libstdc++-7-dev:amd64.
+Preparing to unpack .../159-libstdc++-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++-7.
+Preparing to unpack .../160-g++-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking g++-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++.
+Preparing to unpack .../161-g++_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking g++ (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package build-essential.
+Preparing to unpack .../162-build-essential_12.4ubuntu1_amd64.deb ...
+Unpacking build-essential (12.4ubuntu1) ...
+Selecting previously unselected package python3-pycodestyle.
+Preparing to unpack .../163-python3-pycodestyle_2.3.1-2_all.deb ...
+Unpacking python3-pycodestyle (2.3.1-2) ...
+Selecting previously unselected package pycodestyle.
+Preparing to unpack .../164-pycodestyle_2.3.1-2_all.deb ...
+Unpacking pycodestyle (2.3.1-2) ...
+Selecting previously unselected package pep8.
+Preparing to unpack .../165-pep8_1.7.1-1ubuntu1_all.deb ...
+Unpacking pep8 (1.7.1-1ubuntu1) ...
+Selecting previously unselected package libpython2.7-minimal:amd64.
+Preparing to unpack .../166-libpython2.7-minimal_2.7.17-1~18.04ubuntu1.6_amd64.deb ...
+Unpacking libpython2.7-minimal:amd64 (2.7.17-1~18.04ubuntu1.6) ...
+Selecting previously unselected package python2.7-minimal.
+Preparing to unpack .../167-python2.7-minimal_2.7.17-1~18.04ubuntu1.6_amd64.deb ...
+Unpacking python2.7-minimal (2.7.17-1~18.04ubuntu1.6) ...
+Selecting previously unselected package python-minimal.
+Preparing to unpack .../168-python-minimal_2.7.15~rc1-1_amd64.deb ...
+Unpacking python-minimal (2.7.15~rc1-1) ...
+Selecting previously unselected package libpython2.7-stdlib:amd64.
+Preparing to unpack .../169-libpython2.7-stdlib_2.7.17-1~18.04ubuntu1.6_amd64.deb ...
+Unpacking libpython2.7-stdlib:amd64 (2.7.17-1~18.04ubuntu1.6) ...
+Selecting previously unselected package python2.7.
+Preparing to unpack .../170-python2.7_2.7.17-1~18.04ubuntu1.6_amd64.deb ...
+Unpacking python2.7 (2.7.17-1~18.04ubuntu1.6) ...
+Selecting previously unselected package libpython-stdlib:amd64.
+Preparing to unpack .../171-libpython-stdlib_2.7.15~rc1-1_amd64.deb ...
+Unpacking libpython-stdlib:amd64 (2.7.15~rc1-1) ...
+Setting up libpython2.7-minimal:amd64 (2.7.17-1~18.04ubuntu1.6) ...
+Setting up python2.7-minimal (2.7.17-1~18.04ubuntu1.6) ...
+Setting up python-minimal (2.7.15~rc1-1) ...
+Selecting previously unselected package python.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 122392 files and directories currently installed.)
+Preparing to unpack .../00-python_2.7.15~rc1-1_amd64.deb ...
+Unpacking python (2.7.15~rc1-1) ...
+Selecting previously unselected package python-pkg-resources.
+Preparing to unpack .../01-python-pkg-resources_39.0.1-2_all.deb ...
+Unpacking python-pkg-resources (39.0.1-2) ...
+Selecting previously unselected package python-pyflakes.
+Preparing to unpack .../02-python-pyflakes_1.6.0-1_all.deb ...
+Unpacking python-pyflakes (1.6.0-1) ...
+Selecting previously unselected package pyflakes.
+Preparing to unpack .../03-pyflakes_1.6.0-1_all.deb ...
+Unpacking pyflakes (1.6.0-1) ...
+Selecting previously unselected package libfakeroot:amd64.
+Preparing to unpack .../04-libfakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking libfakeroot:amd64 (1.22-2ubuntu1) ...
+Selecting previously unselected package fakeroot.
+Preparing to unpack .../05-fakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking fakeroot (1.22-2ubuntu1) ...
+Selecting previously unselected package autotools-dev.
+Preparing to unpack .../06-autotools-dev_20180224.1_all.deb ...
+Unpacking autotools-dev (20180224.1) ...
+Selecting previously unselected package m4.
+Preparing to unpack .../07-m4_1.4.18-1_amd64.deb ...
+Unpacking m4 (1.4.18-1) ...
+Selecting previously unselected package autoconf.
+Preparing to unpack .../08-autoconf_2.69-11_all.deb ...
+Unpacking autoconf (2.69-11) ...
+Selecting previously unselected package automake.
+Preparing to unpack .../09-automake_1%3a1.15.1-3ubuntu2_all.deb ...
+Unpacking automake (1:1.15.1-3ubuntu2) ...
+Selecting previously unselected package autopoint.
+Preparing to unpack .../10-autopoint_0.19.8.1-6ubuntu0.3_all.deb ...
+Unpacking autopoint (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package libtool.
+Preparing to unpack .../11-libtool_2.4.6-2_all.deb ...
+Unpacking libtool (2.4.6-2) ...
+Selecting previously unselected package dh-autoreconf.
+Preparing to unpack .../12-dh-autoreconf_17_all.deb ...
+Unpacking dh-autoreconf (17) ...
+Selecting previously unselected package libarchive-zip-perl.
+Preparing to unpack .../13-libarchive-zip-perl_1.60-1ubuntu0.1_all.deb ...
+Unpacking libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Selecting previously unselected package libfile-stripnondeterminism-perl.
+Preparing to unpack .../14-libfile-stripnondeterminism-perl_0.040-1.1~build1_all.deb ...
+Unpacking libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Selecting previously unselected package libtimedate-perl.
+Preparing to unpack .../15-libtimedate-perl_2.3000-2_all.deb ...
+Unpacking libtimedate-perl (2.3000-2) ...
+Selecting previously unselected package dh-strip-nondeterminism.
+Preparing to unpack .../16-dh-strip-nondeterminism_0.040-1.1~build1_all.deb ...
+Unpacking dh-strip-nondeterminism (0.040-1.1~build1) ...
+Selecting previously unselected package libcroco3:amd64.
+Preparing to unpack .../17-libcroco3_0.6.12-2_amd64.deb ...
+Unpacking libcroco3:amd64 (0.6.12-2) ...
+Selecting previously unselected package gettext.
+Preparing to unpack .../18-gettext_0.19.8.1-6ubuntu0.3_amd64.deb ...
+Unpacking gettext (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package intltool-debian.
+Preparing to unpack .../19-intltool-debian_0.35.0+20060710.4_all.deb ...
+Unpacking intltool-debian (0.35.0+20060710.4) ...
+Selecting previously unselected package po-debconf.
+Preparing to unpack .../20-po-debconf_1.0.20_all.deb ...
+Unpacking po-debconf (1.0.20) ...
+Selecting previously unselected package debhelper.
+Preparing to unpack .../21-debhelper_11.1.6ubuntu2_all.deb ...
+Unpacking debhelper (11.1.6ubuntu2) ...
+Selecting previously unselected package python3-extras.
+Preparing to unpack .../22-python3-extras_1.0.0-3_all.deb ...
+Unpacking python3-extras (1.0.0-3) ...
+Selecting previously unselected package python3-fixtures.
+Preparing to unpack .../23-python3-fixtures_3.0.0-2_all.deb ...
+Unpacking python3-fixtures (3.0.0-2) ...
+Selecting previously unselected package python3-linecache2.
+Preparing to unpack .../24-python3-linecache2_1.0.0-3_all.deb ...
+Unpacking python3-linecache2 (1.0.0-3) ...
+Selecting previously unselected package python3-traceback2.
+Preparing to unpack .../25-python3-traceback2_1.4.0-5_all.deb ...
+Unpacking python3-traceback2 (1.4.0-5) ...
+Selecting previously unselected package python3-unittest2.
+Preparing to unpack .../26-python3-unittest2_1.1.0-6.1_all.deb ...
+Unpacking python3-unittest2 (1.1.0-6.1) ...
+Selecting previously unselected package python3-testtools.
+Preparing to unpack .../27-python3-testtools_2.3.0-3ubuntu2_all.deb ...
+Unpacking python3-testtools (2.3.0-3ubuntu2) ...
+Setting up libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libjs-jquery (3.2.1-1) ...
+Setting up libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-incremental (16.10.1-3) ...
+Setting up python3-dnspython (1.15.0-1) ...
+Setting up python3-pbr (3.1.1-3ubuntu3) ...
+update-alternatives: using /usr/bin/python3-pbr to provide /usr/bin/pbr (pbr) in auto mode
+Setting up python3-distro-info (0.18ubuntu0.18.04.1) ...
+Setting up python3-linecache2 (1.0.0-3) ...
+Setting up libdaemon0:amd64 (0.14-6) ...
+Setting up libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-roman (2.0.0-3) ...
+Setting up python3-imagesize (0.7.1-1) ...
+Setting up libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Setting up libjs-underscore (1.8.3~dfsg-1ubuntu0.1) ...
+Setting up ieee-data (20180204.1) ...
+Setting up libfile-which-perl (1.21-1) ...
+Setting up python3-pyvmomi (6.5.0.2017.5-0ubuntu1) ...
+Setting up python3-mock (2.0.0-3) ...
+Setting up libtimedate-perl (2.3000-2) ...
+Setting up python3-twisted-bin:amd64 (17.9.0-2ubuntu0.1) ...
+Setting up libuv1:amd64 (1.18.0-3) ...
+Setting up python3-tempita (0.5.2-2) ...
+Setting up libcurl3-gnutls:amd64 (7.58.0-2ubuntu3.14) ...
+Setting up libfile-homedir-perl (1.002-1) ...
+Setting up python3-constantly (15.1.0-1) ...
+Setting up libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-alabaster (0.7.8-1) ...
+Setting up python3-iso8601 (0.1.11-1) ...
+Setting up libdebian-installer4:amd64 (0.110ubuntu2) ...
+Setting up python3-simplejson (3.13.2-1) ...
+Setting up archdetect-deb (1.117ubuntu6.18.04.1) ...
+Setting up python3-oauth (1.0.1-5) ...
+Setting up linux-libc-dev:amd64 (4.15.0-154.161) ...
+Setting up pxelinux (3:6.03+dfsg1-2) ...
+Setting up libisccfg-export160 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Setting up python3-pyparsing (2.2.0+dfsg1-2) ...
+Setting up formencode-i18n (1.3.0-0ubuntu5) ...
+Setting up libjs-sphinxdoc (1.6.7-1ubuntu1) ...
+Setting up ssl-cert (1.0.39) ...
+Setting up python3-extras (1.0.0-3) ...
+Setting up devscripts (2.17.12ubuntu1.1) ...
+Setting up libecap3:amd64 (1.0.1-3.2) ...
+Setting up python3-petname (2.2-0ubuntu1) ...
+Setting up python3-zope.interface (4.3.2-1build2) ...
+Setting up m4 (1.4.18-1) ...
+Setting up sgml-base (1.29) ...
+Setting up syslinux-common (3:6.03+dfsg1-2) ...
+Setting up libnspr4:amd64 (2:4.18-1ubuntu1) ...
+Setting up python3-simplestreams (0.1.0~bzr460-0ubuntu1.1) ...
+Setting up python3-djorm-ext-pgarray (1.2-0ubuntu2) ...
+Setting up python3-traceback2 (1.4.0-5) ...
+Setting up liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcroco3:amd64 (0.6.12-2) ...
+Setting up libjs-angularjs (1.5.10-1) ...
+Setting up python3-convoy (0.2.1+bzr39-1) ...
+Setting up libxslt1.1:amd64 (1.1.29-5ubuntu0.2) ...
+Setting up libprotobuf10:amd64 (3.0.0-9.1ubuntu1) ...
+Setting up gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-prettytable (0.7.2-3) ...
+Setting up libsodium23:amd64 (1.0.16-2) ...
+Setting up libyajl2:amd64 (2.1.0-2build1) ...
+Setting up libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-pyasn1 (0.4.2-3) ...
+Setting up authbind (2.1.2) ...
+Setting up python3-protobuf (3.0.0-9.1ubuntu1) ...
+Setting up python3-pycodestyle (2.3.1-2) ...
+Setting up libpq5:amd64 (10.18-0ubuntu0.18.04.1) ...
+Setting up autotools-dev (20180224.1) ...
+Setting up python3-nose (1.3.7-3) ...
+Setting up python3-unittest2 (1.1.0-6.1) ...
+update-alternatives: using /usr/bin/python3-unit2 to provide /usr/bin/unit2 (unit2) in auto mode
+Setting up postgresql-client-common (190ubuntu0.1) ...
+Setting up libfakeroot:amd64 (1.22-2ubuntu1) ...
+Setting up python-babel-localedata (2.4.0+dfsg.1-2ubuntu1.1) ...
+Setting up libltdl7:amd64 (2.4.6-2) ...
+Setting up postgresql-common (190ubuntu0.1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Adding user postgres to group ssl-cert
+
+Creating config file /etc/postgresql-common/createcluster.conf with new version
+Building PostgreSQL dictionaries from installed myspell/hunspell packages...
+Removing obsolete dictionary files:
+Created symlink /etc/systemd/system/multi-user.target.wants/postgresql.service → /lib/systemd/system/postgresql.service.
+Setting up squid-langpack (20170901-1) ...
+Setting up sphinx-common (1.6.7-1ubuntu1) ...
+Setting up python3-pyasn1-modules (0.2.1-0.2) ...
+Setting up python3-nacl (1.1.2-1build1) ...
+Setting up squid-common (3.5.27-1ubuntu1.11) ...
+Setting up python3-attr (17.4.0-2) ...
+Setting up python3-mimeparse (0.1.4-3.1) ...
+Setting up libmpc3:amd64 (1.1.0-1) ...
+Setting up python3-ply (3.11-1) ...
+Setting up libirs-export160 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Setting up libc-dev-bin (2.27-3ubuntu1.4) ...
+Setting up freeipmi-common (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-service-identity (16.0.0-2) ...
+Setting up libfreeipmi16 (1.4.11-1.1ubuntu4.1) ...
+Setting up xml-core (0.18) ...
+Setting up isc-dhcp-server (4.3.5-3ubuntu7.3) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Generating /etc/default/isc-dhcp-server...
+Created symlink /etc/systemd/system/multi-user.target.wants/isc-dhcp-server.service → /lib/systemd/system/isc-dhcp-server.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/isc-dhcp-server6.service → /lib/systemd/system/isc-dhcp-server6.service.
+Setting up curtin-common (20.1-2-g42a9667f-0ubuntu1~18.04.1) ...
+Setting up python3-lib2to3 (3.6.9-1~18.04) ...
+Setting up python3-hyperlink (17.3.1-2) ...
+Setting up python-django-common (1:1.11.11-1ubuntu1.14) ...
+Setting up python3-netaddr (0.7.19-1) ...
+Setting up python3-automat (0.6.0-1) ...
+Setting up dbconfig-common (2.0.9) ...
+
+Creating config file /etc/dbconfig-common/config with new version
+Setting up libc6-dev:amd64 (2.27-3ubuntu1.4) ...
+Setting up python3-ptyprocess (0.5.2-1) ...
+Setting up python3-curtin (20.1-2-g42a9667f-0ubuntu1~18.04.1) ...
+Setting up python3-tz (2018.3-2) ...
+Setting up python3-distutils (3.6.9-1~18.04) ...
+Setting up libdbi-perl (1.640-1ubuntu0.3) ...
+Setting up libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libpython2.7-stdlib:amd64 (2.7.17-1~18.04ubuntu1.6) ...
+Setting up autopoint (0.19.8.1-6ubuntu0.3) ...
+Setting up python3-bson (3.6.1+dfsg1-1) ...
+Setting up libipmiconsole2 (1.4.11-1.1ubuntu4.1) ...
+Setting up libavahi-common-data:amd64 (0.7-3.1ubuntu1.3) ...
+Setting up postgresql-client-10 (10.18-0ubuntu0.18.04.1) ...
+update-alternatives: using /usr/share/postgresql/10/man/man1/psql.1.gz to provide /usr/share/man/man1/psql.1.gz (psql.1.gz) in auto mode
+Setting up libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Setting up libisl19:amd64 (0.19-1) ...
+Setting up python3-pygments (2.2.0+dfsg-1ubuntu0.2) ...
+Setting up bind9utils (1:9.11.3+dfsg-1ubuntu1.15) ...
+Setting up python3-formencode (1.3.0-0ubuntu5) ...
+Setting up postgresql-client (10+190ubuntu0.1) ...
+Setting up python3-paramiko (2.0.0-1ubuntu1.2) ...
+Setting up libipmidetect0 (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-uvloop (0.8.1+ds1-1ubuntu0.1) ...
+Setting up pycodestyle (2.3.1-2) ...
+Setting up python3-rfc3339 (1.0-4) ...
+Setting up libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-lxml:amd64 (4.2.1-1ubuntu0.4) ...
+Setting up maas-dhcp (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-dhcpd.service → /lib/systemd/system/maas-dhcpd.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-dhcpd6.service → /lib/systemd/system/maas-dhcpd6.service.
+Setting up gettext (0.19.8.1-6ubuntu0.3) ...
+Setting up libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up squid (3.5.27-1ubuntu1.11) ...
+Setcap worked! /usr/lib/squid/pinger is not suid!
+Skipping profile in /etc/apparmor.d/disable: usr.sbin.squid
+Setting up libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up bind9 (1:9.11.3+dfsg-1ubuntu1.15) ...
+Adding group `bind' (GID 117) ...
+Done.
+Adding system user `bind' (UID 111) ...
+Adding new user `bind' (UID 111) with group `bind' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/cache/bind'.
+wrote key file "/etc/bind/rndc.key"
+Created symlink /etc/systemd/system/multi-user.target.wants/bind9.service → /lib/systemd/system/bind9.service.
+bind9-pkcs11.service is a disabled or a static unit, not starting it.
+bind9-resolvconf.service is a disabled or a static unit, not starting it.
+Setting up python2.7 (2.7.17-1~18.04ubuntu1.6) ...
+Setting up python3-pymacaroons (0.13.0-1) ...
+Setting up libnss3:amd64 (2:3.35-2ubuntu2.12) ...
+Setting up pep8 (1.7.1-1ubuntu1) ...
+Setting up python3-django (1:1.11.11-1ubuntu1.14) ...
+Setting up autoconf (2.69-11) ...
+Setting up postgresql-10 (10.18-0ubuntu0.18.04.1) ...
+Creating new PostgreSQL cluster 10/main ...
+/usr/lib/postgresql/10/bin/initdb -D /var/lib/postgresql/10/main --auth-local peer --auth-host md5
+The files belonging to this database system will be owned by user "postgres".
+This user must also own the server process.
+
+The database cluster will be initialized with locale "en_US.UTF-8".
+The default database encoding has accordingly been set to "UTF8".
+The default text search configuration will be set to "english".
+
+Data page checksums are disabled.
+
+fixing permissions on existing directory /var/lib/postgresql/10/main ... ok
+creating subdirectories ... ok
+selecting default max_connections ... 100
+selecting default shared_buffers ... 128MB
+selecting default timezone ... Etc/UTC
+selecting dynamic shared memory implementation ... posix
+creating configuration files ... ok
+running bootstrap script ... ok
+performing post-bootstrap initialization ... ok
+syncing data to disk ... ok
+
+Success. You can now start the database server using:
+
+    /usr/lib/postgresql/10/bin/pg_ctl -D /var/lib/postgresql/10/main -l logfile start
+
+Ver Cluster Port Status Owner    Data directory              Log file
+[31m10  main    5432 down   postgres /var/lib/postgresql/10/main /var/log/postgresql/postgresql-10-main.log[0m
+update-alternatives: using /usr/share/postgresql/10/man/man1/postmaster.1.gz to provide /usr/share/man/man1/postmaster.1.gz (postmaster.1.gz) in auto mode
+Setting up fakeroot (1.22-2ubuntu1) ...
+update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
+Setting up libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-babel (2.4.0+dfsg.1-2ubuntu1.1) ...
+update-alternatives: using /usr/bin/pybabel-python3 to provide /usr/bin/pybabel (pybabel) in auto mode
+Setting up libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libpython-stdlib:amd64 (2.7.15~rc1-1) ...
+Setting up python3-macaroonbakery (1.1.3-1) ...
+Setting up intltool-debian (0.35.0+20060710.4) ...
+Setting up python3-psycopg2 (2.7.4-1) ...
+Setting up freeipmi-tools (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-pexpect (4.2.1-1) ...
+Setting up postgresql (10+190ubuntu0.1) ...
+Setting up automake (1:1.15.1-3ubuntu2) ...
+update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
+Setting up python3-seamicroclient (0.4.0-1ubuntu1) ...
+Setting up libavahi-common3:amd64 (0.7-3.1ubuntu1.3) ...
+Setting up python3-twisted (17.9.0-2ubuntu0.1) ...
+Setting up python3-setuptools (39.0.1-2) ...
+Setting up dbconfig-pgsql (2.0.9) ...
+Setting up python3-django-piston3 (0.3~rc2-3ubuntu5) ...
+Setting up python (2.7.15~rc1-1) ...
+Setting up libavahi-core7:amd64 (0.7-3.1ubuntu1.3) ...
+Setting up python3-txtftp (0.1~bzr47-0ubuntu2) ...
+Setting up cpp (4:7.4.0-1ubuntu2.3) ...
+Setting up maas-proxy (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-proxy.service → /lib/systemd/system/maas-proxy.service.
+Setting up python3-maas-client (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up po-debconf (1.0.20) ...
+Setting up gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up chrony (3.2-4ubuntu4.5) ...
+Creating '_chrony' system user/group for the chronyd daemon…
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+
+Creating config file /etc/chrony/chrony.conf with new version
+
+Creating config file /etc/chrony/chrony.keys with new version
+Created symlink /etc/systemd/system/chronyd.service → /lib/systemd/system/chrony.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/chrony.service → /lib/systemd/system/chrony.service.
+Setting up g++-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-crochet (1.4.0-0ubuntu2) ...
+Setting up gcc (4:7.4.0-1ubuntu2.3) ...
+Setting up python3-maas-provisioningserver (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up python-pkg-resources (39.0.1-2) ...
+Setting up avahi-daemon (0.7-3.1ubuntu1.3) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/dbus-org.freedesktop.Avahi.service → /lib/systemd/system/avahi-daemon.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/avahi-daemon.service → /lib/systemd/system/avahi-daemon.service.
+Created symlink /etc/systemd/system/sockets.target.wants/avahi-daemon.socket → /lib/systemd/system/avahi-daemon.socket.
+Setting up maas-cli (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up python-pyflakes (1.6.0-1) ...
+Setting up g++ (4:7.4.0-1ubuntu2.3) ...
+update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
+Setting up libavahi-client3:amd64 (0.7-3.1ubuntu1.3) ...
+Setting up libtool (2.4.6-2) ...
+Setting up build-essential (12.4ubuntu1) ...
+Setting up libvirt0:amd64 (4.0.0-1ubuntu8.19) ...
+Setting up pyflakes (1.6.0-1) ...
+Setting up avahi-utils (0.7-3.1ubuntu1.3) ...
+Setting up libvirt-clients (4.0.0-1ubuntu8.19) ...
+Setting up maas-common (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+adduser: Warning: The home directory `/var/lib/maas' does not belong to the user you are currently creating.
+Setting up maas-rack-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-rackd.service → /lib/systemd/system/maas-rackd.service.
+Setting up python3-fixtures (3.0.0-2) ...
+Setting up dh-autoreconf (17) ...
+Setting up python3-testtools (2.3.0-3ubuntu2) ...
+Setting up dh-strip-nondeterminism (0.040-1.1~build1) ...
+Setting up debhelper (11.1.6ubuntu2) ...
+Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
+Processing triggers for mime-support (3.60ubuntu1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
+Processing triggers for systemd (237-3ubuntu10.51) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for shared-mime-info (1.9-2) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.2) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+Processing triggers for sgml-base (1.29) ...
+Setting up docutils-common (0.14+dfsg-3) ...
+Processing triggers for sgml-base (1.29) ...
+Setting up python3-docutils (0.14+dfsg-3) ...
+update-alternatives: using /usr/share/docutils/scripts/python3/rst-buildhtml to provide /usr/bin/rst-buildhtml (rst-buildhtml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html to provide /usr/bin/rst2html (rst2html) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html4 to provide /usr/bin/rst2html4 (rst2html4) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html5 to provide /usr/bin/rst2html5 (rst2html5) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2latex to provide /usr/bin/rst2latex (rst2latex) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2man to provide /usr/bin/rst2man (rst2man) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2odt to provide /usr/bin/rst2odt (rst2odt) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2odt_prepstyles to provide /usr/bin/rst2odt_prepstyles (rst2odt_prepstyles) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2pseudoxml to provide /usr/bin/rst2pseudoxml (rst2pseudoxml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2s5 to provide /usr/bin/rst2s5 (rst2s5) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2xetex to provide /usr/bin/rst2xetex (rst2xetex) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2xml to provide /usr/bin/rst2xml (rst2xml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rstpep2html to provide /usr/bin/rstpep2html (rstpep2html) in auto mode
+Setting up python3-sphinx (1.6.7-1ubuntu1) ...
+Setting up python3-django-maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up maas-region-api (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-regiond.service → /lib/systemd/system/maas-regiond.service.
+Setting up maas-dns (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up maas-region-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+dbconfig-common: writing config to /etc/dbconfig-common/maas-region-controller.conf
+
+Creating config file /etc/dbconfig-common/maas-region-controller.conf with new version
+creating postgres user maas:  success.
+verifying creation of user: success.
+creating database maasdb: success.
+verifying database maasdb exists: success.
+dbconfig-common: flushing administrative password
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+[36;1mOperations to perform:[0m
+[1m  Apply all migrations: [0mauth, contenttypes, maasserver, metadataserver, piston3, sessions, sites
+[36;1mRunning migrations:[0m
+  Applying contenttypes.0001_initial...[32;1m OK[0m
+  Applying auth.0001_initial...[32;1m OK[0m
+  Applying auth.0002_auto_20151119_1629...[32;1m OK[0m
+  Applying auth.0003_django_1_11_update...[32;1m OK[0m
+  Applying auth.0004_user_email_allow_null...[32;1m OK[0m
+  Applying contenttypes.0002_remove_content_type_name...[32;1m OK[0m
+  Applying piston3.0001_initial...[32;1m OK[0m
+  Applying maasserver.0001_initial...[32;1m OK[0m
+  Applying metadataserver.0001_initial...[32;1m OK[0m
+  Applying maasserver.0002_remove_candidate_name_model...[32;1m OK[0m
+  Applying maasserver.0003_add_node_type_to_node...[32;1m OK[0m
+  Applying maasserver.0004_migrate_installable_to_node_type...[32;1m OK[0m
+  Applying maasserver.0005_delete_installable_from_node...[32;1m OK[0m
+  Applying maasserver.0006_add_lease_time_to_staticipaddress...[32;1m OK[0m
+  Applying maasserver.0007_create_node_proxy_models...[32;1m OK[0m
+  Applying maasserver.0008_use_new_arrayfield...[32;1m OK[0m
+  Applying maasserver.0009_remove_routers_field_from_node...[32;1m OK[0m
+  Applying maasserver.0010_add_dns_models...[32;1m OK[0m
+  Applying maasserver.0011_domain_data...[32;1m OK[0m
+  Applying maasserver.0012_drop_dns_fields...[32;1m OK[0m
+  Applying maasserver.0013_remove_boot_type_from_node...[32;1m OK[0m
+  Applying maasserver.0014_add_region_models...[32;1m OK[0m
+  Applying maasserver.0015_add_bmc_model...[32;1m OK[0m
+  Applying maasserver.0016_migrate_power_data_node_to_bmc...[32;1m OK[0m
+  Applying maasserver.0017_remove_node_power_type...[32;1m OK[0m
+  Applying maasserver.0018_add_dnsdata...[32;1m OK[0m
+  Applying maasserver.0019_add_iprange...[32;1m OK[0m
+  Applying maasserver.0020_nodegroup_to_rackcontroller...[32;1m OK[0m
+  Applying maasserver.0021_nodegroupinterface_to_iprange...[32;1m OK[0m
+  Applying maasserver.0022_extract_ip_for_bmcs...[32;1m OK[0m
+  Applying maasserver.0023_add_ttl_field...[32;1m OK[0m
+  Applying maasserver.0024_remove_nodegroupinterface...[32;1m OK[0m
+  Applying maasserver.0025_create_node_system_id_sequence...[32;1m OK[0m
+  Applying maasserver.0026_create_zone_serial_sequence...[32;1m OK[0m
+  Applying maasserver.0027_replace_static_range_with_admin_reserved_ranges...[32;1m OK[0m
+  Applying maasserver.0028_update_default_vlan_on_interface_and_subnet...[32;1m OK[0m
+  Applying maasserver.0029_add_rdns_mode...[32;1m OK[0m
+  Applying maasserver.0030_drop_all_old_funcs...[32;1m OK[0m
+  Applying maasserver.0031_add_region_rack_rpc_conn_model...[32;1m OK[0m
+  Applying maasserver.0032_loosen_vlan...[32;1m OK[0m
+  Applying maasserver.0033_iprange_minor_changes...[32;1m OK[0m
+  Applying maasserver.0034_rename_mount_params_as_mount_options...[32;1m OK[0m
+  Applying maasserver.0035_convert_ether_wake_to_manual_power_type...[32;1m OK[0m
+  Applying maasserver.0036_add_service_model...[32;1m OK[0m
+  Applying maasserver.0037_node_last_image_sync...[32;1m OK[0m
+  Applying maasserver.0038_filesystem_ramfs_tmpfs_support...[32;1m OK[0m
+  Applying maasserver.0039_create_template_and_versionedtextfile_models...[32;1m OK[0m
+  Applying maasserver.0040_fix_id_seq...[32;1m OK[0m
+  Applying maasserver.0041_change_bmc_on_delete_to_set_null...[32;1m OK[0m
+  Applying maasserver.0042_add_routable_rack_controllers_to_bmc...[32;1m OK[0m
+  Applying maasserver.0043_dhcpsnippet...[32;1m OK[0m
+  Applying maasserver.0044_remove_di_bootresourcefiles...[32;1m OK[0m
+  Applying maasserver.0045_add_node_to_filesystem...[32;1m OK[0m
+  Applying maasserver.0046_add_bridge_interface_type...[32;1m OK[0m
+  Applying maasserver.0047_fix_spelling_of_degraded...[32;1m OK[0m
+  Applying maasserver.0048_add_subnet_allow_proxy...[32;1m OK[0m
+  Applying maasserver.0049_add_external_dhcp_present_to_vlan...[32;1m OK[0m
+  Applying maasserver.0050_modify_external_dhcp_on_vlan...[32;1m OK[0m
+  Applying maasserver.0051_space_fabric_unique...[32;1m OK[0m
+  Applying maasserver.0052_add_codename_title_eol_to_bootresourcecache...[32;1m OK[0m
+  Applying maasserver.0053_add_ownerdata_model...[32;1m OK[0m
+  Applying maasserver.0054_controller...[32;1m OK[0m
+  Applying maasserver.0055_dns_publications...[32;1m OK[0m
+  Applying maasserver.0056_zone_serial_ownership...[32;1m OK[0m
+  Applying maasserver.0057_initial_dns_publication...[32;1m OK[0m
+  Applying maasserver.0058_bigger_integer_for_dns_publication_serial...[32;1m OK[0m
+  Applying maasserver.0056_add_description_to_fabric_and_space...[32;1m OK[0m
+  Applying maasserver.0057_merge...[32;1m OK[0m
+  Applying maasserver.0059_merge...[32;1m OK[0m
+  Applying maasserver.0060_amt_remove_mac_address...[32;1m OK[0m
+  Applying maasserver.0061_maas_nodegroup_worker_to_maas...[32;1m OK[0m
+  Applying maasserver.0062_fix_bootsource_daily_label...[32;1m OK[0m
+  Applying maasserver.0063_remove_orphaned_bmcs_and_ips...[32;1m OK[0m
+  Applying maasserver.0064_remove_unneeded_event_triggers...[32;1m OK[0m
+  Applying maasserver.0065_larger_osystem_and_distro_series...[32;1m OK[0m
+  Applying maasserver.0066_allow_squashfs...[32;1m OK[0m
+  Applying maasserver.0067_add_size_to_largefile...[32;1m OK[0m
+  Applying maasserver.0068_drop_node_system_id_sequence...[32;1m OK[0m
+  Applying maasserver.0069_add_previous_node_status_to_node...[32;1m OK[0m
+  Applying maasserver.0070_allow_null_vlan_on_interface...[32;1m OK[0m
+  Applying maasserver.0071_ntp_server_to_ntp_servers...[32;1m OK[0m
+  Applying maasserver.0072_packagerepository...[32;1m OK[0m
+  Applying maasserver.0073_migrate_package_repositories...[32;1m OK[0m
+  Applying maasserver.0072_update_status_and_previous_status...[32;1m OK[0m
+  Applying maasserver.0074_merge...[32;1m OK[0m
+  Applying maasserver.0075_modify_packagerepository...[32;1m OK[0m
+  Applying maasserver.0076_interface_discovery_rescue_mode...[32;1m OK[0m
+  Applying maasserver.0077_static_routes...[32;1m OK[0m
+  Applying maasserver.0078_remove_packagerepository_description...[32;1m OK[0m
+  Applying maasserver.0079_add_keysource_model...[32;1m OK[0m
+  Applying maasserver.0080_change_packagerepository_url_type...[32;1m OK[0m
+  Applying maasserver.0081_allow_larger_bootsourcecache_fields...[32;1m OK[0m
+  Applying maasserver.0082_add_kflavor...[32;1m OK[0m
+  Applying maasserver.0083_device_discovery...[32;1m OK[0m
+  Applying maasserver.0084_add_default_user_to_node_model...[32;1m OK[0m
+  Applying maasserver.0085_no_intro_on_upgrade...[32;1m OK[0m
+  Applying maasserver.0086_remove_powerpc_from_ports_arches...[32;1m OK[0m
+  Applying maasserver.0087_add_completed_intro_to_userprofile...[32;1m OK[0m
+  Applying maasserver.0088_remove_node_disable_ipv4...[32;1m OK[0m
+  Applying maasserver.0089_active_discovery...[32;1m OK[0m
+  Applying maasserver.0090_bootloaders...[32;1m OK[0m
+  Applying maasserver.0091_v2_to_v3...[32;1m OK[0m
+  Applying maasserver.0092_rolling...[32;1m OK[0m
+  Applying maasserver.0093_add_rdns_model...[32;1m OK[0m
+  Applying maasserver.0094_add_unmanaged_subnets...[32;1m OK[0m
+  Applying maasserver.0095_vlan_relay_vlan...[32;1m OK[0m
+  Applying maasserver.0096_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0097_node_chassis_storage_hints...[32;1m OK[0m
+  Applying maasserver.0098_add_space_to_vlan...[32;1m OK[0m
+  Applying maasserver.0099_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0100_migrate_spaces_from_subnet_to_vlan...[32;1m OK[0m
+  Applying maasserver.0101_filesystem_btrfs_support...[32;1m OK[0m
+  Applying maasserver.0102_remove_space_from_subnet...[32;1m OK[0m
+  Applying maasserver.0103_notifications...[32;1m OK[0m
+  Applying maasserver.0104_notifications_dismissals...[32;1m OK[0m
+  Applying metadataserver.0002_script_models...[32;1m OK[0m
+  Applying maasserver.0105_add_script_sets_to_node_model...[32;1m OK[0m
+  Applying maasserver.0106_testing_status...[32;1m OK[0m
+  Applying maasserver.0107_chassis_to_pods...[32;1m OK[0m
+  Applying maasserver.0108_generate_bmc_names...[32;1m OK[0m
+  Applying maasserver.0109_bmc_names_unique...[32;1m OK[0m
+  Applying maasserver.0110_notification_category...[32;1m OK[0m
+  Applying maasserver.0111_remove_component_error...[32;1m OK[0m
+  Applying maasserver.0112_update_notification...[32;1m OK[0m
+  Applying maasserver.0113_set_filepath_limit_to_linux_max...[32;1m OK[0m
+  Applying maasserver.0114_node_dynamic_to_creation_type...[32;1m OK[0m
+  Applying maasserver.0115_additional_boot_resource_filetypes...[32;1m OK[0m
+  Applying maasserver.0116_add_disabled_components_for_mirrors...[32;1m OK[0m
+  Applying maasserver.0117_add_iscsi_block_device...[32;1m OK[0m
+  Applying maasserver.0118_add_iscsi_storage_pod...[32;1m OK[0m
+  Applying maasserver.0119_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0120_bootsourcecache_extra...[32;1m OK[0m
+  Applying maasserver.0121_relax_staticipaddress_unique_constraint...[32;1m OK[0m
+  Applying maasserver.0122_make_virtualblockdevice_uuid_editable...[32;1m OK[0m
+  Applying maasserver.0123_make_iprange_comment_default_to_empty_string...[32;1m OK[0m
+  Applying maasserver.0124_staticipaddress_address_family_index...[32;1m OK[0m
+  Applying maasserver.0125_add_switch_model...[32;1m OK[0m
+  Applying maasserver.0126_add_controllerinfo_model...[32;1m OK[0m
+  Applying maasserver.0127_nodemetadata...[32;1m OK[0m
+  Applying maasserver.0128_events_created_index...[32;1m OK[0m
+  Applying maasserver.0129_add_install_rackd_flag...[32;1m OK[0m
+  Applying maasserver.0130_node_locked_flag...[32;1m OK[0m
+  Applying maasserver.0131_update_event_model_for_audit_logs...[32;1m OK[0m
+  Applying maasserver.0132_consistent_model_name_validation...[32;1m OK[0m
+  Applying maasserver.0133_add_resourcepool_model...[32;1m OK[0m
+  Applying maasserver.0134_create_default_resourcepool...[32;1m OK[0m
+  Applying maasserver.0135_add_pool_reference_to_node...[32;1m OK[0m
+  Applying maasserver.0136_add_user_role_models...[32;1m OK[0m
+  Applying maasserver.0137_create_default_roles...[32;1m OK[0m
+  Applying maasserver.0138_add_ip_and_user_agent_to_event_model...[32;1m OK[0m
+  Applying maasserver.0139_add_endpoint_and_increase_user_agent_length_for_event...[32;1m OK[0m
+  Applying maasserver.0140_add_usergroup_model...[32;1m OK[0m
+  Applying maasserver.0141_add_default_usergroup...[32;1m OK[0m
+  Applying maasserver.0142_pod_default_resource_pool...[32;1m OK[0m
+  Applying maasserver.0143_blockdevice_firmware...[32;1m OK[0m
+  Applying maasserver.0144_filesystem_zfsroot_support...[32;1m OK[0m
+  Applying maasserver.0145_interface_firmware...[32;1m OK[0m
+  Applying maasserver.0146_add_rootkey...[32;1m OK[0m
+  Applying maasserver.0147_pod_zones...[32;1m OK[0m
+  Applying maasserver.0148_add_tags_on_pods...[32;1m OK[0m
+  Applying maasserver.0149_userprofile_auth_last_check...[32;1m OK[0m
+  Applying maasserver.0150_add_pod_commit_ratios...[32;1m OK[0m
+  Applying maasserver.0151_userprofile_is_local...[32;1m OK[0m
+  Applying maasserver.0152_add_usergroup_local...[32;1m OK[0m
+  Applying maasserver.0153_add_skip_bmc_config...[32;1m OK[0m
+  Applying maasserver.0154_link_usergroup_role...[32;1m OK[0m
+  Applying maasserver.0155_add_globaldefaults_model...[32;1m OK[0m
+  Applying maasserver.0156_drop_ssh_unique_key_index...[32;1m OK[0m
+  Applying maasserver.0157_drop_usergroup_and_role...[32;1m OK[0m
+  Applying maasserver.0158_pod_default_pool_to_pod...[32;1m OK[0m
+  Applying maasserver.0159_userprofile_auth_last_check_no_now_default...[32;1m OK[0m
+  Applying maasserver.0160_pool_only_for_machines...[32;1m OK[0m
+  Applying metadataserver.0003_remove_noderesult...[32;1m OK[0m
+  Applying metadataserver.0004_aborted_script_status...[32;1m OK[0m
+  Applying metadataserver.0005_store_powerstate_on_scriptset_creation...[32;1m OK[0m
+  Applying metadataserver.0006_scriptresult_combined_output...[32;1m OK[0m
+  Applying metadataserver.0007_migrate-commissioningscripts...[32;1m OK[0m
+  Applying metadataserver.0008_remove-commissioningscripts...[32;1m OK[0m
+  Applying metadataserver.0009_remove_noderesult_schema...[32;1m OK[0m
+  Applying metadataserver.0010_scriptresult_time_and_script_title...[32;1m OK[0m
+  Applying metadataserver.0011_script_metadata...[32;1m OK[0m
+  Applying metadataserver.0012_store_script_results...[32;1m OK[0m
+  Applying metadataserver.0013_scriptresult_physicalblockdevice...[32;1m OK[0m
+  Applying metadataserver.0014_rename_dhcp_unconfigured_ifaces...[32;1m OK[0m
+  Applying metadataserver.0015_migrate_storage_tests...[32;1m OK[0m
+  Applying metadataserver.0016_script_model_fw_update_and_hw_config...[32;1m OK[0m
+  Applying metadataserver.0017_store_requested_scripts...[32;1m OK[0m
+  Applying metadataserver.0018_script_result_skipped...[32;1m OK[0m
+  Applying piston3.0002_auto_20151209_1652...[32;1m OK[0m
+  Applying sessions.0001_initial...[32;1m OK[0m
+  Applying sites.0001_initial...[32;1m OK[0m
+  Applying sites.0002_alter_domain_unique...[32;1m OK[0m
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Setting up maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up autopkgtest-satdep (0) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--status', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-get', '--simulate', '--quiet', '-o', 'APT::Get::Show-User-Simulation-Note=False', '--auto-remove', 'purge', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Marking test dependencies as manually installed: maas maas-rack-controller maas-region-controller maas-region-api python3-maas-provisioningserver archdetect-deb authbind maas-common avahi-utils avahi-daemon bind9 bind9utils chrony python3-django-maas python3-curtin curtin-common dbconfig-pgsql dbconfig-common dh-strip-nondeterminism debhelper dh-autoreconf devscripts python3-sphinx python3-docutils docutils-common python3-formencode formencode-i18n freeipmi-tools libipmidetect0 freeipmi-common python3-netaddr ieee-data maas-dhcp isc-dhcp-server libfile-stripnondeterminism-perl libarchive-zip-perl libvirt-clients libvirt0 libavahi-client3 libavahi-core7 libavahi-common3 libavahi-common-data libcurl3-gnutls libdaemon0 maas-proxy squid libdbi-perl libdebian-installer4 libecap3 libfile-homedir-perl libfile-which-perl libipmiconsole2 libfreeipmi16 libirs-export160 libisccfg-export160 libjs-angularjs sphinx-common libjs-sphinxdoc libjs-jquery libjs-underscore libltdl7 libnss3 libnspr4 maas-cli python3-maas-client python3-macaroonbakery python3-protobuf libprotobuf10 pyflakes python-pyflakes python-pkg-resources python libpython-stdlib python2.7 libpython2.7-stdlib python-minimal python2.7-minimal libpython2.7-minimal python3-pymacaroons python3-nacl libsodium23 libtimedate-perl python3-uvloop libuv1 libyajl2 maas-dns pep8 postgresql pxelinux pycodestyle python3-seamicroclient python3-babel python-babel-localedata python3-django-piston3 python3-django python-django-common python3-alabaster python3-txtftp python3-crochet python3-twisted python3-automat python3-service-identity python3-attr python3-bson python3-constantly python3-convoy python3-distro-info python3-djorm-ext-pgarray python3-dnspython python3-testtools python3-fixtures python3-extras python3-hyperlink python3-imagesize python3-incremental python3-iso8601 python3-unittest2 python3-traceback2 python3-linecache2 python3-lxml python3-mimeparse python3-mock python3-nose python3-oauth python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply python3-prettytable python3-psycopg2 python3-ptyprocess python3-pyasn1-modules python3-pyasn1 python3-pycodestyle python3-pygments python3-pyparsing python3-pyvmomi python3-rfc3339 python3-roman python3-simplejson python3-simplestreams python3-tempita python3-twisted-bin python3-tz python3-zope.interface xml-core sgml-base squid-common squid-langpack syslinux-common
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'maas', 'maas-rack-controller', 'maas-region-controller', 'maas-region-api', 'python3-maas-provisioningserver', 'archdetect-deb', 'authbind', 'maas-common', 'avahi-utils', 'avahi-daemon', 'bind9', 'bind9utils', 'chrony', 'python3-django-maas', 'python3-curtin', 'curtin-common', 'dbconfig-pgsql', 'dbconfig-common', 'dh-strip-nondeterminism', 'debhelper'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'dh-autoreconf', 'devscripts', 'python3-sphinx', 'python3-docutils', 'docutils-common', 'python3-formencode', 'formencode-i18n', 'freeipmi-tools', 'libipmidetect0', 'freeipmi-common', 'python3-netaddr', 'ieee-data', 'maas-dhcp', 'isc-dhcp-server', 'libfile-stripnondeterminism-perl', 'libarchive-zip-perl', 'libvirt-clients', 'libvirt0', 'libavahi-client3', 'libavahi-core7'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'libavahi-common3', 'libavahi-common-data', 'libcurl3-gnutls', 'libdaemon0', 'maas-proxy', 'squid', 'libdbi-perl', 'libdebian-installer4', 'libecap3', 'libfile-homedir-perl', 'libfile-which-perl', 'libipmiconsole2', 'libfreeipmi16', 'libirs-export160', 'libisccfg-export160', 'libjs-angularjs', 'sphinx-common', 'libjs-sphinxdoc', 'libjs-jquery', 'libjs-underscore'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'libltdl7', 'libnss3', 'libnspr4', 'maas-cli', 'python3-maas-client', 'python3-macaroonbakery', 'python3-protobuf', 'libprotobuf10', 'pyflakes', 'python-pyflakes', 'python-pkg-resources', 'python', 'libpython-stdlib', 'python2.7', 'libpython2.7-stdlib', 'python-minimal', 'python2.7-minimal', 'libpython2.7-minimal', 'python3-pymacaroons', 'python3-nacl'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'libsodium23', 'libtimedate-perl', 'python3-uvloop', 'libuv1', 'libyajl2', 'maas-dns', 'pep8', 'postgresql', 'pxelinux', 'pycodestyle', 'python3-seamicroclient', 'python3-babel', 'python-babel-localedata', 'python3-django-piston3', 'python3-django', 'python-django-common', 'python3-alabaster', 'python3-txtftp', 'python3-crochet', 'python3-twisted'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-automat', 'python3-service-identity', 'python3-attr', 'python3-bson', 'python3-constantly', 'python3-convoy', 'python3-distro-info', 'python3-djorm-ext-pgarray', 'python3-dnspython', 'python3-testtools', 'python3-fixtures', 'python3-extras', 'python3-hyperlink', 'python3-imagesize', 'python3-incremental', 'python3-iso8601', 'python3-unittest2', 'python3-traceback2', 'python3-linecache2', 'python3-lxml'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-mimeparse', 'python3-mock', 'python3-nose', 'python3-oauth', 'python3-paramiko', 'python3-pbr', 'python3-petname', 'python3-pexpect', 'python3-ply', 'python3-prettytable', 'python3-psycopg2', 'python3-ptyprocess', 'python3-pyasn1-modules', 'python3-pyasn1', 'python3-pycodestyle', 'python3-pygments', 'python3-pyparsing', 'python3-pyvmomi', 'python3-rfc3339', 'python3-roman'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-simplejson', 'python3-simplestreams', 'python3-tempita', 'python3-twisted-bin', 'python3-tz', 'python3-zope.interface', 'xml-core', 'sgml-base', 'squid-common', 'squid-langpack', 'syslinux-common'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--purge', 'autopkgtest-satdep'], kind short, sout raw, serr raw, env []
+(Reading database ... 124005 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '[ -d /var/cache/apparmor -a -d /var/lib/apparmor/clicks -a ! -e /var/cache/apparmor/click-ap.rules ] && type aa-clickhook >/dev/null 2>&1'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest: DBG: testbed does not have AppArmor/click or already has Autopilot click rules, no need to adjust rules
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.dn9EKj/maas-package-test-packages.all"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/maas-package-test-packages.all /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/maas-package-test-packages.all /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/maas-package-test-packages.all'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['test', '-e', '/tmp/autopkgtest.dn9EKj/build.Bke/real-tree'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.dn9EKj/build.Bke'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; then mkdir -- /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; fi; cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec if ! test -d /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; then mkdir -- /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; fi; cd /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.dn9EKj/build.Bke/real-tree'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [19:39:40]: test maas-package-test: [-----------------------
+autopkgtest: DBG: testbed command ['su', '-s', '/bin/bash', 'root', '-c', 'set -e; export USER=`id -nu`; . /etc/profile >/dev/null 2>&1 || true;  . ~/.profile >/dev/null 2>&1 || true; buildtree="/tmp/autopkgtest.dn9EKj/build.Bke/real-tree"; mkdir -p -m 1777 -- "/tmp/autopkgtest.dn9EKj/maas-package-test-artifacts"; export AUTOPKGTEST_ARTIFACTS="/tmp/autopkgtest.dn9EKj/maas-package-test-artifacts"; export ADT_ARTIFACTS="$AUTOPKGTEST_ARTIFACTS"; mkdir -p -m 755 "/tmp/autopkgtest.dn9EKj/autopkgtest_tmp"; export AUTOPKGTEST_TMP="/tmp/autopkgtest.dn9EKj/autopkgtest_tmp"; export ADTTMP="$AUTOPKGTEST_TMP"; export DEBIAN_FRONTEND=noninteractive; export LANG=C.UTF-8; export DEB_BUILD_OPTIONS=parallel=8; unset LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE   LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS   LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL;rm -f /tmp/autopkgtest_script_pid; set -C; echo $$ > /tmp/autopkgtest_script_pid; set +C; trap "rm -f /tmp/autopkgtest_script_pid" EXIT INT QUIT PIPE; cd "$buildtree"; export AUTOPKGTEST_NORMAL_USER=ubuntu; export ADT_NORMAL_USER=ubuntu; export \'DEPLOYMENT_RELEASE=bionic\'; export \'TEST_JUJU=\'; export \'TEST_CENTOS=0\'; export \'TEST_RHEL=\'; export \'TEST_WINDOWS=\'; export \'TEST_CUSTOM_IMAGES=1\'; export \'USE_PPC_NODES=0\'; export \'USE_ARM64_NODES=0\'; export \'KEEP_CI_RUNNING=0\'; export \'PAUSE_CI=0\'; export \'TEST_PERFORMANCE=0\'; export \'DEBUG=\'; export \'SLAVE_NODE=HP-DL360-Gen9\'; chmod +x /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/debian/tests/maas-package-test; touch /tmp/autopkgtest.dn9EKj/maas-package-test-stdout /tmp/autopkgtest.dn9EKj/maas-package-test-stderr; /tmp/autopkgtest.dn9EKj/build.Bke/real-tree/debian/tests/maas-package-test 2> >(tee -a /tmp/autopkgtest.dn9EKj/maas-package-test-stderr >&2) > >(tee -a /tmp/autopkgtest.dn9EKj/maas-package-test-stdout);'], kind test, sout raw, serr raw, env []
+MAAS ID: qd3ynh
+maas-integration.TestMAASIntegration.test_setup_prometheus ... SKIP: Prometheus is only supported on MAAS 2.6+
+maas-integration.TestMAASIntegration.test_create_admin ... ok
+maas-integration.TestMAASIntegration.test_update_maas_url ... ok
+maas-integration.TestMAASIntegration.test_update_maas_url_rack ... ok
+maas-integration.TestMAASIntegration.test_check_initial_services_systemctl ... ok
+maas-integration.TestMAASIntegration.test_check_rpc_info ... ok
+maas-integration.TestMAASIntegration.test_update_preseed_arm ... SKIP: Don't test ARM nodes
+maas-integration.TestMAASIntegration.test_login_api ... ok
+maas-integration.TestMAASIntegration.test_maas_logged_in ... ok
+maas-integration.TestMAASIntegration.test_set_main_archive ... ok
+maas-integration.TestMAASIntegration.test_enable_prometheus_stats ... SKIP: Prometheus is only supported on MAAS 2.6+
+maas-integration.TestMAASIntegration.test_main_archive_in_enlist_userdata_package_mirrors_config ... SKIP: Cloud-init "package_mirror" config is used in MAAS 2.0 and earlier
+maas-integration.TestMAASIntegration.test_main_archive_in_enlist_userdata_apt_config ... ok
+maas-integration.TestMAASIntegration.test_set_http_proxy_and_use_peer_proxy ... ok
+maas-integration.TestMAASIntegration.test_add_ssh_key ... ok
+maas-integration.TestMAASIntegration.test_region_rack_connected ... ok
+maas-integration.TestMAASIntegration.test_stop_image_import ... ok
+maas-integration.TestMAASIntegration.test_set_custom_boot_source ... ok
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_ppc64el ... SKIP: Not testing PPC systems
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_arm64 ... SKIP: Not testing arm64 systems
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_centos ... SKIP: Not testing CentOS
+maas-integration.TestMAASIntegration.test_start_image_import ... ok
+maas-integration.TestMAASIntegration.test_create_dynamic_range ... ok
+maas-integration.TestMAASIntegration.test_reserve_reserved_range ... ok
+maas-integration.TestMAASIntegration.test_reserve_bmc_range ... ok
+maas-integration.TestMAASIntegration.test_create_slave_device_and_link_subnet ... ok
+maas-integration.TestMAASIntegration.test_slave_device_interface_linked ... ok
+maas-integration.TestMAASIntegration.test_set_up_dhcp_vlan ... ok
+maas-integration.TestMAASIntegration.test_check_dhcp_service_systemctl ... ok
+maas-integration.TestMAASIntegration.test_use_internal_dns_for_proxy_on_managed_dhcp ... SKIP: Internal DNS (for proxy/metadata) is available on 2.5+ only.
+maas-integration.TestMAASIntegration.test_update_dns_config_systemctl ... ok
+maas-integration.TestMAASIntegration.test_add_new_zones ... ok
+maas-integration.TestMAASIntegration.test_list_zones ... ok
+maas-integration.TestMAASIntegration.test_delete_zone ... ok
+maas-integration.TestMAASIntegration.test_add_new_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_list_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_delete_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_add_new_spaces ... ok
+maas-integration.TestMAASIntegration.test_create_subnet ... ok
+maas-integration.TestMAASIntegration.test_list_spaces ... ok
+maas-integration.TestMAASIntegration.test_list_subnets ... ok
+maas-integration.TestMAASIntegration.test_delete_subnet ... ok
+maas-integration.TestMAASIntegration.test_delete_space ... ok
+maas-integration.TestMAASIntegration.test_add_new_fabrics ... ok
+maas-integration.TestMAASIntegration.test_add_vlan_to_fabric ... ok
+maas-integration.TestMAASIntegration.test_list_fabrics ... ok
+maas-integration.TestMAASIntegration.test_list_vlans ... ok
+maas-integration.TestMAASIntegration.test_delete_vlan ... ok
+maas-integration.TestMAASIntegration.test_delete_fabric ... ok
+maas-integration.TestMAASIntegration.test_tag_uefi ... ok
+maas-integration.TestMAASIntegration.test_region_imported_images ... ok
+maas-integration.TestMAASIntegration.test_rack_imported_images ... ok
+maas-integration.TestMAASIntegration.test_add_windows_boot_resource ... SKIP: Not testing Windows
+maas-integration.TestMAASIntegration.test_add_rhel_boot_resource ... SKIP: Not testing RHEL
+maas-integration.TestMAASIntegration.test_poweron_nodes_to_enlist ... ok
+maas-integration.TestMAASIntegration.test_check_machines_new ... qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_check_enlisted_machines_commissioned ... SKIP: Commissioning during enlistment only supported in MAAS 2.5+
+maas-integration.TestMAASIntegration.test_assign_machines_to_test_zone ... ok
+maas-integration.TestMAASIntegration.test_assign_machines_to_test_resource_pool ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_set_machines_ipmi_config ... ok
+maas-integration.TestMAASIntegration.test_start_commissioning_machines ... ok
+maas-integration.TestMAASIntegration.test_check_nodes_ready ... qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_read_commissioning_results ... ok
+maas-integration.TestMAASIntegration.test_configure_juju ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_juju_bootstrap ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_apply_tag_to_all_machines ... ok
+maas-integration.TestMAASIntegration.test_check_tag_applied_to_all_machines ... SKIP: Known MAAS bug with proxies on MAAS < 2.7 - see 4eee730d67082731ed43fe1075a4ce883fcd3823.
+maas-integration.TestMAASIntegration.test_juju_deploy_postgresql ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_juju_deploy_ubuntu_container ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_allocate_machines ... ok
+maas-integration.TestMAASIntegration.test_deploy_machine_with_centos ... SKIP: Not testing CentOS.
+maas-integration.TestMAASIntegration.test_deploy_machine_with_rhel ... SKIP: Not testing RHEL
+maas-integration.TestMAASIntegration.test_deploy_machine_with_windows ... SKIP: Not testing Windows
+maas-integration.TestMAASIntegration.test_deploy_machines ... ok
+maas-integration.TestMAASIntegration.test_machines_deployed ... qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_compose_machines_per_pod ... SKIP: Not running test until LP: #1827149 is fixed.
+maas-integration.TestMAASIntegration.test_ip_addresses_not_in_dynamic_range ... ok
+maas-integration.TestMAASIntegration.test_ip_addresses_not_in_bmc_range ... ok
+maas-integration.TestMAASIntegration.test_ip_addresses_exist_as_dhcp_hostmaps ... ok
+maas-integration.TestMAASIntegration.test_ssh_to_machines ... ok
+maas-integration.TestMAASIntegration.test_enter_rescue_mode ... qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+qemu-system-x86_64: Slirp: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_exit_rescue_mode ... ok
+maas-integration.TestMAASIntegration.test_release_machines ... ok
+maas-integration.TestMAASIntegration.test_machines_released_and_ready ... ok
+
+----------------------------------------------------------------------
+XML: /tmp/autopkgtest.dn9EKj/maas-package-test-artifacts/nosetests.xml
+----------------------------------------------------------------------
+Ran 84 tests in 2814.451s
+
+OK (SKIP=24)
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [20:26:43]: test maas-package-test: -----------------------]
+autopkgtest: DBG: testbed executing test finished with exit status 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/maas-package-test-stdout /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/maas-package-test-stdout /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/maas-package-test-stdout'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/maas-package-test-stderr /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/maas-package-test-stderr /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.dn9EKj/maas-package-test-stderr'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cat </tmp/autopkgtest.dn9EKj/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest [20:26:44]: test maas-package-test:  - - - - - - - - - - results - - - - - - - - - -
+maas-package-test    PASS
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.dn9EKj/maas-package-test-artifacts/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.dn9EKj/maas-package-test-artifacts/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-qemu.rtstl4_z/runcmd', 'sh', '-ec', 'cd /tmp/autopkgtest.dn9EKj/maas-package-test-artifacts/; tar --warning=none -c . -f -'], ['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/', '--warning=none', '--preserve-permissions', '--extract', '--no-same-owner', '-f', '-'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-qemu.rtstl4_z/runcmd sh -ec cd /tmp/autopkgtest.dn9EKj/maas-package-test-artifacts/; tar --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/ --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['rm', '-rf', '/tmp/autopkgtest.dn9EKj/maas-package-test-artifacts', '/tmp/autopkgtest.dn9EKj/autopkgtest_tmp'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: no need to restore click AppArmor profiles
+autopkgtest: DBG: needs_reset, previously=False, requested by run_tests() line 199
+autopkgtest [20:26:47]: @@@@@@@@@@@@@@@@@@@@ summary
+maas-package-test    PASS
+autopkgtest: DBG: testbed stop
+autopkgtest: DBG: testbed close, scratch=/tmp/autopkgtest.dn9EKj
+autopkgtest: DBG: sending command to testbed: close
+autopkgtest-virt-qemu: DBG: executing close
+autopkgtest-virt-qemu: DBG: cleanup...
+qemu-system-x86_64: terminating on signal 15 from pid 4007712 (/usr/bin/python3)
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: sending command to testbed: quit
+autopkgtest-virt-qemu: DBG: executing quit
+autopkgtest-virt-qemu: DBG: cleanup...
++ RET=0
++ '[' 0 -eq 2 ']'
++ exit 0
+Archiving artifacts
+Recording test results
+[Checks API] No suitable checks publisher found.
+Finished: SUCCESS


### PR DESCRIPTION
In order to simplify how we add things, I made a few changes:
* Use release number instead of date to order new SRU directories. This is just to simply knowing what was added when.
* Keep all results under the SRU directory, and only use manual if we had to do manual tests that aren't part of our automated integration tests.
* Only add issues to README if we had to write manual tests.

One thing to keep in mind is that upgrade tests are now inline with the integration tests, so you'll need to search "test_upgrade" (or something similar) to get the various boot/blame times.